### PR TITLE
fix: resolve clippy errors (unsafe fns, unsigned comparisons)

### DIFF
--- a/vm-rust/src/director/cast.rs
+++ b/vm-rust/src/director/cast.rs
@@ -79,7 +79,7 @@ impl CastDef {
         let mut section_to_member: HashMap<u32, (u32, String)> = HashMap::new();
         for i in 0..member_ids.len() {
             let section_id = member_ids[i];
-            if section_id <= 0 {
+            if section_id == 0 {
                 continue;
             }
             let member_id = i as u16 + min_member;

--- a/vm-rust/src/player/allocator.rs
+++ b/vm-rust/src/player/allocator.rs
@@ -422,7 +422,7 @@ impl DatumAllocator {
 
     pub fn get_datum_ref(&self, id: DatumId) -> Option<DatumRef> {
         if let Some(entry) = self.datums.get(id) {
-            Some(DatumRef::from_id(id, entry.ref_count.get()))
+            Some(unsafe { DatumRef::from_id(id, entry.ref_count.get()) })
         } else {
             None
         }

--- a/vm-rust/src/player/allocator.rs
+++ b/vm-rust/src/player/allocator.rs
@@ -430,7 +430,7 @@ impl DatumAllocator {
 
     pub fn get_script_instance_ref(&self, id: ScriptInstanceId) -> Option<ScriptInstanceRef> {
         if let Some(entry) = self.script_instances.get(id as usize) {
-            Some(ScriptInstanceRef::from_id(id, entry.ref_count.get()))
+            Some(unsafe { ScriptInstanceRef::from_id(id, entry.ref_count.get()) })
         } else {
             None
         }
@@ -550,7 +550,7 @@ impl ScriptInstanceAllocatorTrait for DatumAllocator {
             .unwrap()
             .ref_count
             .get();
-        ScriptInstanceRef::from_id(id, ref_count_ptr)
+        unsafe { ScriptInstanceRef::from_id(id, ref_count_ptr) }
     }
 
     fn get_script_instance(&self, instance_ref: &ScriptInstanceRef) -> &ScriptInstance {

--- a/vm-rust/src/player/datum_ref.rs
+++ b/vm-rust/src/player/datum_ref.rs
@@ -11,9 +11,9 @@ pub enum DatumRef {
 
 impl DatumRef {
     #[inline]
-    pub fn from_id(id: DatumId, ref_count: *mut u32) -> DatumRef {
+    pub unsafe fn from_id(id: DatumId, ref_count: *mut u32) -> DatumRef {
         if id != 0 {
-            let mut_ref = unsafe { &mut *ref_count };
+            let mut_ref = &mut *ref_count;
             if *mut_ref != u32::MAX {
                 *mut_ref += 1;
             }
@@ -57,7 +57,7 @@ impl Clone for DatumRef {
     fn clone(&self) -> Self {
         match self {
             DatumRef::Void => DatumRef::Void,
-            DatumRef::Ref(id, ref_count) => DatumRef::from_id(*id, ref_count.clone()),
+            DatumRef::Ref(id, ref_count) => unsafe { DatumRef::from_id(*id, ref_count.clone()) },
         }
     }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -79,16 +79,16 @@ impl CastMemberRefHandlers {
                         .find_member_by_ref(&cast_member_ref)
                         .unwrap();
                     let text_data = cast_member.member_type.as_text().unwrap();
-                    let char_pos = player.get_datum(&args[0]).int_value()? as u16;
+                    let char_pos = player.get_datum(&args[0]).int_value()?;
                     let char_width: i32 = 7;
                     let line_height: i32 = get_text_member_line_height(&text_data) as i32;
 
                     let (x, y) = if text_data.text.is_empty() || char_pos <= 0 {
                         (0, 0)
-                    } else if char_pos > text_data.text.len() as u16 {
+                    } else if char_pos > text_data.text.len() as i32 {
                         (char_width * text_data.text.len() as i32, line_height)
                     } else {
-                        (char_width * (char_pos - 1) as i32, line_height)
+                        (char_width * (char_pos - 1), line_height)
                     };
 
                     let x_ref = player.alloc_datum(Datum::Int(x));

--- a/vm-rust/src/player/script_ref.rs
+++ b/vm-rust/src/player/script_ref.rs
@@ -5,12 +5,10 @@ pub struct ScriptInstanceRef(ScriptInstanceId, *mut u32);
 
 impl ScriptInstanceRef {
     #[inline]
-    pub fn from_id(id: ScriptInstanceId, ref_count: *mut u32) -> Self {
+    pub unsafe fn from_id(id: ScriptInstanceId, ref_count: *mut u32) -> Self {
         let val = id.into();
-        unsafe {
-            let mut_ref = &mut *ref_count;
-            *mut_ref += 1;
-        }
+        let mut_ref = &mut *ref_count;
+        *mut_ref += 1;
         Self(val, ref_count)
     }
 
@@ -31,7 +29,7 @@ impl std::ops::Deref for ScriptInstanceRef {
 
 impl Clone for ScriptInstanceRef {
     fn clone(&self) -> Self {
-        Self::from_id(self.0, self.1)
+        unsafe { Self::from_id(self.0, self.1) }
     }
 }
 


### PR DESCRIPTION
## Summary
- Keep `charPosToLoc` char_pos as `i32` instead of casting to `u16`, fixing incorrect behavior for negative inputs
- Replace `section_id <= 0` with `== 0` for `u32` (tautological comparison)
- Mark `DatumRef::from_id` and `ScriptInstanceRef::from_id` as `unsafe fn` since they dereference raw pointers

Fixes all 4 clippy errors; no change to engine behavior for valid inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)