### PR TITLE
Add built-in tan() function

### DIFF
--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -783,6 +783,7 @@ impl BuiltInHandlerManager {
             "sin" => TypeHandlers::sin(args),
             "cos" => TypeHandlers::cos(args),
             "sqrt" => TypeHandlers::sqrt(args),
+            "tan" => TypeHandlers::tan(args),
             "atan" => TypeHandlers::atan(args),
             "sound" => TypeHandlers::sound(args),
             "vector" => TypeHandlers::vector(args),

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -1279,6 +1279,13 @@ impl TypeHandlers {
         })
     }
 
+    pub fn tan(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            let value = player.get_datum(&args[0]).to_float()?;
+            Ok(player.alloc_datum(Datum::Float(value.tan())))
+        })
+    }
+
     pub fn atan(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let value = player.get_datum(&args[0]);


### PR DESCRIPTION
## Summary
- Register `tan()` as a built-in Lingo handler alongside `sin`, `cos`, `sqrt`, and `atan`

## Test plan
- [x] `cargo check` passes
- [ ] Verify `tan(0.4636)` returns expected result (~0.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)