### PR TITLE
Use tuple struct for `ScriptInstanceRef` and some changes

### DIFF
--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -190,7 +190,7 @@ impl JsApi {
       Datum::ScriptInstanceRef(script_ref.clone().unwrap())
     };
     let snapshot = concrete_datum_to_js_bridge(&datum, player, 0);
-    onScriptInstanceSnapshot(script_ref.unwrap().id, snapshot);
+    onScriptInstanceSnapshot(*script_ref.unwrap(), snapshot);
   }
   pub fn dispatch_schedule_timeout(timeout_name: &str, interval: u32) {
     onScheduleTimeout(timeout_name, interval);
@@ -457,7 +457,7 @@ impl JsApi {
 
     let script_instance_array = js_sys::Array::new();
     for script_instance in &channel.sprite.script_instance_list {
-      script_instance_array.push(&JsValue::from_f64(script_instance.id as f64));
+      script_instance_array.push(&JsValue::from_f64(**script_instance as f64));
     }
 
     let sprite_map = js_sys::Map::new();
@@ -690,7 +690,7 @@ fn concrete_datum_to_js_bridge(datum: &Datum, player: &DirPlayer, depth: u8) -> 
       let ancestor_id = &instance.ancestor;
       match ancestor_id {
         Some(ancestor_id) => {
-          map.str_set("ancestor", &ancestor_id.id.to_js_value());
+          map.str_set("ancestor", &(**ancestor_id).to_js_value());
         }
         None => map.str_set("ancestor", &JsValue::NULL)
       }

--- a/vm-rust/src/player/allocator.rs
+++ b/vm-rust/src/player/allocator.rs
@@ -194,19 +194,19 @@ impl ScriptInstanceAllocatorTrait for DatumAllocator {
       ref_count: 0,
       script_instance,
     });
-    ScriptInstanceRef::from_id(id)
+    ScriptInstanceRef::from(id)
   }
 
   fn get_script_instance(&self, instance_ref: &ScriptInstanceRef) -> &ScriptInstance {
-    &self.script_instances.get(&instance_ref.id).unwrap().script_instance
+    &self.script_instances.get(instance_ref).unwrap().script_instance
   }
 
   fn get_script_instance_opt(&self, instance_ref: &ScriptInstanceRef) -> Option<&ScriptInstance> {
-    self.script_instances.get(&instance_ref.id).map(|entry| &entry.script_instance)
+    self.script_instances.get(instance_ref).map(|entry| &entry.script_instance)
   }
 
   fn get_script_instance_mut(&mut self, instance_ref: &ScriptInstanceRef) -> &mut ScriptInstance {
-    &mut self.script_instances.get_mut(&instance_ref.id).unwrap().script_instance
+    &mut self.script_instances.get_mut(instance_ref).unwrap().script_instance
   }
 
   fn on_script_instance_ref_added(&mut self, id: ScriptInstanceId) {

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -63,7 +63,7 @@ impl GetSetBytecodeHandler {
       
       match receiver {
         Some(instance_ref) => {
-          if instance_ref.id == 0 {
+          if *instance_ref == 0 {
             return Err(ScriptError::new(format!("Can't set prop {} of Void", prop_name)));
           }
           script_set_prop(player, &instance_ref, &prop_name.to_owned(), &value_ref, false)?;

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -364,7 +364,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
         }
         PlayerVMCommand::RequestScriptInstanceSnapshot(script_instance_id) => {
             reserve_player_ref(|player| {
-                JsApi::dispatch_script_instance_snapshot(if script_instance_id > 0 { Some(ScriptInstanceRef::from_id(script_instance_id)) } else { None }, player);
+                JsApi::dispatch_script_instance_snapshot(if script_instance_id > 0 { Some(ScriptInstanceRef::from(script_instance_id)) } else { None }, player);
             });
         }
         PlayerVMCommand::SubscribeToMember(member_ref) => {

--- a/vm-rust/src/player/compare.rs
+++ b/vm-rust/src/player/compare.rs
@@ -30,7 +30,7 @@ pub fn datum_equals(left: &Datum, right: &Datum, allocator: &DatumAllocator) -> 
       let right = right.string_value()?;
       Ok(left == right)
     },
-    (Datum::ScriptInstanceRef(left), Datum::ScriptInstanceRef(right)) => Ok(*left == *right),
+    (Datum::ScriptInstanceRef(left), Datum::ScriptInstanceRef(right)) => Ok(**left == **right),
     (Datum::Symbol(left), Datum::Symbol(right)) => Ok(left.eq_ignore_ascii_case(right)),
     (Datum::Void, Datum::Void) => Ok(true),
     (Datum::ColorRef(left), Datum::ColorRef(right)) => Ok(*left == *right),

--- a/vm-rust/src/player/datum_formatting.rs
+++ b/vm-rust/src/player/datum_formatting.rs
@@ -42,7 +42,7 @@ pub fn format_concrete_datum(datum: &Datum, player: &DirPlayer) -> String {
       let instance = player.allocator.get_script_instance(instance_ref);
       let script = player.movie.cast_manager.get_script_by_ref(&instance.script).unwrap();
 
-      format!("<offspring {} {} _>", script.name, instance_ref.id)
+      format!("<offspring {} {} _>", script.name, instance_ref)
     }
     Datum::CastMember(member_ref) => {
       format!("(member {} of castLib {})", member_ref.cast_member, member_ref.cast_lib)

--- a/vm-rust/src/player/handlers/datum_handlers/script_instance.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/script_instance.rs
@@ -8,7 +8,7 @@ impl ScriptInstanceUtils {
     let datum = player.get_datum(datum);
     match datum {
       Datum::ScriptInstanceRef(instance_ref) => {
-        let instance_id = instance_ref.id;
+        let instance_id = **instance_ref;
         let instance = player.allocator.get_script_instance_opt(&instance_ref).ok_or(ScriptError::new(format!("Script instance {instance_id} not found")))?;
         let script = player.movie.cast_manager.get_script_by_ref(&instance.script).ok_or(ScriptError::new(format!("Script not found")))?;
         Ok((instance_ref.clone(), script))

--- a/vm-rust/src/player/script_ref.rs
+++ b/vm-rust/src/player/script_ref.rs
@@ -1,29 +1,43 @@
 use super::{allocator::DatumAllocatorEvent, script::ScriptInstanceId, ALLOCATOR_TX};
 
-#[derive(Eq, PartialEq, Debug)]
-pub struct ScriptInstanceRef {
-  pub id: ScriptInstanceId,
+pub struct ScriptInstanceRef(ScriptInstanceId);
+
+impl<T> From<T> for ScriptInstanceRef where T: Into<ScriptInstanceId> {
+  #[inline]
+  fn from(id: T) -> Self {
+    let val = id.into();
+    unsafe {
+      ALLOCATOR_TX.as_ref().unwrap().try_send(DatumAllocatorEvent::ScriptInstanceRefAdded(val)).unwrap();
+    }
+    Self(val)
+  }
 }
 
-impl ScriptInstanceRef {
-  pub fn from_id(id: ScriptInstanceId) -> ScriptInstanceRef {
-    unsafe {
-      ALLOCATOR_TX.as_ref().unwrap().try_send(DatumAllocatorEvent::ScriptInstanceRefAdded(id)).unwrap();
-    }
-    ScriptInstanceRef { id }
+impl std::ops::Deref for ScriptInstanceRef {
+  type Target = ScriptInstanceId;
+
+  #[inline]
+  fn deref(&self) -> &Self::Target {
+    &self.0
   }
 }
 
 impl Clone for ScriptInstanceRef {
   fn clone(&self) -> Self {
-    Self::from_id(self.id)
+    Self::from(self.0)
   }
 }
 
 impl Drop for ScriptInstanceRef {
   fn drop(&mut self) {
     unsafe {
-      ALLOCATOR_TX.as_ref().unwrap().try_send(DatumAllocatorEvent::ScriptInstanceRefDropped(self.id)).unwrap();
+      ALLOCATOR_TX.as_ref().unwrap().try_send(DatumAllocatorEvent::ScriptInstanceRefDropped(self.0)).unwrap();
     }
+  }
+}
+
+impl std::fmt::Display for ScriptInstanceRef {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.0)
   }
 }


### PR DESCRIPTION
**This is my personal recommendation.**

We can now simply dereference with a pointer to get the `ScriptInstanceId` (u32). Example:
```rust
fn test(first: ScriptInstanceRef, second: ScriptInstanceRef) -> bool {
  let first_val: ScriptInstanceId = *first;
  // let first_val: u32 = *first;
  let second_val: ScriptInstanceId = *second;
  // let second_val: u32 = *second;
  first_val == second_val
}
```
`impl std::fmt::Display for ScriptInstanceRef` was added. It also allows us to add more information as in this example:
```rust
// format!("Test: {}", instance_ref)
// This will display the following in the console: "Test: ScriptInstanceRef(1337) <.<"
impl std::fmt::Display for ScriptInstanceRef {
  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
    write!(
        f, 
        "ScriptInstanceRef({}) <.<", 
        self.0, // 1337
    )
  }
}
```
Thanks to `impl<T> From<T> for ScriptInstanceRef where T: Into<ScriptInstanceId>` we can easily pass data types which can be converted to `ScriptInstanceId` (u32). Example:
```rust
fn test(first: u8) -> ScriptInstanceRef {
    ScriptInstanceRef::from(first)
}
fn test(first: u16) -> ScriptInstanceRef {
    ScriptInstanceRef::from(first)
}
```
`Debug` derive was removed because it was not used anywhere.

