### PR TITLE
fix: remove unreachable match arms and dead code

### DIFF
--- a/vm-rust/src/director/static_datum.rs
+++ b/vm-rust/src/director/static_datum.rs
@@ -183,19 +183,5 @@ fn static_datum_to_runtime(param: &StaticDatum, allocator: &mut DatumAllocator) 
             allocator.alloc_datum(Datum::Rect(arr)).unwrap()
         }
         StaticDatum::Void => DatumRef::Void,
-        _ => {
-            warn!("⚠️ Unhandled StaticDatum type, using Void");
-            DatumRef::Void
-        }
-        StaticDatum::IntRect(left, top, right, bottom) => {
-            let arr = [
-                allocator.alloc_datum(Datum::Int(*left)).unwrap(),
-                allocator.alloc_datum(Datum::Int(*top)).unwrap(),
-                allocator.alloc_datum(Datum::Int(*right)).unwrap(),
-                allocator.alloc_datum(Datum::Int(*bottom)).unwrap(),
-            ];
-            allocator.alloc_datum(Datum::Rect(arr)).unwrap()
-        }
-        StaticDatum::Void => DatumRef::Void,
     }
 }

--- a/vm-rust/src/player/bytecode/handler_manager.rs
+++ b/vm-rust/src/player/bytecode/handler_manager.rs
@@ -243,7 +243,6 @@ impl StaticBytecodeHandlerManager {
             OpCode::PushFloat32 => StackBytecodeHandler::push_f32(ctx),
             OpCode::Mul => ArithmeticsBytecodeHandler::mul(ctx),
             OpCode::PushChunkVarRef => StackBytecodeHandler::push_chunk_var_ref(ctx),
-            OpCode::PushVarRef => StackBytecodeHandler::push_var_ref(ctx),
             OpCode::DeleteChunk => StringBytecodeHandler::delete_chunk(ctx),
             OpCode::GetTopLevelProp => GetSetBytecodeHandler::get_top_level_prop(ctx),
             OpCode::PutChunk => StringBytecodeHandler::put_chunk(ctx),

--- a/vm-rust/src/player/datum_operations.rs
+++ b/vm-rust/src/player/datum_operations.rs
@@ -652,67 +652,6 @@ pub fn multiply_datums(
             let right_float = right.parse::<f64>().unwrap_or(0.0);
             Datum::Float((*left as f64) * right_float)
         }
-        // Point multiplication
-        (Datum::Point(a), Datum::Int(right)) => {
-            let right_ref = player.alloc_datum(Datum::Int(*right));
-            let mut result: [DatumRef; 2] = std::array::from_fn(|_| DatumRef::Void);
-            for i in 0..2 {
-                let a_val = player.get_datum(&a[i]).clone();
-                let b_val = player.get_datum(&right_ref).clone();
-                let prod = multiply_datums(
-                    player.alloc_datum(a_val),
-                    player.alloc_datum(b_val),
-                    player
-                )?;
-                result[i] = player.alloc_datum(prod);
-            }
-            Datum::Point(result)
-        }
-        (Datum::Point(a), Datum::Float(right)) => {
-            let right_ref = player.alloc_datum(Datum::Float(*right));
-            let mut result: [DatumRef; 2] = std::array::from_fn(|_| DatumRef::Void);
-            for i in 0..2 {
-                let a_val = player.get_datum(&a[i]).clone();
-                let b_val = player.get_datum(&right_ref).clone();
-                let prod = multiply_datums(
-                    player.alloc_datum(a_val),
-                    player.alloc_datum(b_val),
-                    player
-                )?;
-                result[i] = player.alloc_datum(prod);
-            }
-            Datum::Point(result)
-        }
-        (Datum::Int(left), Datum::Point(b)) => {
-            let left_ref = player.alloc_datum(Datum::Int(*left));
-            let mut result: [DatumRef; 2] = std::array::from_fn(|_| DatumRef::Void);
-            for i in 0..2 {
-                let a_val = player.get_datum(&left_ref).clone();
-                let b_val = player.get_datum(&b[i]).clone();
-                let prod = multiply_datums(
-                    player.alloc_datum(a_val),
-                    player.alloc_datum(b_val),
-                    player
-                )?;
-                result[i] = player.alloc_datum(prod);
-            }
-            Datum::Point(result)
-        }
-        (Datum::Float(left), Datum::Point(b)) => {
-            let left_ref = player.alloc_datum(Datum::Float(*left));
-            let mut result: [DatumRef; 2] = std::array::from_fn(|_| DatumRef::Void);
-            for i in 0..2 {
-                let a_val = player.get_datum(&left_ref).clone();
-                let b_val = player.get_datum(&b[i]).clone();
-                let prod = multiply_datums(
-                    player.alloc_datum(a_val),
-                    player.alloc_datum(b_val),
-                    player
-                )?;
-                result[i] = player.alloc_datum(prod);
-            }
-            Datum::Point(result)
-        }
         (Datum::Point(p), Datum::List(_, list, _)) if list.len() == 2 => {
             let mut result: [DatumRef; 2] = std::array::from_fn(|_| DatumRef::Void);
             for i in 0..2 {

--- a/vm-rust/src/player/datum_ref.rs
+++ b/vm-rust/src/player/datum_ref.rs
@@ -39,7 +39,6 @@ impl PartialEq for DatumRef {
             (DatumRef::Ref(id1, ..), DatumRef::Void) => *id1 == 0,
             (DatumRef::Void, DatumRef::Ref(id2, ..)) => *id2 == 0,
             (DatumRef::Ref(id1, ..), DatumRef::Ref(id2, ..)) => id1 == id2,
-            _ => false,
         }
     }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -1113,7 +1113,6 @@ impl FontMemberHandlers {
                 // fallback: find closest palette index
                 0
             }
-            _ => 0, // fallback
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove duplicate `PushVarRef` match arm in handler_manager
- Remove 4 duplicate Point×scalar multiply arms in datum_operations
- Remove unreachable wildcard in `DatumRef::PartialEq`
- Remove unreachable wildcard in `color_ref_to_u8`
- Remove dead wildcard + duplicate arms in `static_datum_to_runtime`

## Motivation

These unreachable patterns added noise to `cargo check` output, making it harder to spot real warnings.