### PR TITLE
fix error handling for movie file loading

### DIFF
--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -366,24 +366,43 @@ impl DirPlayer {
     pub async fn load_movie_from_file(&mut self, path: &str) {
         let task_id = self.net_manager.preload_net_thing(path.to_owned());
         self.net_manager.await_task(task_id).await;
-        let task = self.net_manager.get_task(task_id).unwrap();
-        let data_bytes = self
-            .net_manager
-            .get_task_result(Some(task_id))
-            .unwrap()
-            .unwrap();
+
+        let task = match self.net_manager.get_task(task_id) {
+            Some(task) => task,
+            None => {
+                log::error!("load_movie_from_file: task {} not found for {}", task_id, path);
+                return;
+            }
+        };
+
+        let data_bytes = match self.net_manager.get_task_result(Some(task_id)) {
+            Some(Ok(bytes)) => bytes,
+            Some(Err(code)) => {
+                log::error!("load_movie_from_file: fetch failed for {} (error code {})", task.resolved_url, code);
+                return;
+            }
+            None => {
+                log::error!("load_movie_from_file: no result for task {} ({})", task_id, path);
+                return;
+            }
+        };
 
         let file_name = task.resolved_url
             .path_segments()
             .and_then(|segments| segments.last())
             .unwrap_or("untitled.dcr");
 
-        let movie_file = read_director_file_bytes(
+        let movie_file = match read_director_file_bytes(
             &data_bytes,
             &file_name,
             &get_base_url(&task.resolved_url).to_string(),
-        )
-        .unwrap();
+        ) {
+            Ok(file) => file,
+            Err(e) => {
+                log::error!("load_movie_from_file: failed to parse {}: {:?}", path, e);
+                return;
+            }
+        };
         self.load_movie_from_dir(movie_file).await;
     }
 

--- a/vm-rust/src/player/net_task.rs
+++ b/vm-rust/src/player/net_task.rs
@@ -9,7 +9,6 @@ use web_sys::Response;
 
 use percent_encoding::percent_decode_str;
 
-use crate::utils::log_i;
 
 pub type NetResult = Result<Vec<u8>, i32>;
 
@@ -104,10 +103,12 @@ pub async fn fetch_net_task(task: &NetTask) -> NetResult {
 
             task_result = Ok(blob_buffer.to_vec().iter().map(|x| *x as u8).collect_vec());
         } else {
-            task_result = Err(4); // TODO: Error code
+            log::warn!("Fetch failed for {} (status {})", url_string, resp.status());
+            task_result = Err(resp.status() as i32);
         }
     } else {
-        task_result = Err(4); // TODO: Error code
+        log::warn!("Fetch rejected for {}", url_string);
+        task_result = Err(-1);
     }
 
     return task_result;


### PR DESCRIPTION
## Summary
- Log actual URL and HTTP status on fetch failure instead of hardcoded error code `4`
- Handle errors gracefully in `load_movie_from_file` instead of panicking

## Test plan
- [ ] Build and load Bionicle Colgate game — should log error instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)