### PR TITLE
fix: guard process.env access in polyfill build

### DIFF
--- a/src/utils/debug.ts
+++ b/src/utils/debug.ts
@@ -5,5 +5,5 @@ export function isDebugSession() {
 }
 
 export function isUIShown() {
-  return process.env.REACT_APP_SHOW_UI === "true" || isDebugSession();
+  return (typeof process !== 'undefined' && process.env?.REACT_APP_SHOW_UI === "true") || isDebugSession();
 }


### PR DESCRIPTION
## Summary
- Add `typeof process` check in `isUIShown()` to prevent `ReferenceError` in browser environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)