### PR TITLE
fix: remove dead assignments to variables that are never read

### DIFF
--- a/vm-rust/src/director/chunks/pfr1/glyph.rs
+++ b/vm-rust/src/director/chunks/pfr1/glyph.rs
@@ -3273,10 +3273,10 @@ pub fn parse_glyph(
     let mut best_glyph: Option<OutlineGlyph> = None;
     let mut best_score: i32 = -1;
     let mut best_is_header = false;
-    let mut header_score: i32 = 0;
-    let mut direct_score: i32 = 0;
-    let mut header_contours = 0usize;
-    let mut direct_contours = 0usize;
+    let header_score: i32;
+    let direct_score: i32;
+    let header_contours: usize;
+    let direct_contours: usize;
 
     {
         let known_offsets = if known_gps_offsets.is_empty() { None } else { Some(known_gps_offsets) };

--- a/vm-rust/src/director/chunks/pfr1/glyph.rs
+++ b/vm-rust/src/director/chunks/pfr1/glyph.rs
@@ -1570,8 +1570,8 @@ impl<'a> Pfr1HeaderParser<'a> {
 
     /// Process curve commands 7-15
     fn process_curve(&mut self, cmd: i32) {
-        let mut v5: u32 = 0;
-        let mut path: u32 = 0; // 49, 54, or 70
+        let v5: u32;
+        let path: u32; // 49, 54, or 70
 
         match cmd {
             7 => { v5 = 2210; path = 49; }

--- a/vm-rust/src/director/enums.rs
+++ b/vm-rust/src/director/enums.rs
@@ -287,8 +287,6 @@ impl BitmapInfo {
         let mut reader = BinaryReader::from_u8(bytes);
         reader.set_endian(binary_reader::Endian::Big);
 
-        let mut width = 0u16;
-        let mut height = 0u16;
         let mut reg_x = 0i16;
         let mut reg_y = 0i16;
         let mut bit_depth = 1u8;
@@ -309,8 +307,8 @@ impl BitmapInfo {
         let left = reader.read_i16().unwrap_or(0);
         let bottom = reader.read_i16().unwrap_or(0);
         let right = reader.read_i16().unwrap_or(0);
-        height = (bottom - top) as u16;
-        width = (right - left) as u16;
+        let height = (bottom - top) as u16;
+        let width = (right - left) as u16;
 
         if dir_version < 600 {
             // D4/D5: bytes 10-17 = boundingRect (8 bytes, skip)

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -1706,13 +1706,10 @@ impl Bitmap {
         let src_left_f = src_rect.left as f64;
         let src_top_f = src_rect.top as f64;
 
-        let mut sprite_num = 0;
-
         // ----------------------------------------------------------
         // Calculate sprite rotation pivot (registration point)
         // ----------------------------------------------------------
         let (center_x, center_y) = if let Some(sprite) = params.sprite {
-            sprite_num = sprite.number;
             // Rotate around the sprite's registration point (locH, locV)
             (sprite.loc_h as f64, sprite.loc_v as f64)
         } else {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -990,7 +990,6 @@ impl FontMemberHandlers {
             } else {
                 if !current_line.is_empty() {
                     lines.push(current_line);
-                    current_line = String::new();
                 }
                 // Handle very long words
                 if word.len() > max_chars {

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -1402,7 +1402,7 @@ pub fn render_score_to_bitmap_with_offset(
                     None
                 };
 
-                let mut src_rect = IntRect::from(0, 0, 0, 0);
+                let src_rect;
 
                 let mut option = 0;
 

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -3500,34 +3500,40 @@ impl WebGL2Renderer {
         let is_system_font_requested = font_name == "System" || font_name.is_empty();
         let force_bitmap = glyph_pref == GlyphPreference::Bitmap || glyph_pref == GlyphPreference::Outline;
         let force_native = glyph_pref == GlyphPreference::Native;
-        let mut synthetic_spans: Option<Vec<StyledSpan>> = None;
+        let synthetic_spans = if !force_bitmap
+            && (force_native || !is_pfr_font || use_native_for_pfr)
+            && !is_system_font_requested
+            && styled_spans.is_none()
+        {
+            let (r, g, b) = resolve_color_ref(
+                &palettes,
+                fg_color,
+                &PaletteRef::BuiltIn(get_system_default_palette()),
+                8,
+            );
+            let mut style = HtmlStyle::default();
+            // Use the REQUESTED font name for Canvas2D rendering, not the fallback.
+            // When "Arial" is requested but the PFR lookup falls back to System,
+            // we want Canvas2D to render with "Arial" (a real browser font).
+            style.font_face = Some(font_name.to_string());
+            style.font_size = Some(font_size as i32);
+            style.color = Some(((r as u32) << 16) | ((g as u32) << 8) | (b as u32));
+            style.bold = bold;
+            style.italic = italic;
+            style.underline = underline;
+            Some(vec![StyledSpan {
+                text: text.to_string(),
+                style,
+            }])
+        } else {
+            None
+        };
         let spans_for_native: Option<&Vec<StyledSpan>> = if force_bitmap {
-            // Force bitmap rendering for everything
             None
         } else if (force_native || !is_pfr_font || use_native_for_pfr) && !is_system_font_requested {
             if let Some(spans) = styled_spans {
                 Some(spans)
             } else {
-                let (r, g, b) = resolve_color_ref(
-                    &palettes,
-                    fg_color,
-                    &PaletteRef::BuiltIn(get_system_default_palette()),
-                    8,
-                );
-                let mut style = HtmlStyle::default();
-                // Use the REQUESTED font name for Canvas2D rendering, not the fallback.
-                // When "Arial" is requested but the PFR lookup falls back to System,
-                // we want Canvas2D to render with "Arial" (a real browser font).
-                style.font_face = Some(font_name.to_string());
-                style.font_size = Some(font_size as i32);
-                style.color = Some(((r as u32) << 16) | ((g as u32) << 8) | (b as u32));
-                style.bold = bold;
-                style.italic = italic;
-                style.underline = underline;
-                synthetic_spans = Some(vec![StyledSpan {
-                    text: text.to_string(),
-                    style,
-                }]);
                 synthetic_spans.as_ref()
             }
         } else {


### PR DESCRIPTION
## Summary
- Remove variables and initializations where the assigned value is never read
- Restructure `synthetic_spans` ownership pattern to avoid dead `None` init
- Reduces "value assigned but never read" warnings from 13 to 1 (the remaining one is an intentional invariant on `best_score`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)