### PR TITLE
Fix u16 overflow in 2-bit and 4-bit bitmap decoders

### DIFF
--- a/vm-rust/src/player/bitmap/bitmap.rs
+++ b/vm-rust/src/player/bitmap/bitmap.rs
@@ -293,7 +293,7 @@ fn decode_bitmap_2bit(
     let mut result_bmp = vec![0; width as usize * height as usize];
     for y in 0..scan_height {
         for x in 0..scan_width {
-            let compressed_index = (y * scan_width + x) as usize;
+            let compressed_index = y as usize * scan_width as usize + x as usize;
             if compressed_index >= decoded_data.len() {
                 return Err(format!(
                     "decode_bitmap_2bit: compressed_index {} >= decoded_data.len() {}",
@@ -302,7 +302,7 @@ fn decode_bitmap_2bit(
                 ));
             }
             if x < width {
-                let pixel_index = (y * width + x) as usize;
+                let pixel_index = y as usize * width as usize + x as usize;
                 let pixel = decoded_data[compressed_index];
                 result_bmp[pixel_index] = pixel;
             }
@@ -349,7 +349,7 @@ fn decode_bitmap_4bit(
 
     for y in 0..height {
         for x in 0..width {
-            let scan_index = (y * scan_width + x) as usize;
+            let scan_index = y as usize * scan_width as usize + x as usize;
 
             if scan_index >= decoded_data.len() {
                 return Err(format!(
@@ -360,7 +360,7 @@ fn decode_bitmap_4bit(
             }
 
             let pixel = decoded_data[scan_index];
-            let pixel_index = (y * width + x) as usize;
+            let pixel_index = y as usize * width as usize + x as usize;
 
             // Store as 8-bit indexed (values 0-15)
             result_bmp[pixel_index] = pixel;


### PR DESCRIPTION
## Summary
- Fix arithmetic overflow panic in `decode_bitmap_2bit` and `decode_bitmap_4bit` when index calculations (`y * scan_width + x`) exceed u16 max (65535)
- Cast operands to `usize` before multiplying, matching the existing fix in `decode_bitmap_1bit`
- Fixes crash when loading World Builder and other movies with large bitmaps

## Test plan
- [x] Verified World Builder (`worldbuilder.dcr`) loads and renders correctly after fix
- [ ] Verify other movies with 2-bit and 4-bit bitmaps still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)