### PR TITLE
fix: replace deprecated web-sys method calls

### DIFF
--- a/vm-rust/Cargo.toml
+++ b/vm-rust/Cargo.toml
@@ -94,6 +94,7 @@ features = [
   'AudioContext',
   'AudioBuffer',
   'AudioBufferSourceNode',
+  'AudioScheduledSourceNode',
   'GainNode',
   'StereoPannerNode',
   'AudioParam',

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -6,8 +6,8 @@ use crate::{
 use std::sync::Arc;
 use wasm_bindgen::JsCast;
 use web_sys::{
-    AudioBuffer, AudioBufferSourceNode, AudioContext, Blob, GainNode, HtmlAudioElement,
-    OfflineAudioContext, StereoPannerNode, Url,
+    AudioBuffer, AudioBufferSourceNode, AudioContext, AudioScheduledSourceNode, Blob, GainNode,
+    HtmlAudioElement, OfflineAudioContext, StereoPannerNode, Url,
 };
 
 use crate::player::cast_member::CastMemberType;
@@ -1492,7 +1492,8 @@ impl SoundChannel {
 
         // Disconnect and stop any existing nodes
         if let Some(source) = channel.source_node.take() {
-            let _ = source.stop();
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop();
             let _ = source.disconnect();
         }
 
@@ -2587,7 +2588,8 @@ impl SoundChannel {
         self.is_fading = false;
 
         if let Some(ref source) = self.source_node {
-            let _ = source.stop_with_when(0.0);
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop_with_when(0.0);
             let _ = source.disconnect();
             debug!("🛑 Stopped previous sound");
         }
@@ -3112,9 +3114,11 @@ impl SoundChannel {
         let mut blob_parts = js_sys::Array::new();
         blob_parts.push(&uint8_array);
 
+        let blob_opts = web_sys::BlobPropertyBag::new();
+        blob_opts.set_type("audio/mpeg");
         let blob = Blob::new_with_u8_array_sequence_and_options(
             &blob_parts,
-            web_sys::BlobPropertyBag::new().type_("audio/mpeg"),
+            &blob_opts,
         )?;
 
         debug!("✅ Blob created: {} bytes", blob.size());
@@ -3204,7 +3208,8 @@ impl SoundChannel {
 
         // Step 3: Stop any existing playback
         if let Some(ref source) = self.source_node {
-            let _ = source.stop_with_when(0.0);
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop_with_when(0.0);
             let _ = source.disconnect();
         }
         self.source_node = None;
@@ -3653,7 +3658,8 @@ impl SoundChannel {
         
         if let Some(source) = self.source_node.take() {
             debug!("🛑 Stopping channel {}", self.channel_num);
-            let _ = source.stop_with_when(0.0);
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop_with_when(0.0);
             let _ = source.disconnect();
         }
         if let Some(gain) = self.gain_node.take() {
@@ -3877,7 +3883,8 @@ impl SoundChannel {
         }
 
         if let Some(ref source) = self.source_node {
-            let _ = source.stop_with_when(0.0);
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop_with_when(0.0);
         }
         self.source_node = None;
 
@@ -3982,7 +3989,8 @@ impl SoundChannel {
 
     pub fn stop_sound(&mut self) {
         if let Some(ref source) = self.source_node {
-            let _ = source.stop_with_when(0.0);
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop_with_when(0.0);
             let _ = source.disconnect();
             debug!("🛑 Stopped previous sound");
         } else {
@@ -3996,7 +4004,8 @@ impl SoundChannel {
     pub fn pause_sound(&mut self) {
         if let Some(ref source) = self.source_node {
             debug!("⏸️ Pausing current sound...");
-            let _ = source.stop_with_when(0.0);
+            let scheduled: &AudioScheduledSourceNode = source.as_ref();
+            let _ = scheduled.stop_with_when(0.0);
             self.source_node = None;
         } else {
             debug!("ℹ️ No active sound source to pause");

--- a/vm-rust/src/player/net_task.rs
+++ b/vm-rust/src/player/net_task.rs
@@ -98,11 +98,11 @@ pub async fn fetch_net_task(
     let request = match task.method {
         HttpMethod::Get => web_sys::Request::new_with_str(&url_string.as_str()).unwrap(),
         HttpMethod::Post => {
-            let mut opts = web_sys::RequestInit::new();
-            opts.method("POST");
+            let opts = web_sys::RequestInit::new();
+            opts.set_method("POST");
 
             if let Some(post_data) = &task.post_data {
-                opts.body(Some(&JsValue::from_str(post_data)));
+                opts.set_body(&JsValue::from_str(post_data));
             }
 
             // Set content type for form data

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -2635,7 +2635,7 @@ impl PlayerCanvasRenderer {
             bitmap.width.into(),
             bitmap.height.into(),
         );
-        self.ctx2d.set_fill_style(&safe_js_string("white"));
+        self.ctx2d.set_fill_style_str("white");
         match image_data {
             Ok(image_data) => {
                 self.ctx2d.put_image_data(&image_data, 0.0, 0.0).unwrap();


### PR DESCRIPTION
## Summary
- Migrate `AudioBufferSourceNode::stop`/`stop_with_when` to use `AudioScheduledSourceNode` (the parent interface) instead of the deprecated methods on the subclass
- Replace `BlobPropertyBag::type_()` with `set_type()`, `RequestInit::method()`/`body()` with `set_method()`/`set_body()`, and `set_fill_style()` with `set_fill_style_str()`
- Eliminates all 11 deprecated method warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)