### PR TITLE
fix: prefix unused player variables with underscore

### DIFF
--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -57,7 +57,7 @@ impl GetSetUtils {
     }
 
     pub fn get_top_level_prop(
-        player: &mut DirPlayer,
+        _player: &mut DirPlayer,
         prop_name: &str,
     ) -> Result<Datum, ScriptError> {
         match prop_name {

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -1633,7 +1633,7 @@ pub async fn eval_lingo_expr_ast_runtime(expr: &LingoExpr) -> Result<DatumRef, S
         }
         LingoExpr::PutDisplay(value_expr) => {
             let value = Box::pin(eval_lingo_expr_ast_runtime(value_expr)).await?;
-            reserve_player_mut(|player| {
+            reserve_player_mut(|_player| {
                 use crate::player::handlers::manager::BuiltInHandlerManager;
                 BuiltInHandlerManager::put(&vec![value])?;
                 Ok(DatumRef::Void)

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
@@ -320,7 +320,7 @@ impl FieldMemberHandlers {
         match prop {
             "text" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().text = value?.trim_end_matches('\0').to_string();
                     Ok(())
@@ -355,7 +355,7 @@ impl FieldMemberHandlers {
             ),
             "alignment" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().alignment = value?;
                     Ok(())
@@ -363,7 +363,7 @@ impl FieldMemberHandlers {
             ),
             "wordWrap" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().word_wrap = value?;
                     Ok(())
@@ -371,7 +371,7 @@ impl FieldMemberHandlers {
             ),
             "width" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().width = value? as u16;
                     Ok(())
@@ -379,7 +379,7 @@ impl FieldMemberHandlers {
             ),
             "height" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().fixed_line_space = value? as u16;
                     Ok(())
@@ -387,7 +387,7 @@ impl FieldMemberHandlers {
             ),
             "font" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().font = value?;
                     Ok(())
@@ -395,7 +395,7 @@ impl FieldMemberHandlers {
             ),
             "fontSize" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let font_size = value? as u16;
                     let field = cast_member.member_type.as_field_mut().unwrap();
@@ -405,7 +405,7 @@ impl FieldMemberHandlers {
             ),
             "fontStyle" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().font_style = value?;
                     Ok(())
@@ -413,7 +413,7 @@ impl FieldMemberHandlers {
             ),
             "fixedLineSpace" | "lineHeight" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member
                         .member_type
@@ -425,7 +425,7 @@ impl FieldMemberHandlers {
             ),
             "topSpacing" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().top_spacing = value? as i16;
                     Ok(())
@@ -433,7 +433,7 @@ impl FieldMemberHandlers {
             ),
             "boxType" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().box_type = value?;
                     Ok(())
@@ -441,7 +441,7 @@ impl FieldMemberHandlers {
             ),
             "antialias" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().anti_alias = value?;
                     Ok(())
@@ -449,7 +449,7 @@ impl FieldMemberHandlers {
             ),
             "autoTab" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().auto_tab = value?;
                     Ok(())
@@ -457,7 +457,7 @@ impl FieldMemberHandlers {
             ),
             "editable" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().editable = value?;
                     Ok(())
@@ -465,7 +465,7 @@ impl FieldMemberHandlers {
             ),
             "border" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().border = value? as u16;
                     Ok(())
@@ -473,7 +473,7 @@ impl FieldMemberHandlers {
             ),
             "margin" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().margin = value? as u16;
                     Ok(())
@@ -481,7 +481,7 @@ impl FieldMemberHandlers {
             ),
             "boxDropShadow" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().box_drop_shadow = value? as u16;
                     Ok(())
@@ -489,7 +489,7 @@ impl FieldMemberHandlers {
             ),
             "dropShadow" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().drop_shadow = value? as u16;
                     Ok(())
@@ -497,7 +497,7 @@ impl FieldMemberHandlers {
             ),
             "scrollTop" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().scroll_top = value? as u16;
                     Ok(())
@@ -505,7 +505,7 @@ impl FieldMemberHandlers {
             ),
             "hilite" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_field_mut().unwrap().hilite = value?;
                     Ok(())
@@ -513,7 +513,7 @@ impl FieldMemberHandlers {
             ),
             "foreColor" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let v = value? as u8;
                     cast_member.member_type.as_field_mut().unwrap().fore_color = Some(ColorRef::PaletteIndex(v));
@@ -522,7 +522,7 @@ impl FieldMemberHandlers {
             ),
             "backColor" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let v = value? as u8;
                     cast_member.member_type.as_field_mut().unwrap().back_color = Some(ColorRef::PaletteIndex(v));
@@ -531,7 +531,7 @@ impl FieldMemberHandlers {
             ),
             "media" => borrow_member_mut(
                 member_ref,
-                |player| value.media_value(),
+                |_player| value.media_value(),
                 |cast_member, value| {
                     let field = cast_member.member_type.as_field_mut().unwrap();
                     match value? {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -1411,14 +1411,14 @@ impl FontMemberHandlers {
     }
 
     pub fn set_prop(
-        player: &mut DirPlayer,
+        _player: &mut DirPlayer,
         member_ref: &CastMemberRef,
         prop: &str,
         value: Datum,
     ) -> Result<(), ScriptError> {
         borrow_member_mut(
             member_ref,
-            |player| (), // no extra data needed
+            |_player| (), // no extra data needed
             |cast_member, _| {
                 if let CastMemberType::Font(font_member) = &mut cast_member.member_type {
                     let prop = prop.to_ascii_lowercase();

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -945,7 +945,7 @@ impl TextMemberHandlers {
         match prop_lc.as_str() {
             "text" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     let new_text = value?.trim_end_matches('\0').to_string();
@@ -982,7 +982,7 @@ impl TextMemberHandlers {
             ),
             "alignment" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().alignment = value?;
                     Ok(())
@@ -990,7 +990,7 @@ impl TextMemberHandlers {
             ),
             "wordwrap" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().word_wrap = value?;
                     Ok(())
@@ -998,7 +998,7 @@ impl TextMemberHandlers {
             ),
             "width" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().width = value? as u16;
                     Ok(())
@@ -1006,7 +1006,7 @@ impl TextMemberHandlers {
             ),
             "font" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let font_name = value?;
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
@@ -1019,7 +1019,7 @@ impl TextMemberHandlers {
             ),
             "fontsize" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let size = value? as u16;
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
@@ -1056,7 +1056,7 @@ impl TextMemberHandlers {
             ),
             "fixedlinespace" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member
                         .member_type
@@ -1068,7 +1068,7 @@ impl TextMemberHandlers {
             ),
             "topspacing" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().top_spacing = value? as i16;
                     Ok(())
@@ -1076,7 +1076,7 @@ impl TextMemberHandlers {
             ),
             "boxtype" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().box_type = value?;
                     Ok(())
@@ -1084,7 +1084,7 @@ impl TextMemberHandlers {
             ),
             "antialias" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().anti_alias = value?;
                     Ok(())
@@ -1092,7 +1092,7 @@ impl TextMemberHandlers {
             ),
             "html" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let html_string = value?;
                     let spans = HtmlParser::parse_html(&html_string).map_err(|e| {
@@ -1238,7 +1238,7 @@ impl TextMemberHandlers {
             ),
             "height" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_data = cast_member.member_type.as_text_mut().unwrap();
                     // Setting height is a no-op for #adjust box type
@@ -1250,7 +1250,7 @@ impl TextMemberHandlers {
             ),
             "forecolor" | "color" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let color_val = value?;
                     // If value > 255, treat as RGB, otherwise as palette index
@@ -1267,7 +1267,7 @@ impl TextMemberHandlers {
             ),
             "bgcolor" | "backcolor" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let color_val = value?;
                     // If value > 255, treat as RGB, otherwise as palette index
@@ -1284,7 +1284,7 @@ impl TextMemberHandlers {
             ),
             "lineheight" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     cast_member.member_type.as_text_mut().unwrap().fixed_line_space = value? as u16;
                     Ok(())
@@ -1293,7 +1293,7 @@ impl TextMemberHandlers {
             // TextInfo (3D text / D6+ text member) property setters
             "tunneldepth" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1304,7 +1304,7 @@ impl TextMemberHandlers {
             ),
             "beveldepth" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1315,7 +1315,7 @@ impl TextMemberHandlers {
             ),
             "smoothness" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1326,7 +1326,7 @@ impl TextMemberHandlers {
             ),
             "reflectivity" => borrow_member_mut(
                 member_ref,
-                |player| value.float_value().or_else(|_| value.int_value().map(|i| i as f64)),
+                |_player| value.float_value().or_else(|_| value.int_value().map(|i| i as f64)),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1337,7 +1337,7 @@ impl TextMemberHandlers {
             ),
             "beveltype" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1354,7 +1354,7 @@ impl TextMemberHandlers {
             ),
             "displaymode" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1370,7 +1370,7 @@ impl TextMemberHandlers {
             ),
             "directionalpreset" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1394,7 +1394,7 @@ impl TextMemberHandlers {
             ),
             "texturetype" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1411,7 +1411,7 @@ impl TextMemberHandlers {
             ),
             "directionalcolor" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1427,7 +1427,7 @@ impl TextMemberHandlers {
             ),
             "ambientcolor" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1442,7 +1442,7 @@ impl TextMemberHandlers {
             ),
             "specularcolor" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1505,7 +1505,7 @@ impl TextMemberHandlers {
             ),
             "texturemember" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1544,7 +1544,7 @@ impl TextMemberHandlers {
             ),
             "editable" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1555,7 +1555,7 @@ impl TextMemberHandlers {
             ),
             "autotab" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1566,7 +1566,7 @@ impl TextMemberHandlers {
             ),
             "directtostage" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1577,7 +1577,7 @@ impl TextMemberHandlers {
             ),
             "prerender" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1594,7 +1594,7 @@ impl TextMemberHandlers {
             ),
             "savebitmap" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1605,7 +1605,7 @@ impl TextMemberHandlers {
             ),
             "kerning" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1616,7 +1616,7 @@ impl TextMemberHandlers {
             ),
             "kerningthreshold" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1627,7 +1627,7 @@ impl TextMemberHandlers {
             ),
             "usehypertextstyles" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1638,7 +1638,7 @@ impl TextMemberHandlers {
             ),
             "antialiasthreshold" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1649,7 +1649,7 @@ impl TextMemberHandlers {
             ),
             "scrolltop" => borrow_member_mut(
                 member_ref,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if let Some(ref mut info) = text_member.info {
@@ -1660,7 +1660,7 @@ impl TextMemberHandlers {
             ),
             "centerregpoint" => borrow_member_mut(
                 member_ref,
-                |player| value.bool_value(),
+                |_player| value.bool_value(),
                 |cast_member, value| {
                     let text_member = cast_member.member_type.as_text_mut().unwrap();
                     if text_member.info.is_none() {
@@ -1674,7 +1674,7 @@ impl TextMemberHandlers {
             ),
             "rtf" => borrow_member_mut(
                 member_ref,
-                |player| value.string_value(),
+                |_player| value.string_value(),
                 |cast_member, value| {
                     let rtf_string = value?;
                     let text_member = cast_member.member_type.as_text_mut().unwrap();

--- a/vm-rust/src/player/handlers/datum_handlers/player.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/player.rs
@@ -12,7 +12,7 @@ impl PlayerDatumHandlers {
     pub fn call(handler_name: &str, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         match handler_name {
             "count" => Self::count(args),
-            _ => reserve_player_ref(|player| {
+            _ => reserve_player_ref(|_player| {
                 Err(ScriptError::new_code(
                     ScriptErrorCode::HandlerNotFound,
                     format!("No handler {handler_name} for player datum"),

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -3606,7 +3606,7 @@ impl SoundChannel {
         self.sample_count as f64 / self.sample_rate as f64
     }
 
-    pub fn update(&mut self, delta_time: f64, player: &mut DirPlayer) -> Result<(), ScriptError> {
+    pub fn update(&mut self, delta_time: f64, _player: &mut DirPlayer) -> Result<(), ScriptError> {
         // Handle fading
         if self.is_fading {
             self.fade_elapsed += delta_time;

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -3258,7 +3258,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "stretch" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 sprite.stretch = value?;
                 Ok(())
@@ -3266,7 +3266,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "locH" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 let val = value?;
                 sprite.loc_h = val;
@@ -3275,7 +3275,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "locV" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 let val = value?;
                 sprite.loc_v = val;
@@ -3289,7 +3289,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             }
             borrow_sprite_mut(
                 sprite_id,
-                |player| value.int_value(),
+                |_player| value.int_value(),
                 |sprite, value| {
                     sprite.loc_z = value?;
                     Ok(())
@@ -3298,7 +3298,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         }
         "width" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 sprite.width = value?;
                 sprite.has_size_changed = true;
@@ -3307,7 +3307,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "height" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 sprite.height = value?;
                 sprite.has_size_changed = true;
@@ -3370,7 +3370,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "ink" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 sprite.ink = value?;
                 Ok(())
@@ -3378,7 +3378,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "blend" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 sprite.blend = value?;
                 Ok(())
@@ -3587,7 +3587,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "memberNum" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 let value = value?;
                 // Check if value looks like a slot number (cast_lib << 16 | cast_member)
@@ -3610,7 +3610,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "castNum" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 let value = value?;
                 let new_member_ref =
@@ -3845,7 +3845,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "constraint" => borrow_sprite_mut(
             sprite_id,
-            |player| value.int_value(),
+            |_player| value.int_value(),
             |sprite, value| {
                 let val = value?;
                 sprite.constraint = val;

--- a/vm-rust/src/player/script.rs
+++ b/vm-rust/src/player/script.rs
@@ -338,7 +338,7 @@ pub fn get_current_scope<'a>(
 }
 
 pub fn get_current_script<'a>(
-    player: &'a DirPlayer,
+    _player: &'a DirPlayer,
     ctx: &'a BytecodeHandlerContext,
 ) -> Option<&'a Script> {
     return Some(unsafe { &*ctx.script_ptr });


### PR DESCRIPTION
## Summary

- Prefix 80 unused `player` closure/function parameters with `_` across 9 files
- These are all cases where `borrow_member_mut`, `reserve_player_mut`, or similar helpers pass a `player` reference that the callback doesn't need

## Motivation

The 80 unused-variable warnings created enough noise that useful warnings were getting buried. Cleaning these up makes it easier to spot real issues in `cargo check` output.