### PR TITLE
fix: ruffle collision and main-world URL rewriters

### DIFF
--- a/public/dirplayer-ruffle-bridge-host.js
+++ b/public/dirplayer-ruffle-bridge-host.js
@@ -56,25 +56,37 @@
     },
   );
 
+  // Communicate via DOM CustomEvents instead of postMessage. The Wayback
+  // Machine's `wombat.js` overrides `window.postMessage` to sanitize
+  // origins and silently drops our bridge traffic; CustomEvents propagate
+  // through the shared document and are not intercepted. Standalone
+  // (non-Wayback) pages also work fine — events are a strict superset of
+  // postMessage's broadcast semantics for same-window communication.
+  var REQ_EVENT = 'dirplayer-ruffle-bridge-request';
+  var RES_EVENT = 'dirplayer-ruffle-bridge-response';
+  var EVT_EVENT = 'dirplayer-ruffle-bridge-event';
+
   function respond(requestId, payload, error) {
-    window.postMessage({
-      __dirplayerRuffleBridge: 'response',
-      requestId,
-      result: payload,
-      error: error == null ? null : (error && error.message) || String(error),
-    }, '*');
+    window.dispatchEvent(new CustomEvent(RES_EVENT, {
+      detail: {
+        requestId: requestId,
+        result: payload,
+        error: error == null ? null : (error && error.message) || String(error),
+      },
+    }));
   }
 
   function announceEvent(playerId, eventName, detail) {
     // Forward player events back to the isolated world. Detail must be
     // structured-cloneable (no DOM elements / functions). We only
     // forward the data we know dirplayer cares about today.
-    window.postMessage({
-      __dirplayerRuffleBridge: 'event',
-      playerId,
-      eventName,
-      detail,
-    }, '*');
+    window.dispatchEvent(new CustomEvent(EVT_EVENT, {
+      detail: {
+        playerId: playerId,
+        eventName: eventName,
+        detail: detail,
+      },
+    }));
   }
 
   function attachEventForwarders(playerId, player) {
@@ -103,10 +115,9 @@
     }
   }
 
-  window.addEventListener('message', async (ev) => {
-    if (ev.source !== window) return;
-    const m = ev.data;
-    if (!m || m.__dirplayerRuffleBridge !== 'request') return;
+  window.addEventListener(REQ_EVENT, async (ev) => {
+    const m = ev.detail;
+    if (!m) return;
 
     const { requestId, method, playerId, methodName, propName, args } = m;
     try {

--- a/src/components/VMProvider.tsx
+++ b/src/components/VMProvider.tsx
@@ -63,7 +63,7 @@ export default function VMProvider({ children, systemFontPath, wasmUrl }: VMProv
         // Step 2: Initialize WASM and VM
         initVmCallbacks();
         if (wasmUrl) {
-          await init(wasmUrl);
+          await init({ module_or_path: wasmUrl });
         } else {
           await init({});
         }

--- a/src/services/ruffleBridgeClient.ts
+++ b/src/services/ruffleBridgeClient.ts
@@ -7,7 +7,17 @@
 // `customElements`, so Ruffle (which calls `customElements.define`
 // during element registration) cannot run in the same world as
 // dirplayer's content script. We register Ruffle in the main world
-// instead and ferry method/property calls across via `postMessage`.
+// instead and ferry method/property calls across via DOM CustomEvents.
+//
+// Why CustomEvents instead of postMessage: the Wayback Machine's
+// `wombat.js` overwrites `window.postMessage` in the main world to
+// sanitize origins and rewrite URLs, which silently drops our bridge
+// traffic. DOM events propagate through the shared document and are
+// not intercepted by wombat.
+
+const REQ_EVENT = 'dirplayer-ruffle-bridge-request';
+const RES_EVENT = 'dirplayer-ruffle-bridge-response';
+const EVT_EVENT = 'dirplayer-ruffle-bridge-event';
 
 let nextRequest = 1;
 const pendingRequests = new Map<
@@ -18,27 +28,24 @@ const pendingRequests = new Map<
 type BridgeEventHandler = (eventName: string, detail: unknown) => void;
 const eventHandlers = new Map<string, Set<BridgeEventHandler>>();
 
-window.addEventListener('message', (ev) => {
-  if (ev.source !== window) return;
-  const m: any = ev.data;
+window.addEventListener(RES_EVENT, (ev) => {
+  const m: any = (ev as CustomEvent).detail;
   if (!m) return;
+  const pending = pendingRequests.get(m.requestId);
+  if (!pending) return;
+  pendingRequests.delete(m.requestId);
+  if (m.error) pending.reject(new Error(m.error));
+  else pending.resolve(m.result);
+});
 
-  if (m.__dirplayerRuffleBridge === 'response') {
-    const pending = pendingRequests.get(m.requestId);
-    if (!pending) return;
-    pendingRequests.delete(m.requestId);
-    if (m.error) pending.reject(new Error(m.error));
-    else pending.resolve(m.result);
-    return;
-  }
-
-  if (m.__dirplayerRuffleBridge === 'event') {
-    const handlers = eventHandlers.get(m.playerId);
-    if (handlers) {
-      handlers.forEach((h) => {
-        try { h(m.eventName, m.detail); } catch (e) { /* ignore */ }
-      });
-    }
+window.addEventListener(EVT_EVENT, (ev) => {
+  const m: any = (ev as CustomEvent).detail;
+  if (!m) return;
+  const handlers = eventHandlers.get(m.playerId);
+  if (handlers) {
+    handlers.forEach((h) => {
+      try { h(m.eventName, m.detail); } catch (e) { /* ignore */ }
+    });
   }
 });
 
@@ -49,10 +56,9 @@ function bridgeCall<T = unknown>(payload: Record<string, unknown>): Promise<T> {
       resolve: (v) => resolve(v as T),
       reject,
     });
-    window.postMessage(
-      { __dirplayerRuffleBridge: 'request', requestId, ...payload },
-      '*',
-    );
+    window.dispatchEvent(new CustomEvent(REQ_EVENT, {
+      detail: { requestId, ...payload },
+    }));
   });
 }
 

--- a/vm-rust/src/player/xtra/multiuser/mod.rs
+++ b/vm-rust/src/player/xtra/multiuser/mod.rs
@@ -16,7 +16,7 @@ use web_sys::{CloseEvent, Event, MessageEvent, WebSocket};
 // Use console::warn_1 directly for debugging since log level is set to Error
 macro_rules! multiuser_log {
     ($($arg:tt)*) => {
-        web_sys::console::warn_1(&format!($($arg)*).into());
+        web_sys::console::warn_1(&format!($($arg)*).into())
     };
 }
 


### PR DESCRIPTION
Submodule ruffle on dirplayer-integration:

[dd95d2081](https://github.com/chameleonxxl/ruffle/commit/dd95d20819973b20a0fcd2f338752be159b30e5d) selfhosted: namespace webpack chunkLoadingGlobal to avoid stock Ruffle collision
[43a9db4ea](https://github.com/chameleonxxl/ruffle/commit/43a9db4ea71ca0a8cb11703f503b0bfb225a0908) bypass main-world URL rewriters (Wayback wombat) for Ruffle chunk + WASM fetch

dirplayer-rs on cham/ruffle-wombat-fix:

1bbc128 VMProvider: pass module_or_path object to wasm-bindgen init
b328d4b Ruffle bridge: switch isolated↔main world transport to DOM CustomEvents
8095548 Bump ruffle submodule