### PR TITLE
improve sprite loading from score

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Web site for playing Shockwave movies"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>DirPlayer App</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "DirPlayer",
+  "name": "DirPlayer App",
   "icons": [
     {
       "src": "favicon.ico",

--- a/src/components/ScriptMemberPreview/index.tsx
+++ b/src/components/ScriptMemberPreview/index.tsx
@@ -82,7 +82,7 @@ export default function ScriptMemberPreview({
           ([name, _, scriptMemRef]) => name === handler.name && memberId.castNumber === scriptMemRef[0] && memberId.memberNumber === scriptMemRef[1]
         );
         return (
-          <div>
+          <div key={handler.name}>
             <button
               className={classNames(
                 styles.handlerName,

--- a/src/components/VMProvider.tsx
+++ b/src/components/VMProvider.tsx
@@ -49,7 +49,7 @@ export default function VMProvider({ children }: VMProviderProps) {
       console.log("Initializing VM");
 
       initVmCallbacks();
-      init().then((vm: Object) => {
+      init({}).then((vm: Object) => {
         console.log("VM initialized", vm);
         send({ type: "INIT_OK" });
 

--- a/vm-rust/src/director/chunks/score.rs
+++ b/vm-rust/src/director/chunks/score.rs
@@ -21,7 +21,7 @@ impl ScoreFrameDelta {
 const K_CHANNEL_DATA_SIZE: usize = 38664; // (25 * 50);
 
 #[allow(dead_code)]
-#[derive(Clone)]
+#[derive(Clone, Default, PartialEq)]
 pub struct ScoreFrameChannelData {
   pub sprite_type: u8,
   pub ink: u8,
@@ -110,7 +110,7 @@ impl ScoreFrameData {
           let pos = channel_reader.pos;
           let data = ScoreFrameChannelData::read(&mut channel_reader);
           channel_reader.jmp(pos + header.sprite_record_size as usize);
-          if data.sprite_type != 0 {
+          if data != ScoreFrameChannelData::default() {
             log_i(format_args!("frame_index={frame_index} channel_index={channel_index} sprite_type={} ink={} fore_color={} back_color={} pos_y={} pos_x={} height={} width={}", data.sprite_type, data.ink, data.fore_color, data.back_color, data.pos_y, data.pos_x, data.height, data.width).to_string().as_str());
             frame_channel_data.push((frame_index, channel_index, data));
           }

--- a/vm-rust/src/director/chunks/score.rs
+++ b/vm-rust/src/director/chunks/score.rs
@@ -90,6 +90,19 @@ impl ScoreFrameData {
         let mut frame_chunk_reader = BinaryReader::from_u8(chunk_data);
         frame_chunk_reader.set_endian(Endian::Big);
 
+        // director reserves the first 6 channels:
+        // note that channel indices are different than channel numbers
+        // ┌───────┬─────────────────┐
+        // │ index │                 │
+        // ├───────┼─────────────────┤
+        // │     0 │ frame script    │
+        // │     1 │ palette         │
+        // │     2 │ transition      │
+        // │     3 │ sound 1         │
+        // │     4 │ sound 2         │
+        // │     5 │ tempo           │
+        // │   N>5 │ sprites         │
+        // └───────┴─────────────────┘
         let mut channel_index = 0;
         while !frame_chunk_reader.eof() {
           channel_index = channel_index + 1;

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -392,13 +392,14 @@ impl JsApi {
 
     member_map.str_set(
       "behaviorReferences",
-      &js_sys::Array::from_iter(score.behavior_references.iter().map(|scr_ref| {
+      &js_sys::Array::from_iter(score.sprite_spans.iter().filter(|span| span.scripts.len() > 0).map(|span| {
+        let behavior = span.scripts.first().unwrap();
         let script_ref_map = js_sys::Map::new();
-        script_ref_map.str_set("startFrame", &scr_ref.start_frame.to_js_value());
-        script_ref_map.str_set("endFrame", &scr_ref.end_frame.to_js_value());
-        script_ref_map.str_set("castLib", &scr_ref.cast_lib.to_js_value());
-        script_ref_map.str_set("castMember", &scr_ref.cast_member.to_js_value());
-        script_ref_map.str_set("channelNumber", &scr_ref.channel_number.to_js_value());
+        script_ref_map.str_set("startFrame", &span.start_frame.to_js_value());
+        script_ref_map.str_set("endFrame", &span.end_frame.to_js_value());
+        script_ref_map.str_set("castLib", &behavior.cast_lib.to_js_value());
+        script_ref_map.str_set("castMember", &behavior.cast_member.to_js_value());
+        script_ref_map.str_set("channelNumber", &span.channel_number.to_js_value());
         script_ref_map.to_js_object()
       })),
     );

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -775,12 +775,14 @@ pub async fn run_frame_loop() {
       if !frame_skipped {
         player_unwrap_result(player_invoke_global_event(&"exitFrame".to_string(), &vec![]).await);
         let ended_sprite_nums = reserve_player_mut(|player| {
-          player.movie.score.end_sprites(prev_frame)
+          let next_frame = player.get_next_frame(); // an exitFrame handler may have changed the next frame
+          player.movie.score.end_sprites(prev_frame, next_frame)
         });
         player_wait_available().await;
         reserve_player_mut(|player| {
           for sprite_num in ended_sprite_nums.iter() {
-            player.movie.score.get_sprite_mut(*sprite_num as i16).script_instance_list.clear();
+            let sprite = player.movie.score.get_sprite_mut(*sprite_num as i16);
+            sprite.exited = true; 
           }
         });
         (is_playing, is_script_paused) = reserve_player_mut(|player| {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -72,7 +72,7 @@ impl Score {
 
   pub fn get_script_in_frame(&self, frame: u32) -> Option<ScoreBehaviorReference> {
     return self.behavior_references.iter()
-      .find(|x| frame >= x.start_frame && frame <= x.end_frame)
+      .find(|x| x.channel_number == 0 && frame >= x.start_frame && frame <= x.end_frame)
       .map(|x| x.clone())
   }
 

--- a/vm-rust/src/player/sprite.rs
+++ b/vm-rust/src/player/sprite.rs
@@ -57,6 +57,8 @@ pub struct Sprite {
   pub script_instance_list: Vec<ScriptInstanceRef>,
   pub cursor_ref: Option<CursorRef>,
   pub editable: bool,
+  pub entered: bool,
+  pub exited: bool,
 }
 
 impl Sprite {
@@ -85,6 +87,8 @@ impl Sprite {
       script_instance_list: vec![],
       cursor_ref: None,
       editable: false,
+      entered: false,
+      exited: false,
     }
   }
 
@@ -111,5 +115,7 @@ impl Sprite {
     self.script_instance_list.clear();
     self.cursor_ref = None;
     self.editable = false;
+    self.entered = false;
+    self.exited = false;
   }
 }


### PR DESCRIPTION
* Fixed an issue where sprite data was only deserialized on the first frame instead of its appropriate frame
* Refactored the score so behavior_references are part of a new ScoreSpriteSpan struct, which simplifies the mental model
* Changed sprite initialization to rely on sprite spans rather than behaviors in case there are sprites which don't have a corresponding behavior

Open questions:
- Is it possible for a single sprite span to have multiple scripts in the score? I assume so but am not sure how this would be serialized...
- Is it appropriate to reset sprite spans on the beginning of the next frame like we are doing, to avoid resetting it before the frame loop has processed the endSprite events?