### PR TITLE
Minor improvements

### DIFF
--- a/vm-rust/src/director/file.rs
+++ b/vm-rust/src/director/file.rs
@@ -680,7 +680,7 @@ fn read_chunk_data(reader: &mut BinaryReader, fourcc: u32, len: u32) -> Result<V
   return Ok(reader.read_bytes(use_len as usize).unwrap().to_vec());
 }
 
-pub fn read_director_file_bytes(bytes: &Vec<u8>, file_name: &String, base_path: &String) -> Result<DirectorFile, String> {
+pub fn read_director_file_bytes(bytes: &Vec<u8>, file_name: &str, base_path: &str) -> Result<DirectorFile, String> {
   let mut reader = binary_reader::BinaryReader::from_vec(bytes);
   let mut chunk_container = ChunkContainer {
     cached_chunk_views: HashMap::new(),
@@ -690,7 +690,7 @@ pub fn read_director_file_bytes(bytes: &Vec<u8>, file_name: &String, base_path: 
   
   return DirectorFile::read(
     file_name.to_owned(),
-    Url::from_str(&base_path).unwrap(),
+    Url::from_str(base_path).unwrap(),
     &mut reader, 
     &mut chunk_container
   );

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -98,7 +98,7 @@ pub struct DirPlayer {
   pub hovered_sprite: Option<i16>,
   pub timer_tick_start: u32,
   pub allocator: DatumAllocator,
-  pub dir_cache: HashMap<String, DirectorFile>,
+  pub dir_cache: HashMap<Box<str>, DirectorFile>,
 }
 
 impl DirPlayer {

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -26,7 +26,7 @@ impl Movie {
     file: &DirectorFile, 
     net_manager: &mut NetManager, 
     bitmap_manager: &mut BitmapManager,
-    dir_cache: &mut HashMap<String, DirectorFile>,
+    dir_cache: &mut HashMap<Box<str>, DirectorFile>,
   ) {
     self.dir_version = file.version;
     self.stage_color = (


### PR DESCRIPTION
Instead of `is_loading` and `is_loaded` (2x `i8` data types), only `state` (1x `u8` data type) is now used (same size as `i8`).

The key of `dir_cache` is never changed, so `Box::<str>` is now used, which uses less memory than `String`.

I have also made other small changes/improvements. Please take a look at the changes.

[In some places a `&str` is now used directly instead of creating a new `string`.](https://github.com/igorlira/dirplayer-rs/pull/8/files#diff-ca6a94a0c4ec4208822e0cf424db6655e58e65c314b966a081f06c2e2677e42dL71) I also recommend to always pass a `&str` instead of a `&String` if the content is not changed.