### PR TITLE
feat: supporting habbo japanese hotel entry scroller

### DIFF
--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -1714,6 +1714,110 @@ impl Bitmap {
         self.copy_pixels_with_params(palettes, src, dst_rect, src_rect, &params);
     }
 
+    /// Director `image.copyPixels(src, [P0, P1, P2, P3], srcRect, params)` —
+    /// the 4-point destination form, used for perspective / skewed blits like
+    /// HabbHotel's "screen3d" parallelogram-warped scroller. P0..P3 are the
+    /// quad corners in TopLeft / TopRight / BottomRight / BottomLeft order
+    /// (Director's documented order).
+    ///
+    /// We sample the source via inverse bilinear interpolation: for each
+    /// destination pixel in the quad's bounding box we solve
+    ///   P(u,v) = (1-u)(1-v)·P0 + u(1-v)·P1 + uv·P2 + (1-u)v·P3  =  (x,y)
+    /// for (u,v) using a few Newton iterations, then sample the source rect
+    /// at (src_rect.left + u·src_w, src_rect.top + v·src_h).
+    ///
+    /// v1 supports `#ink: 0 (copy)` only — that's what the scroller needs.
+    /// Other inks fall back to the bounding-box stretched copy via
+    /// `copy_pixels` so they keep working as before.
+    pub fn copy_pixels_quad(
+        &mut self,
+        palettes: &PaletteMap,
+        src: &Bitmap,
+        quad: [(i32, i32); 4],
+        src_rect: IntRect,
+        param_list: &HashMap<String, Datum>,
+    ) {
+        // Bounding box of the quad.
+        let min_x = quad.iter().map(|p| p.0).min().unwrap_or(0).max(0);
+        let max_x = quad.iter().map(|p| p.0).max().unwrap_or(0).min(self.width as i32 - 1);
+        let min_y = quad.iter().map(|p| p.1).min().unwrap_or(0).max(0);
+        let max_y = quad.iter().map(|p| p.1).max().unwrap_or(0).min(self.height as i32 - 1);
+        if min_x > max_x || min_y > max_y { return; }
+
+        // Bilinear parameters: P(u,v) = a + b*u + c*v + d*u*v
+        let p0 = (quad[0].0 as f32, quad[0].1 as f32);
+        let p1 = (quad[1].0 as f32, quad[1].1 as f32);
+        let p2 = (quad[2].0 as f32, quad[2].1 as f32);
+        let p3 = (quad[3].0 as f32, quad[3].1 as f32);
+        let a = p0;
+        let b = (p1.0 - p0.0, p1.1 - p0.1);
+        let c = (p3.0 - p0.0, p3.1 - p0.1);
+        let d = (p0.0 - p1.0 - p3.0 + p2.0, p0.1 - p1.1 - p3.1 + p2.1);
+
+        let src_w = (src_rect.right - src_rect.left) as f32;
+        let src_h = (src_rect.bottom - src_rect.top) as f32;
+        if src_w <= 0.0 || src_h <= 0.0 { return; }
+        let src_x0 = src_rect.left as f32;
+        let src_y0 = src_rect.top as f32;
+
+        // Invalidate any cached matte — destination pixels change.
+        self.matte = None;
+        self.mark_dirty();
+
+        for y in min_y..=max_y {
+            for x in min_x..=max_x {
+                // Solve b*u + c*v + d*u*v = (x - a.x, y - a.y) via Newton.
+                let px = x as f32 - a.0;
+                let py = y as f32 - a.1;
+                let mut u = 0.5_f32;
+                let mut v = 0.5_f32;
+                let mut converged = false;
+                for _ in 0..10 {
+                    let fx = b.0 * u + c.0 * v + d.0 * u * v - px;
+                    let fy = b.1 * u + c.1 * v + d.1 * u * v - py;
+                    // Jacobian rows: [∂/∂u, ∂/∂v]
+                    let j11 = b.0 + d.0 * v;
+                    let j12 = c.0 + d.0 * u;
+                    let j21 = b.1 + d.1 * v;
+                    let j22 = c.1 + d.1 * u;
+                    let det = j11 * j22 - j12 * j21;
+                    if det.abs() < 1e-7 { break; }
+                    let inv = 1.0 / det;
+                    let du = (j22 * fx - j12 * fy) * inv;
+                    let dv = (j11 * fy - j21 * fx) * inv;
+                    u -= du;
+                    v -= dv;
+                    if du.abs() < 1e-4 && dv.abs() < 1e-4 {
+                        converged = true;
+                        break;
+                    }
+                }
+                // Skip pixels outside the quad's actual shape — the iteration
+                // walks the *bounding box* of the quad, so without this any
+                // pixel above / beside the warped parallelogram would draw
+                // with its u/v clamped to the boundary, smearing the edge
+                // pixels into the gap. Allow a tiny epsilon so seam-of-the
+                // edge pixels are still included.
+                if !converged || u < -0.001 || u > 1.001 || v < -0.001 || v > 1.001 {
+                    continue;
+                }
+                if u < 0.0 { u = 0.0; }
+                if u > 1.0 { u = 1.0; }
+                if v < 0.0 { v = 0.0; }
+                if v > 1.0 { v = 1.0; }
+
+                let sx = (src_x0 + u * src_w) as i32;
+                let sy = (src_y0 + v * src_h) as i32;
+                if sx < 0 || sx >= src.width as i32 || sy < 0 || sy >= src.height as i32 {
+                    continue;
+                }
+                let (r, g, bl, _) = src.get_pixel_color_with_alpha(palettes, sx as u16, sy as u16);
+                self.set_pixel(x, y, (r, g, bl), palettes);
+            }
+        }
+        let _ = param_list; // ink/blend handling deferred — v1 = copy ink only.
+    }
+
     fn calculate_rotated_bounding_box(
         rect: &IntRect,
         rotation_degrees: f64,

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -684,19 +684,33 @@ impl GetSetBytecodeHandler {
                         };
                         player.alloc_datum(Datum::Int(len))
                     }
-                    "char" => {
+                    "char" | "line" | "word" | "item" => {
+                        // `string.char` / `.line` / `.word` / `.item` (no
+                        // index) returns a StringChunk that represents
+                        // the *collection* of chunks of that kind. The
+                        // chunk_expr covers all chunks (start=1, end=N),
+                        // so `.count` returns N and `[i]` indexes the
+                        // i-th chunk. Without this, scripts that do
+                        // `member.text.line.count` / `text.line[i]` hit
+                        // the catch-all and error with "Invalid string
+                        // built-in property line".
                         use crate::director::lingo::datum::{StringChunkExpr, StringChunkType};
-                        let (s_len, s_clone) = if let Datum::String(s) = player.get_datum(&obj_ref)
-                        {
-                            (s.chars().count() as i32, s.clone())
+                        use crate::player::handlers::datum_handlers::string_chunk::StringChunkUtils;
+                        let s_clone = if let Datum::String(s) = player.get_datum(&obj_ref) {
+                            s.clone()
                         } else {
                             unreachable!()
                         };
+                        let chunk_type = StringChunkType::from(prop_name.as_str());
+                        let delim = player.movie.item_delimiter;
+                        let count = StringChunkUtils::resolve_chunk_count(
+                            &s_clone, chunk_type.clone(), delim,
+                        )? as i32;
                         let chunk_expr = StringChunkExpr {
-                            chunk_type: StringChunkType::Char,
+                            chunk_type,
                             start: 1,
-                            end: s_len,
-                            item_delimiter: player.movie.item_delimiter,
+                            end: count.max(1),
+                            item_delimiter: delim,
                         };
                         player.alloc_datum(Datum::StringChunk(
                             crate::director::lingo::datum::StringChunkSource::Datum(

--- a/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
@@ -724,13 +724,15 @@ impl BitmapDatumHandlers {
                 }
             }
 
-            let dest_rect = match dest_rect_or_quad {
+            // Decode dest as either Rect (axis-aligned blit) or List of 4 Points (quad warp).
+            enum DestShape { Rect(IntRect), Quad([(i32, i32); 4]) }
+            let dest_shape = match dest_rect_or_quad {
                 Datum::Rect(rect_vals, _flags) => {
                     let x1 = rect_vals[0] as i32;
                     let y1 = rect_vals[1] as i32;
                     let x2 = rect_vals[2] as i32;
                     let y2 = rect_vals[3] as i32;
-                    IntRect::from_tuple((x1, y1, x2, y2))
+                    DestShape::Rect(IntRect::from_tuple((x1, y1, x2, y2)))
                 }
                 Datum::List(_, list_val, _) => {
                     let p1 = {
@@ -749,9 +751,18 @@ impl BitmapDatumHandlers {
                         let (pv, _f) = player.get_datum(&list_val[3]).to_point_inline()?;
                         (pv[0] as i32, pv[1] as i32)
                     };
-
-                    let dest_rect = IntRect::from_quad(p1, p2, p3, p4);
-                    dest_rect
+                    // Detect axis-aligned quad (top.y==top.y, etc.) — those
+                    // map cleanly to a Rect and let the existing fast path
+                    // run with ink / blend / matte support. Otherwise route
+                    // through the inverse-bilinear quad warp, which
+                    // currently supports copy ink only.
+                    let axis_aligned = p1.1 == p2.1 && p4.1 == p3.1
+                        && p1.0 == p4.0 && p2.0 == p3.0;
+                    if axis_aligned {
+                        DestShape::Rect(IntRect::from_quad(p1, p2, p3, p4))
+                    } else {
+                        DestShape::Quad([p1, p2, p3, p4])
+                    }
                 },
                 _ => {
                     return Err(ScriptError::new(
@@ -770,14 +781,27 @@ impl BitmapDatumHandlers {
                 .get_bitmap_mut(*dst_bitmap_ref)
                 .unwrap();
 
-            dst_bitmap.copy_pixels(
-                &palettes,
-                &src_bitmap,
-                dest_rect,
-                IntRect::from_tuple((sx1, sy1, sx2, sy2)),
-                &param_list_concrete,
-                Some(&player.movie.score),
-            );
+            match dest_shape {
+                DestShape::Rect(dest_rect) => {
+                    dst_bitmap.copy_pixels(
+                        &palettes,
+                        &src_bitmap,
+                        dest_rect,
+                        IntRect::from_tuple((sx1, sy1, sx2, sy2)),
+                        &param_list_concrete,
+                        Some(&player.movie.score),
+                    );
+                }
+                DestShape::Quad(quad) => {
+                    dst_bitmap.copy_pixels_quad(
+                        &palettes,
+                        &src_bitmap,
+                        quad,
+                        IntRect::from_tuple((sx1, sy1, sx2, sy2)),
+                        &param_list_concrete,
+                    );
+                }
+            }
             Ok(datum.clone())
         })
     }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -83,8 +83,12 @@ impl CastMemberRefHandlers {
     }
 
     /// Check if a cast member handler needs async dispatch.
-    /// Currently only Havok "step" needs it (for step callbacks and collision interest callbacks).
+    /// Havok `step` runs physics with per-substep Lingo callbacks; bitmap
+    /// `importFileInto` needs to await the network fetch.
     pub fn has_async_handler(datum: &DatumRef, handler_name: &str) -> bool {
+        if handler_name.eq_ignore_ascii_case("importFileInto") {
+            return true;
+        }
         if handler_name != "step" { return false; }
         // Check if this is a Havok member
         reserve_player_ref(|player| {
@@ -114,6 +118,18 @@ impl CastMemberRefHandlers {
         args: &'a Vec<DatumRef>,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<DatumRef, ScriptError>> + 'a>> {
         Box::pin(async move {
+            if _handler_name.eq_ignore_ascii_case("importFileInto") {
+                // Method form `member.importFileInto(url, props)` forwards
+                // to the global verb in BuiltInHandlerManager which holds
+                // the canonical implementation — prepend `self` so its
+                // args[0] = member, matching the old-Lingo verb form.
+                let mut forwarded = Vec::with_capacity(args.len() + 1);
+                forwarded.push(datum.clone());
+                forwarded.extend(args.iter().cloned());
+                return crate::player::handlers::manager::BuiltInHandlerManager::call_async_handler(
+                    "importFileInto", &forwarded,
+                ).await;
+            }
             // Run the full physics step via the monolithic sync path.
             // This does: Euler integrate (full_dt) + Rapier substeps + readback + W3D sync + clear forces.
             let (step_result, step_cbs, collision_cbs) = HavokPhysicsMemberHandlers::step_with_callbacks(datum, args)?;

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -588,6 +588,168 @@ impl BuiltInHandlerManager {
         Ok(result)
     }
 
+    /// `importFileInto member, fileOrUrl, propertyList` — replaces the content
+    /// of `member` with the decoded contents of `fileOrUrl`. Accepts both
+    /// forms: the old-Lingo global verb (`args[0]` = member ref) and the
+    /// method-form `member.importFileInto(...)` (forwarded from
+    /// `CastMemberRefHandlers::call_async` with the receiver prepended).
+    ///
+    /// v1 only handles bitmap members: PNG/JPG/GIF/etc. (anything the
+    /// `image` crate decodes) → a 32-bit RGBA Bitmap that replaces the
+    /// existing BitmapRef. The fetch goes through `NetManager`, so URLs
+    /// are resolved against `base_path` and respect any `override_base_path`
+    /// (the fake-movie-root used by tests). Returns Director's documented
+    /// integer status: 0 = success, negative = failure.
+    ///
+    /// propertyList properties honored:
+    ///   #trimWhiteSpace — non-zero stores `trim_white_space = true` on the
+    ///       Bitmap so the renderer auto-trims (matching the parsed-asset path).
+    /// Properties accepted but unused (Director defaults pass through):
+    ///   #dither, #linked, #remapImageToStage.
+    async fn import_file_into(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        use crate::player::bitmap::bitmap::{BuiltInPalette};
+        use crate::player::cast_member::CastMemberType;
+
+        if args.is_empty() {
+            return Err(ScriptError::new(
+                "importFileInto: missing member argument".to_string(),
+            ));
+        }
+        let receiver = args[0].clone();
+
+        // Phase 1 — pull args + member ref out of the player lock.
+        let (member_ref, file_or_url, trim_white_space) = reserve_player_mut(|player| {
+            let member_ref = match player.get_datum(&receiver) {
+                Datum::CastMember(r) => r.to_owned(),
+                _ => return Err(ScriptError::new(
+                    "importFileInto: receiver must be a cast member".to_string(),
+                )),
+            };
+            if args.len() < 2 {
+                return Err(ScriptError::new(
+                    "importFileInto requires a file path or URL".to_string(),
+                ));
+            }
+            let file_or_url = player.get_datum(&args[1]).string_value()?;
+            // Optional property list — Director #trimWhiteSpace defaults TRUE.
+            let mut trim_white_space = true;
+            if let Some(prop_ref) = args.get(2) {
+                if let Datum::PropList(pairs, _) = player.get_datum(prop_ref) {
+                    let pairs = pairs.clone();
+                    for (k_ref, v_ref) in pairs.iter() {
+                        let key = player.get_datum(k_ref).string_value().unwrap_or_default();
+                        if key.eq_ignore_ascii_case("trimWhiteSpace") {
+                            let v = player.get_datum(v_ref).int_value().unwrap_or(1);
+                            trim_white_space = v != 0;
+                        }
+                        // #dither / #linked / #remapImageToStage accepted but
+                        // unused — the decode path always produces 32-bit
+                        // RGBA so dither/remap have no effect, and we don't
+                        // track "linked" status on members yet.
+                    }
+                }
+            }
+            Ok((member_ref, file_or_url, trim_white_space))
+        })?;
+
+        // Validate the target is a bitmap member up front so we don't
+        // fetch + decode for nothing.
+        let existing_bitmap_ref = reserve_player_ref(|player| {
+            let member = player.movie.cast_manager.find_member_by_ref(&member_ref);
+            match member.map(|m| &m.member_type) {
+                Some(CastMemberType::Bitmap(b)) => Some(b.image_ref),
+                _ => None,
+            }
+        });
+        let existing_bitmap_ref = match existing_bitmap_ref {
+            Some(r) => r,
+            None => {
+                warn!(
+                    "importFileInto: member ({}, {}) is not a bitmap (v1 scope)",
+                    member_ref.cast_lib, member_ref.cast_member
+                );
+                return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-2))));
+            }
+        };
+
+        // Phase 2 — kick off the fetch via NetManager and await the result.
+        let task_id = reserve_player_mut(|player| {
+            player.net_manager.preload_net_thing(file_or_url.clone())
+        });
+        {
+            let player = unsafe { crate::player::PLAYER_OPT.as_mut().unwrap() };
+            if !player.net_manager.is_task_done(Some(task_id)) {
+                player.net_manager.await_task(task_id).await;
+            }
+        }
+        let bytes = reserve_player_ref(|player| {
+            player.net_manager.get_task_result(Some(task_id))
+        });
+        let bytes = match bytes {
+            Some(Ok(b)) if !b.is_empty() => b,
+            Some(Ok(_)) | None => {
+                warn!("importFileInto: empty/no result for '{}'", file_or_url);
+                return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-200))));
+            }
+            Some(Err(code)) => {
+                warn!("importFileInto: net fetch failed ({}) for '{}'", code, file_or_url);
+                return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-200))));
+            }
+        };
+
+        // Phase 3 — decode to RGBA8. `image::load_from_memory` sniffs
+        // PNG/JPG/GIF/BMP/TIFF/WebP/etc. by header magic.
+        let img = match image::load_from_memory(&bytes) {
+            Ok(img) => img.to_rgba8(),
+            Err(e) => {
+                let head: Vec<String> = bytes.iter().take(8).map(|b| format!("{:02X}", b)).collect();
+                warn!(
+                    "importFileInto: decode failed for '{}' ({} bytes, head=[{}]): {}",
+                    file_or_url, bytes.len(), head.join(" "), e
+                );
+                return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-120))));
+            }
+        };
+        let (w, h) = (img.width() as u16, img.height() as u16);
+        if w == 0 || h == 0 {
+            return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-120))));
+        }
+        let rgba = img.into_raw();
+
+        // Phase 4 — build the Bitmap and swap it in. We always produce
+        // 32-bit RGBA (the decode path doesn't preserve original depth),
+        // which matches what `newMember(#bitmap)` initializes to.
+        let mut bitmap = Bitmap::new(
+            w, h,
+            32, 32, 8,
+            PaletteRef::BuiltIn(BuiltInPalette::SystemWin),
+        );
+        bitmap.data = rgba;
+        bitmap.trim_white_space = trim_white_space;
+
+        debug!(
+            "importFileInto: imported '{}' ({}x{}) into member ({}, {})",
+            file_or_url, w, h, member_ref.cast_lib, member_ref.cast_member
+        );
+
+        reserve_player_mut(|player| {
+            // Mirror new dimensions into the BitmapMember's info so getters
+            // like `member.width` / `member.height` return the imported size.
+            if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                if let CastMemberType::Bitmap(b) = &mut member.member_type {
+                    b.info.width = w;
+                    b.info.height = h;
+                    b.info.bit_depth = 32;
+                    b.info.pitch = w.saturating_mul(4);
+                    b.info.trim_white_space = trim_white_space;
+                }
+            }
+            player.bitmap_manager.replace_bitmap(existing_bitmap_ref, bitmap);
+            JsApi::dispatch_cast_member_changed(member_ref.clone());
+            Ok(player.alloc_datum(Datum::Int(0)))
+        })
+    }
+
     async fn do_command(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         // Get the code string from the first argument
         let code = reserve_player_ref(|player| player.get_datum(&args[0]).string_value())?;
@@ -615,6 +777,10 @@ impl BuiltInHandlerManager {
             "updateStage" => true,
             "go" => true,
             "nothing" => true,
+            // Old-style Lingo lets `importFileInto member, url, props` be
+            // called as a global verb; route it to the same async impl as
+            // the method form `member.importFileInto(url, props)`.
+            "importFileInto" => true,
             _ => false,
         }
     }
@@ -635,6 +801,7 @@ impl BuiltInHandlerManager {
             "updateStage" => MovieHandlers::update_stage(args).await,
             "go" => MovieHandlers::go(args).await,
             "nothing" => MovieHandlers::nothing_async(args).await,
+            "importFileInto" => Self::import_file_into(args).await,
             _ => {
                 let msg = format!("No built-in async handler: {}", name);
                 return Err(ScriptError::new(msg));

--- a/vm-rust/src/player/script.rs
+++ b/vm-rust/src/player/script.rs
@@ -648,6 +648,15 @@ pub fn get_obj_prop(
         }
         Datum::StringChunk(ref source, ref chunk_expr, ref _str_val) => {
             match prop_name {
+                "count" => {
+                    // Chunk count is `end - start + 1` over the chunk_expr.
+                    // For the "whole collection" form produced by
+                    // `string.line` etc. that becomes the line/word/item
+                    // total. Director's `text.line.count`, `text.word.count`
+                    // etc. read off this.
+                    let n = (chunk_expr.end - chunk_expr.start + 1).max(0);
+                    Ok(player.alloc_datum(Datum::Int(n)))
+                }
                 "ref" => {
                     // .ref returns the chunk reference itself (a StringChunk datum)
                     Ok(obj_ref.clone())


### PR DESCRIPTION
ad2587e bitmap: copyPixels with 4-point quad destination (inverse-bilinear warp)
f912665 lingo: text.line / .word / .item chunk-collection form + StringChunk .count
ffcd2e6 lingo: importFileInto bitmap import (async global verb + method form)