### PR TITLE
generalize score frame script references to behavior references

### DIFF
--- a/src/views/ScoreInspector/index.tsx
+++ b/src/views/ScoreInspector/index.tsx
@@ -33,7 +33,7 @@ export default function ScoreInspector() {
     <div className={styles.container}>
       <div className={styles.scriptHeader}>
         {range(1, framesToRender + 1).map((frame) => {
-          const scriptRef = score?.scriptReferences?.find(
+          const scriptRef = score?.behaviorReferences?.find(
             (element) =>
               frame >= element.startFrame && frame <= element.endFrame
           );

--- a/src/vm/index.ts
+++ b/src/vm/index.ts
@@ -141,7 +141,7 @@ export interface IUnknownMemberSnapshot {
   type: 'unknown'
 }
 
-export interface IScoreFrameScriptReference {
+export interface IScoreBehaviorReference {
   startFrame: number
   endFrame: number
   castLib: number
@@ -155,7 +155,7 @@ export interface ScoreSpriteSnapshot {
 
 export interface ScoreSnapshot {
   channelCount: number,
-  scriptReferences: IScoreFrameScriptReference[]
+  scriptReferences: IScoreBehaviorReference[]
 }
 
 export type MemberSnapshot = IBaseMemberSnapshot & (IFieldMemberSnapshot | IScriptMemberSnapshot | IBitmapMemberSnapshot | IPaletteMemberSnapshot | IUnknownMemberSnapshot)

--- a/src/vm/index.ts
+++ b/src/vm/index.ts
@@ -155,7 +155,7 @@ export interface ScoreSpriteSnapshot {
 
 export interface ScoreSnapshot {
   channelCount: number,
-  scriptReferences: IScoreBehaviorReference[]
+  behaviorReferences: IScoreBehaviorReference[]
 }
 
 export type MemberSnapshot = IBaseMemberSnapshot & (IFieldMemberSnapshot | IScriptMemberSnapshot | IBitmapMemberSnapshot | IPaletteMemberSnapshot | IUnknownMemberSnapshot)

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -391,8 +391,8 @@ impl JsApi {
     member_map.str_set("channelCount", &JsValue::from(score.get_channel_count()));
 
     member_map.str_set(
-      "scriptReferences",
-      &js_sys::Array::from_iter(score.script_references.iter().map(|scr_ref| {
+      "behaviorReferences",
+      &js_sys::Array::from_iter(score.behavior_references.iter().map(|scr_ref| {
         let script_ref_map = js_sys::Map::new();
         script_ref_map.str_set("startFrame", &scr_ref.start_frame.to_js_value());
         script_ref_map.str_set("endFrame", &scr_ref.end_frame.to_js_value());

--- a/vm-rust/src/player/bytecode/flow_control.rs
+++ b/vm-rust/src/player/bytecode/flow_control.rs
@@ -1,4 +1,4 @@
-use crate::{director::lingo::datum::{Datum, DatumType}, player::{compare::datum_is_zero, handlers::datum_handlers::player_call_datum_handler, player_call_script_handler_raw_args, player_ext_call, player_handle_scope_return, reserve_player_mut, reserve_player_ref, script::{get_current_handler_def, get_current_script, get_name}, HandlerExecutionResult, HandlerExecutionResultContext, ScriptError, PLAYER_OPT}};
+use crate::{director::lingo::datum::{Datum, DatumType}, player::{compare::datum_is_zero, handlers::datum_handlers::player_call_datum_handler, player_call_script_handler_raw_args, player_ext_call, player_handle_scope_return, reserve_player_mut, reserve_player_ref, script::{get_current_handler_def, get_current_script, get_name}, HandlerExecutionResult, ScriptError, PLAYER_OPT}};
 
 use super::handler_manager::BytecodeHandlerContext;
 

--- a/vm-rust/src/player/handlers/datum_handlers/script.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/script.rs
@@ -44,9 +44,7 @@ impl ScriptDatumHandlers {
       let lctx: &crate::director::lingo::script::ScriptContext = get_lctx_for_script(player, script).unwrap();
       let instance = ScriptInstance::new(instance_id, script_ref.to_owned(), script, lctx);
       let instance_ref = player.allocator.alloc_script_instance(instance);
-      let datum_ref = reserve_player_mut(|player| {
-        player.alloc_datum(Datum::ScriptInstanceRef(instance_ref.clone()))
-      });
+      let datum_ref = player.alloc_datum(Datum::ScriptInstanceRef(instance_ref.clone()));
       (instance_ref, datum_ref)
     })
   }

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -26,7 +26,7 @@ impl SpriteChannel {
 }
 
 #[derive(Clone)]
-pub struct ScoreFrameScriptReference {
+pub struct ScoreBehaviorReference {
   pub start_frame: u32,
   pub end_frame: u32,
   pub cast_lib: u16,
@@ -35,7 +35,7 @@ pub struct ScoreFrameScriptReference {
 
 pub struct Score {
   pub channels: Vec<SpriteChannel>,
-  pub script_references: Vec<ScoreFrameScriptReference>,
+  pub script_references: Vec<ScoreBehaviorReference>,
   pub frame_labels: Vec<FrameLabel>,
 }
 
@@ -58,7 +58,7 @@ impl Score {
     }
   }
 
-  pub fn get_script_in_frame(&self, frame: u32) -> Option<ScoreFrameScriptReference> {
+  pub fn get_script_in_frame(&self, frame: u32) -> Option<ScoreBehaviorReference> {
     return self.script_references.iter()
       .find(|x| frame >= x.start_frame && frame <= x.end_frame)
       .map(|x| x.clone())
@@ -120,7 +120,7 @@ impl Score {
       };
 
       self.script_references.push(
-        ScoreFrameScriptReference {
+        ScoreBehaviorReference {
           start_frame: primary.start_frame, 
           end_frame: primary.end_frame, 
           cast_lib: secondary.cast_lib, 

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -35,7 +35,7 @@ pub struct ScoreBehaviorReference {
 
 pub struct Score {
   pub channels: Vec<SpriteChannel>,
-  pub script_references: Vec<ScoreBehaviorReference>,
+  pub behavior_references: Vec<ScoreBehaviorReference>,
   pub frame_labels: Vec<FrameLabel>,
 }
 
@@ -53,13 +53,13 @@ impl Score {
   pub fn empty() -> Score {
     Score {
       channels: vec![],
-      script_references: vec![],
+      behavior_references: vec![],
       frame_labels: vec![],
     }
   }
 
   pub fn get_script_in_frame(&self, frame: u32) -> Option<ScoreBehaviorReference> {
-    return self.script_references.iter()
+    return self.behavior_references.iter()
       .find(|x| frame >= x.start_frame && frame <= x.end_frame)
       .map(|x| x.clone())
   }
@@ -119,7 +119,7 @@ impl Score {
         continue;
       };
 
-      self.script_references.push(
+      self.behavior_references.push(
         ScoreBehaviorReference {
           start_frame: primary.start_frame, 
           end_frame: primary.end_frame, 


### PR DESCRIPTION
both deserialization and behavior creation are consistent between frame scripts and sprite scripts, so generalize naming in preparation for loading sprites from the score