### PR TITLE
Delimiter as `char`

### DIFF
--- a/vm-rust/src/director/lingo/datum.rs
+++ b/vm-rust/src/director/lingo/datum.rs
@@ -89,7 +89,7 @@ pub struct  StringChunkExpr {
   pub chunk_type: StringChunkType,
   pub start: i32,
   pub end: i32,
-  pub item_delimiter: String,
+  pub item_delimiter: char,
 }
 
 pub type PropListPair = (DatumRef, DatumRef);

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -317,7 +317,7 @@ impl GetSetBytecodeHandler {
         };
         let string = player.get_datum(&string_id).string_value()?;
         let chunk_type = StringChunkType::from(&(prop_id - 0x0b));
-        let last_chunk = StringChunkUtils::resolve_last_chunk(&string, chunk_type, &player.movie.item_delimiter)?;
+        let last_chunk = StringChunkUtils::resolve_last_chunk(&string, chunk_type, player.movie.item_delimiter)?;
 
         Ok(player.alloc_datum(Datum::String(last_chunk)))
       } else if prop_type == 0x07 {
@@ -353,7 +353,7 @@ impl GetSetBytecodeHandler {
         };
         let string = player.get_datum(&string_id).string_value()?;
         let chunk_type = StringChunkType::from(&prop_id);
-        let chunks = StringChunkUtils::resolve_chunk_list(&string, chunk_type, &player.movie.item_delimiter)?;
+        let chunks = StringChunkUtils::resolve_chunk_list(&string, chunk_type, player.movie.item_delimiter)?;
         Ok(player.alloc_datum(Datum::Int(chunks.len() as i32)))
       } else {
         Err(ScriptError::new(format!("OpCode.kOpGet call not implemented propertyID={} propertyType={}", prop_id, prop_type)))

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
@@ -31,7 +31,7 @@ impl FieldMemberHandlers {
                 if args.len() != 1 {
                     return Err(ScriptError::new("count requires 1 argument".to_string()));
                 }
-                let delimiter = &player.movie.item_delimiter;
+                let delimiter = player.movie.item_delimiter;
                 let count = StringChunkUtils::resolve_chunk_count(
                     &field.text,
                     StringChunkType::from(&count_of),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -18,7 +18,7 @@ impl TextMemberHandlers {
               if args.len() != 1 {
                 return Err(ScriptError::new("count requires 1 argument".to_string()));
               }
-              let delimiter = &player.movie.item_delimiter;
+              let delimiter = player.movie.item_delimiter;
               let count = StringChunkUtils::resolve_chunk_count(&text.text, StringChunkType::from(&count_of), delimiter)?;
               Ok(player.alloc_datum(Datum::Int(count as i32)))
             }

--- a/vm-rust/src/player/handlers/datum_handlers/string.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string.rs
@@ -37,7 +37,7 @@ impl StringDatumHandlers {
     reserve_player_mut(|player| {
       let value = player.get_datum(datum).string_value()?;
       let operand = player.get_datum(&args[0]).string_value()?;
-      let delimiter = &player.movie.item_delimiter;
+      let delimiter = player.movie.item_delimiter;
       let count = string_get_count(&value, &operand, delimiter)?;
       Ok(player.alloc_datum(Datum::Int(count as i32)))
     })
@@ -75,7 +75,7 @@ impl StringDatumHandlers {
   }
 }
 
-pub fn string_get_count(value: &String, operand: &String, delimiter: &String) -> Result<u32, ScriptError> {
+pub fn string_get_count(value: &String, operand: &String, delimiter: char) -> Result<u32, ScriptError> {
   match operand.as_str() {
     "char" => Ok(value.len() as u32),
     "item" => Ok(string_get_items(value, delimiter).len() as u32),
@@ -86,8 +86,8 @@ pub fn string_get_count(value: &String, operand: &String, delimiter: &String) ->
   }
 }
 
-pub fn string_get_items(value: &String, delimiter: &String) -> Vec<String> {
-  if delimiter == "\r" || delimiter == "\n" {
+pub fn string_get_items(value: &String, delimiter: char) -> Vec<String> {
+  if delimiter == '\r' || delimiter == '\n' {
     string_get_lines(value)
   } else {
     value.split(delimiter).map(|s| s.to_string()).collect()

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -124,7 +124,7 @@ impl DirPlayer {
         puppet_tempo: 0,
         exit_lock: false,
         dir_version: 0,
-        item_delimiter: ".".to_string(),
+        item_delimiter: '.',
         alert_hook: None,
         base_path: "".to_string(),
         file_name: "".to_string(),

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -14,7 +14,7 @@ pub struct Movie {
   pub puppet_tempo: u32,
   pub exit_lock: bool,
   pub dir_version: u16,
-  pub item_delimiter: String,
+  pub item_delimiter: char,
   pub alert_hook: Option<ScriptReceiver>,
   pub base_path: String,
   pub file_name: String,
@@ -57,7 +57,7 @@ impl Movie {
         }
       }
       "exitLock" => Ok(datum_bool(self.exit_lock)),
-      "itemDelimiter" => Ok(Datum::String(self.item_delimiter.clone())),
+      "itemDelimiter" => Ok(Datum::String(self.item_delimiter.into())),
       "runMode" => Ok(Datum::String("Plugin".to_string())), // Plugin / Author
       "date" => {
         // TODO localize formatting
@@ -100,7 +100,7 @@ impl Movie {
         self.exit_lock = value.int_value()? == 1;
       },
       "itemDelimiter" => {
-        self.item_delimiter = value.string_value()?;
+        self.item_delimiter = (value.string_value()?).as_bytes()[0] as char;
       },
       "debugPlaybackEnabled" => {
         // TODO


### PR DESCRIPTION
My first PR with my new account on GitHub. Older PR from me: https://github.com/igorlira/dirplayer-rs/pull/5 https://github.com/igorlira/dirplayer-rs/pull/7 https://github.com/igorlira/dirplayer-rs/pull/8

The delimiter should only have a single `char`.

This avoids unnecessary calls from the processor and saves memory space (a `String` has a size of 24 bytes while a simple `char` has a size of 1 byte).

### Compare `String`'s
`if delimiter == "\r" { }`
```asm
lea     rdi, [rsp + 16]
lea     rsi, [rip + .L__unnamed_13]
call    qword ptr [rip + core::cmp::impls::<impl core::cmp::PartialEq<&B> for &A>::eq::h5252a21b9e880e82@GOTPCREL]
test    al, 1
jne     .LBB30_2
```

### Compare `char`'s
`if delimiter == '\r' { }`
```asm
cmp     al, 13
je      .LBB31_2
```