### PR TITLE
feat: allowing special characters for glyphs and text- / fieldmembers

### DIFF
--- a/src/views/Stage/index.tsx
+++ b/src/views/Stage/index.tsx
@@ -792,7 +792,13 @@ export default function Stage({ showControls, enableGestures }: { showControls?:
           // Forward modifier key presses to keep the keyboard manager in sync.
           // Required so is_shift_down() / is_control_down() return correct
           // values when the hidden input is focused (editable field active).
-          if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Meta' || e.key === 'Alt') {
+          // 'AltGraph' is the right-Alt key on German / Nordic layouts -- the
+          // browser fires it BEFORE the resolved character (€, @, |, [, ])
+          // arrives via onInput, and wasm's is_alt_graph_down() needs to be
+          // truthy by then so the insertion gate doesn't treat the char as
+          // a Ctrl shortcut.
+          if (e.key === 'Shift' || e.key === 'Control' || e.key === 'Meta'
+              || e.key === 'Alt' || e.key === 'AltGraph') {
             key_down(e.key, e.keyCode);
             return;
           }

--- a/vm-rust/src/director/chunks/pfr1/rasterizer.rs
+++ b/vm-rust/src/director/chunks/pfr1/rasterizer.rs
@@ -585,9 +585,16 @@ pub fn rasterize_pfr1_font(
         target_height as f32
     };
 
-    // Determine character range
+    // Determine character range.
+    // 256 covers the full Windows-1252 byte range: ASCII (0x00-0x7F) plus
+    // Western European letters in 0x80-0xFF -- German umlauts (ä ö ü ß),
+    // Scandinavian (å ø æ), Spanish (á é í ó ú ñ ¿ ¡), smart quotes, Euro.
+    // The previous 128-glyph cap silently dropped every non-ASCII glyph
+    // present in the PFR font, leaving visible gaps where umlauts should
+    // render. Atlas grows from 16x8 to 16x16 cells (one extra row of
+    // rasterization work per font instance).
     let first_char: u8 = 0;
-    let num_chars: usize = 128; // ASCII range
+    let num_chars: usize = 256;
     let grid_columns: usize = 16;
     let grid_rows: usize = (num_chars + grid_columns - 1) / grid_columns;
 

--- a/vm-rust/src/director/chunks/xmedia_styled_text.rs
+++ b/vm-rust/src/director/chunks/xmedia_styled_text.rs
@@ -1,35 +1,6 @@
 use log::debug;
+use crate::io::encoding::win1252_byte_to_char;
 use crate::player::handlers::datum_handlers::cast_member::font::{StyledSpan, HtmlStyle, TextAlignment};
-
-/// Mac Roman to Unicode mapping for bytes 0x80-0xFF.
-/// Director files from Mac use Mac Roman encoding.
-/// Source: https://www.unicode.org/Public/MAPPINGS/VENDORS/APPLE/ROMAN.TXT
-const MAC_ROMAN_TABLE: [char; 128] = [
-    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}', // 80-87
-    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}', // 88-8F
-    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}', // 90-97
-    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}', // 98-9F
-    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}', // A0-A7
-    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}', // A8-AF
-    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}', // B0-B7
-    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}', // B8-BF
-    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}', // C0-C7
-    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}', // C8-CF
-    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}', // D0-D7
-    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}', // D8-DF
-    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}', // E0-E7
-    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}', // E8-EF
-    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}', // F0-F7
-    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}', // F8-FF
-];
-
-fn mac_roman_to_char(byte: u8) -> char {
-    if byte < 0x80 {
-        byte as char
-    } else {
-        MAC_ROMAN_TABLE[(byte - 0x80) as usize]
-    }
-}
 
 impl XmedStyledText {
     /// Resolve the active `par_info` for a given text byte/char position.
@@ -837,11 +808,14 @@ fn parse_section_3(data: &[u8]) -> Result<Section3Data, String> {
         text_end = data.len(); // No end marker, use full length
     }
 
-    // Extract text, preserving all characters including \r, \n, \t
-    // Use Mac Roman decoding for bytes 0x80-0xFF (Director files use Mac Roman encoding)
+    // Extract text, preserving all characters including \r, \n, \t.
+    // Director text members store bytes as Windows-1252. The earlier
+    // Mac-Roman decoder mapped 0xE4 to U+2021 (‡) instead of U+00E4 (ä),
+    // breaking umlauts, ß, ø, ñ, and Spanish accents in Windows-authored
+    // movies (i.e. virtually all live test corpora).
     let mut text = String::new();
     for i in text_start..text_end {
-        let ch = mac_roman_to_char(data[i]);
+        let ch = win1252_byte_to_char(data[i]);
         if ch == '\0' {
             break; // Stop at first null byte (padding)
         }

--- a/vm-rust/src/io/encoding.rs
+++ b/vm-rust/src/io/encoding.rs
@@ -1,0 +1,128 @@
+//! Director text encoding.
+//!
+//! Modern Director files (Windows-authored .dir / .dcr / .cct) store text as
+//! Windows-1252 (CP1252). The 0x00-0x7F range is plain ASCII; 0x80-0xFF
+//! covers Western European letters including the German umlauts (ä ö ü ß),
+//! Scandinavian (å ø æ Å Ø Æ), and Spanish accents (á é í ó ú ñ ¿ ¡).
+//!
+//! Mac-authored Director files use Mac Roman in the same byte range, but
+//! that's vanishingly rare in current test corpora — every reported
+//! "missing umlaut" comes from a Windows movie. We default to Win-1252.
+//!
+//! Five codepoints in 0x80-0x9F are undefined in Win-1252 (0x81, 0x8D,
+//! 0x8F, 0x90, 0x9D). We map those to U+FFFD (replacement char) so they
+//! surface visibly rather than silently becoming the wrong glyph.
+//!
+//! References:
+//! - https://en.wikipedia.org/wiki/Windows-1252
+//! - https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT
+
+/// Windows-1252 byte → Unicode codepoint table for bytes 0x80-0xFF.
+/// U+FFFD marks the five officially-undefined positions.
+const WIN1252_HIGH: [char; 128] = [
+    '\u{20AC}', '\u{FFFD}', '\u{201A}', '\u{0192}', '\u{201E}', '\u{2026}', '\u{2020}', '\u{2021}', // 80-87
+    '\u{02C6}', '\u{2030}', '\u{0160}', '\u{2039}', '\u{0152}', '\u{FFFD}', '\u{017D}', '\u{FFFD}', // 88-8F
+    '\u{FFFD}', '\u{2018}', '\u{2019}', '\u{201C}', '\u{201D}', '\u{2022}', '\u{2013}', '\u{2014}', // 90-97
+    '\u{02DC}', '\u{2122}', '\u{0161}', '\u{203A}', '\u{0153}', '\u{FFFD}', '\u{017E}', '\u{0178}', // 98-9F
+    '\u{00A0}', '\u{00A1}', '\u{00A2}', '\u{00A3}', '\u{00A4}', '\u{00A5}', '\u{00A6}', '\u{00A7}', // A0-A7
+    '\u{00A8}', '\u{00A9}', '\u{00AA}', '\u{00AB}', '\u{00AC}', '\u{00AD}', '\u{00AE}', '\u{00AF}', // A8-AF
+    '\u{00B0}', '\u{00B1}', '\u{00B2}', '\u{00B3}', '\u{00B4}', '\u{00B5}', '\u{00B6}', '\u{00B7}', // B0-B7
+    '\u{00B8}', '\u{00B9}', '\u{00BA}', '\u{00BB}', '\u{00BC}', '\u{00BD}', '\u{00BE}', '\u{00BF}', // B8-BF
+    '\u{00C0}', '\u{00C1}', '\u{00C2}', '\u{00C3}', '\u{00C4}', '\u{00C5}', '\u{00C6}', '\u{00C7}', // C0-C7
+    '\u{00C8}', '\u{00C9}', '\u{00CA}', '\u{00CB}', '\u{00CC}', '\u{00CD}', '\u{00CE}', '\u{00CF}', // C8-CF
+    '\u{00D0}', '\u{00D1}', '\u{00D2}', '\u{00D3}', '\u{00D4}', '\u{00D5}', '\u{00D6}', '\u{00D7}', // D0-D7
+    '\u{00D8}', '\u{00D9}', '\u{00DA}', '\u{00DB}', '\u{00DC}', '\u{00DD}', '\u{00DE}', '\u{00DF}', // D8-DF
+    '\u{00E0}', '\u{00E1}', '\u{00E2}', '\u{00E3}', '\u{00E4}', '\u{00E5}', '\u{00E6}', '\u{00E7}', // E0-E7
+    '\u{00E8}', '\u{00E9}', '\u{00EA}', '\u{00EB}', '\u{00EC}', '\u{00ED}', '\u{00EE}', '\u{00EF}', // E8-EF
+    '\u{00F0}', '\u{00F1}', '\u{00F2}', '\u{00F3}', '\u{00F4}', '\u{00F5}', '\u{00F6}', '\u{00F7}', // F0-F7
+    '\u{00F8}', '\u{00F9}', '\u{00FA}', '\u{00FB}', '\u{00FC}', '\u{00FD}', '\u{00FE}', '\u{00FF}', // F8-FF
+];
+
+/// Decode a single Windows-1252 byte into its Unicode `char`.
+#[inline]
+pub fn win1252_byte_to_char(byte: u8) -> char {
+    if byte < 0x80 {
+        byte as char
+    } else {
+        WIN1252_HIGH[(byte - 0x80) as usize]
+    }
+}
+
+/// Encode a Unicode `char` to its Windows-1252 byte equivalent, returning
+/// `None` if the character has no CP1252 mapping. Used by the bitmap-font
+/// renderer to look up glyph slots in the PFR1 atlas — a plain `c as u8`
+/// truncates higher codepoints to the wrong byte (€ U+20AC -> 0xAC = ¬,
+/// ‘ U+2018 -> 0x18 control, em-dash U+2014 -> 0x14 control, etc.) so the
+/// user sees random glyphs.
+///
+/// ASCII (0x00-0x7F) passes through. For 0x80-0xFF, the table is the
+/// inverse of `WIN1252_HIGH`. The 5 unassigned positions (0x81, 0x8D,
+/// 0x8F, 0x90, 0x9D) have no Unicode codepoint, so they don't appear here.
+#[inline]
+pub fn char_to_win1252_byte(c: char) -> Option<u8> {
+    let cp = c as u32;
+    if cp < 0x80 {
+        return Some(cp as u8);
+    }
+    if cp >= 0x00A0 && cp <= 0x00FF {
+        // Latin-1 range -- direct mapping for everything except the
+        // five points that Win-1252 reassigns in 0x80-0x9F.
+        return Some(cp as u8);
+    }
+    // High-byte non-Latin-1 codepoints: search the WIN1252_HIGH table.
+    // Only 27 entries, linear scan is fine and runs once per rendered
+    // glyph; this avoids embedding a second 256-entry sparse table.
+    for (i, &mapped) in WIN1252_HIGH.iter().enumerate() {
+        if (mapped as u32) == cp && mapped != '\u{FFFD}' {
+            return Some(0x80 + i as u8);
+        }
+    }
+    None
+}
+
+/// Shorthand for the bitmap-font glyph lookup: return the Win-1252 byte
+/// for `c`, or `0` (NUL — no advance, no glyph) for chars with no CP1252
+/// mapping. Designed to replace the unsafe `c as u8` pattern that
+/// silently truncated codepoints like € (U+20AC) into the wrong glyph cell.
+#[inline]
+pub fn glyph_byte_for(c: char) -> u8 {
+    char_to_win1252_byte(c).unwrap_or(0)
+}
+
+/// Decode a slice of Windows-1252 bytes into a Rust `String`.
+/// Replaces the old `String::from_utf8_lossy(bytes).into_owned()` pattern,
+/// which mangled every non-ASCII byte into U+FFFD because Director text is
+/// never UTF-8.
+pub fn decode_win1252(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len());
+    for &b in bytes {
+        s.push(win1252_byte_to_char(b));
+    }
+    s
+}
+
+/// Decode bytes that came from an external source (HTTP response body,
+/// local FileIO read, XML payload) where the encoding isn't recorded
+/// in-band. Strategy:
+///
+/// 1. If the bytes start with a UTF-8 BOM (`EF BB BF`), strip it.
+/// 2. Try strict UTF-8. If valid, use it.
+/// 3. Otherwise fall back to Windows-1252.
+///
+/// This is unambiguous in practice because valid UTF-8 multi-byte sequences
+/// almost never form by accident when the source is Win-1252: a high byte
+/// (≥ 0x80) in CP1252 is a standalone character, while UTF-8 requires high
+/// bytes to come in well-formed continuation patterns. The check is cheap
+/// (`std::str::from_utf8` is O(n) and bails on the first invalid sequence),
+/// so the fallback only runs when the strict path actually fails.
+pub fn decode_text_auto(bytes: &[u8]) -> String {
+    let bytes = if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &bytes[3..]
+    } else {
+        bytes
+    };
+    match std::str::from_utf8(bytes) {
+        Ok(s) => s.to_owned(),
+        Err(_) => decode_win1252(bytes),
+    }
+}

--- a/vm-rust/src/io/list_readers.rs
+++ b/vm-rust/src/io/list_readers.rs
@@ -1,5 +1,6 @@
 use binary_reader::{BinaryReader, Endian};
 
+use super::encoding::decode_win1252;
 use super::reader::DirectorExt;
 
 pub fn read_pascal_string(item_bufs: &Vec<Vec<u8>>, index: usize, item_endian: Endian) -> String {
@@ -22,8 +23,9 @@ pub fn read_string(item_bufs: &Vec<Vec<u8>>, index: usize) -> String {
         return "".to_owned();
     }
 
+    // Win-1252, not UTF-8. See io::encoding for context.
     let buf = &item_bufs[index];
-    return String::from_utf8_lossy(buf).into_owned();
+    return decode_win1252(buf);
 }
 
 pub fn read_u16(item_bufs: &Vec<Vec<u8>>, index: usize, item_endian: Endian) -> u16 {

--- a/vm-rust/src/io/mod.rs
+++ b/vm-rust/src/io/mod.rs
@@ -1,2 +1,3 @@
+pub mod encoding;
 pub mod list_readers;
 pub mod reader;

--- a/vm-rust/src/io/reader.rs
+++ b/vm-rust/src/io/reader.rs
@@ -2,6 +2,8 @@ use std::io::Read;
 
 use binary_reader::BinaryReader;
 
+use crate::io::encoding::decode_win1252;
+
 pub trait DirectorExt {
     fn read_var_int(&mut self) -> Result<i32, std::io::Error>;
     fn read_zlib_bytes(&mut self, length: usize) -> Result<Vec<u8>, std::io::Error>;
@@ -48,8 +50,13 @@ impl DirectorExt for BinaryReader {
     }
 
     fn read_string(&mut self, len: usize) -> Result<String, std::io::Error> {
+        // Director text is Windows-1252 (CP1252), not UTF-8. The old
+        // from_utf8_lossy here silently replaced every non-ASCII byte with
+        // U+FFFD, killing umlauts (ä ö ü ß), Scandinavian (å ø æ), and
+        // Spanish (á é í ó ú ñ) characters in fields, text members, Lingo
+        // string literals, score labels, etc.
         let bytes = self.read_bytes(len).unwrap();
-        return Ok(String::from_utf8_lossy(&bytes).into_owned());
+        return Ok(decode_win1252(&bytes));
     }
 
     fn read_apple_float_80(&mut self) -> Result<f64, String> {

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -596,7 +596,15 @@ pub fn get_focused_field_selected_text() -> String {
         let len = text.len() as i32;
         let lo = lo.clamp(0, len).min(hi.clamp(0, len));
         let hi = lo.max(hi.clamp(0, len));
-        text[lo as usize..hi as usize].to_string()
+        // Snap to char boundaries before slicing. Caret indices are byte
+        // positions into a UTF-8 string; if any prior path produced one
+        // landing inside a multi-byte sequence (e.g. mid-ß), a raw slice
+        // would panic.
+        let mut lo_b = lo as usize;
+        let mut hi_b = hi as usize;
+        while lo_b < text.len() && !text.is_char_boundary(lo_b) { lo_b += 1; }
+        while hi_b < text.len() && !text.is_char_boundary(hi_b) { hi_b += 1; }
+        text[lo_b..hi_b].to_string()
     })
 }
 

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -3130,7 +3130,7 @@ impl Bitmap {
         for line in &lines {
             // Calculate x based on alignment
             let line_w: i32 = line.chars()
-                .map(|ch| font.get_char_advance(ch as u8) as i32)
+                .map(|ch| font.get_char_advance_for(ch) as i32)
                 .sum();
             let x = match alignment {
                 "center" => loc_h + ((max_width - line_w) / 2).max(0),
@@ -3142,10 +3142,10 @@ impl Bitmap {
             let mut cx = x;
             for ch in line.chars() {
                 bitmap_font_copy_char(
-                    font, font_bitmap, ch as u8,
+                    font, font_bitmap, crate::io::encoding::glyph_byte_for(ch),
                     self, cx, y, palettes, &params,
                 );
-                cx += font.get_char_advance(ch as u8) as i32;
+                cx += font.get_char_advance_for(ch) as i32;
             }
             y += line_height;
         }
@@ -3187,12 +3187,20 @@ impl Bitmap {
                 let mut line_w: i32 = 0;
                 let mut last_space: Option<usize> = None;
 
-                let mut p = para_start;
-                while p < para_end {
-                    let ch = bytes[p];
-                    let cw = font.get_char_advance(ch) as i32;
+                // Walk Unicode chars (via char_indices for byte positions)
+                // rather than raw UTF-8 bytes. Bytes-based iteration both
+                // (a) gave umlauts 2x phantom width by counting their
+                // lead+continuation bytes as separate glyphs, and (b)
+                // could leave `p` mid-codepoint, panicking at the next
+                // `text[line_start..p]` slice when the wrap point landed
+                // inside a multi-byte char (e.g. "lets tryäö+üß" at byte
+                // 16 inside ß).
+                let para_text = &text[para_start..para_end];
+                for (local_p, ch) in para_text.char_indices() {
+                    let p = para_start + local_p;
+                    let cw = font.get_char_advance_for(ch) as i32;
 
-                    if ch == b' ' {
+                    if ch == ' ' {
                         last_space = Some(p);
                     }
 
@@ -3203,20 +3211,22 @@ impl Bitmap {
                                 end: sp,
                                 text: text[line_start..sp].to_string(),
                             });
+                            // ' ' is ASCII so sp + 1 is always a char
+                            // boundary.
                             line_start = sp + 1;
                             last_space = None;
-                            // If the space we just wrapped at is the current
-                            // character (it was the overflowing one), the
-                            // space itself is consumed by the wrap — skip
-                            // past it without double-counting its width.
+                            // If the wrap point IS the current char (the
+                            // overflowing one), skip it without counting
+                            // its width on the new line.
                             if line_start > p {
                                 line_w = 0;
-                                p = line_start;
                                 continue;
                             }
+                            // Re-accumulate glyph advances for the chars
+                            // that now form the start of the new line.
                             line_w = text[line_start..p]
-                                .bytes()
-                                .map(|b| font.get_char_advance(b) as i32)
+                                .chars()
+                                .map(|c| font.get_char_advance(c as u8) as i32)
                                 .sum();
                         } else {
                             #[cfg(feature = "word_hard_break")]
@@ -3234,7 +3244,6 @@ impl Bitmap {
                     }
 
                     line_w += cw;
-                    p += 1;
                 }
 
                 lines.push(LineSpan {
@@ -3299,7 +3308,13 @@ impl Bitmap {
 
         let line = &lines[line_idx];
         let col = idx.saturating_sub(line.start);
-        let line_w: i32 = line.text.bytes().map(|b| font.get_char_advance(b) as i32).sum();
+        // Iterate Unicode chars, not raw UTF-8 bytes. The bitmap renderer
+        // advances one glyph per char (see render_html_text_to_bitmap_styled),
+        // so the caret-pixel calculation must mirror that. The previous
+        // .bytes() loop counted each lead+continuation byte of an umlaut
+        // as separate glyph advances, producing 4 phantom advances for
+        // "öäüß" (8 UTF-8 bytes → 8 advances instead of 4).
+        let line_w: i32 = line.text.chars().map(|c| font.get_char_advance(c as u8) as i32).sum();
         let x_offset = if max_width > 0 {
             let key = alignment.trim().trim_start_matches('#').to_ascii_lowercase();
             match key.as_str() {
@@ -3311,9 +3326,15 @@ impl Bitmap {
             0
         };
 
+        // Walk chars until we've covered `col` bytes from the line start.
+        // `col` and `idx` are byte indices into the UTF-8 string; one umlaut
+        // contributes 2 bytes but only one glyph advance.
         let mut x = x_offset;
-        for b in line.text.bytes().take(col) {
-            x += font.get_char_advance(b) as i32;
+        let mut byte_pos = 0usize;
+        for c in line.text.chars() {
+            if byte_pos >= col { break; }
+            x += font.get_char_advance(c as u8) as i32;
+            byte_pos += c.len_utf8();
         }
         (x, (line_idx as i32) * line_height)
     }
@@ -3338,7 +3359,11 @@ impl Bitmap {
         };
 
         let line = &lines[line_idx];
-        let line_w: i32 = line.text.bytes().map(|b| font.get_char_advance(b) as i32).sum();
+        // Walk chars instead of UTF-8 bytes — see caret_index_to_xy. This
+        // also keeps the returned caret index aligned to char boundaries
+        // (was bug source for the byte-index-7-mid-of-ß slice panic
+        // observed in get_focused_field_selected_text / pixel_x_for_byte).
+        let line_w: i32 = line.text.chars().map(|c| font.get_char_advance(c as u8) as i32).sum();
         let x_offset = if max_width > 0 {
             let key = alignment.trim().trim_start_matches('#').to_ascii_lowercase();
             match key.as_str() {
@@ -3355,12 +3380,14 @@ impl Bitmap {
         }
 
         let mut cx = x_offset;
-        for (i, b) in line.text.bytes().enumerate() {
-            let cw = font.get_char_advance(b) as i32;
+        let mut byte_pos = 0usize;
+        for c in line.text.chars() {
+            let cw = font.get_char_advance(c as u8) as i32;
             if x < cx + cw / 2 {
-                return (line.start + i) as i32;
+                return (line.start + byte_pos) as i32;
             }
             cx += cw;
+            byte_pos += c.len_utf8();
         }
         line.end as i32
     }

--- a/vm-rust/src/player/font/mod.rs
+++ b/vm-rust/src/player/font/mod.rs
@@ -91,6 +91,14 @@ impl BitmapFont {
         }
         self.char_width
     }
+
+    /// Advance width for a Unicode char. Maps the char to its Win-1252
+    /// glyph slot first, so codepoints like € (U+20AC) hit the correct
+    /// atlas cell (0x80) instead of `c as u8` truncating to 0xAC.
+    #[inline]
+    pub fn get_char_advance_for(&self, c: char) -> u16 {
+        self.get_char_advance(crate::io::encoding::glyph_byte_for(c))
+    }
 }
 
 pub struct DrawTextParams<'a> {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -1238,7 +1238,13 @@ impl FontMemberHandlers {
                             continue;
                         }
                         let inner = byte - segment.start_byte;
-                        let prefix = &segment.text[..inner.min(segment.text.len())];
+                        // Snap to a UTF-8 char boundary -- selection
+                        // indices can land mid-codepoint (e.g. inside ß)
+                        // and a raw slice would panic. Rounding DOWN
+                        // means the prefix excludes a half-finished char.
+                        let mut clamped = inner.min(segment.text.len());
+                        while clamped > 0 && !segment.text.is_char_boundary(clamped) { clamped -= 1; }
+                        let prefix = &segment.text[..clamped];
                         ctx.set_font(&segment.style.font);
                         let prefix_w = ctx.measure_text(prefix)
                             .map(|m| m.width())
@@ -1437,7 +1443,7 @@ impl FontMemberHandlers {
             // Calculate line width using proportional per-character advances
             let line_width: i32 = line.chars()
                 .map(|c| {
-                    let advance = font.get_char_advance(c as u8) as i32;
+                    let advance = font.get_char_advance_for(c) as i32;
                     (advance * requested_font_size) / native_char_height
                 })
                 .sum();
@@ -1471,7 +1477,7 @@ impl FontMemberHandlers {
                 }
 
                 // Calculate proportional advance for this character
-                let char_advance = ((font.get_char_advance(ch as u8) as i32) * requested_font_size / native_char_height).max(1);
+                let char_advance = ((font.get_char_advance_for(ch) as i32) * requested_font_size / native_char_height).max(1);
 
                 // For space character, just advance position without drawing
                 if ch == ' ' {
@@ -1485,7 +1491,7 @@ impl FontMemberHandlers {
 
                 // Draw the character with scaling (use full cell width for source mapping)
                 bitmap_font_copy_char_scaled(
-                    font, font_bitmap, ch as u8, bitmap,
+                    font, font_bitmap, crate::io::encoding::glyph_byte_for(ch), bitmap,
                     char_x, y, char_width, char_height,
                     palettes, &params
                 );
@@ -1493,7 +1499,7 @@ impl FontMemberHandlers {
                 // Simulate bold by drawing again with 1px offset
                 if is_bold {
                     bitmap_font_copy_char_scaled(
-                        font, font_bitmap, ch as u8, bitmap,
+                        font, font_bitmap, crate::io::encoding::glyph_byte_for(ch), bitmap,
                         char_x + 1, y, char_width, char_height,
                         palettes, &params
                     );

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -1459,7 +1459,7 @@ impl TextMemberHandlers {
                                 }
                                 continue;
                             }
-                            let adv = font.get_char_advance(ch as u8) as i32;
+                            let adv = font.get_char_advance_for(ch) as i32;
                             let per = per_char
                                 .get(line_char_offset + ch_idx)
                                 .copied()
@@ -1486,24 +1486,24 @@ impl TextMemberHandlers {
                             };
                             if use_tight {
                                 bitmap_font_copy_char_tight(
-                                    &font, font_bitmap, ch as u8, bitmap,
+                                    &font, font_bitmap, crate::io::encoding::glyph_byte_for(ch), bitmap,
                                     x, y_pos, &palettes, &ch_params,
                                 );
                             } else {
                                 bitmap_font_copy_char(
-                                    &font, font_bitmap, ch as u8, bitmap,
+                                    &font, font_bitmap, crate::io::encoding::glyph_byte_for(ch), bitmap,
                                     x, y_pos, &palettes, &ch_params,
                                 );
                             }
                             if per.bold {
                                 if use_tight {
                                     bitmap_font_copy_char_tight(
-                                        &font, font_bitmap, ch as u8, bitmap,
+                                        &font, font_bitmap, crate::io::encoding::glyph_byte_for(ch), bitmap,
                                         x + 1, y_pos, &palettes, &ch_params,
                                     );
                                 } else {
                                     bitmap_font_copy_char(
-                                        &font, font_bitmap, ch as u8, bitmap,
+                                        &font, font_bitmap, crate::io::encoding::glyph_byte_for(ch), bitmap,
                                         x + 1, y_pos, &palettes, &ch_params,
                                     );
                                 }

--- a/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
@@ -20,6 +20,33 @@ use super::string::{string_get_items, string_get_lines};
 pub struct StringChunkHandlers {}
 pub struct StringChunkUtils {}
 
+/// Convert a CHAR range (0-based, half-open) into a BYTE range suitable
+/// for `String::replace_range` / direct slicing. Without this, Director's
+/// `char N of t = "x"` / `delete char N of t` would panic on any text
+/// containing multi-byte codepoints (umlauts, accents, Euro, smart quotes,
+/// etc.) -- the call sites collected `chars().count()` as the max but then
+/// passed the resulting indices into byte-indexed APIs.
+///
+/// Out-of-range indices clamp to the string's byte length so the caller's
+/// "delete chars 100..200 of a 5-char string" still produces an empty
+/// range instead of panicking.
+pub(crate) fn char_range_to_byte_range(s: &str, char_start: usize, char_end: usize) -> (usize, usize) {
+    if char_start >= char_end {
+        // Caller already handles the "empty range" case for ranges that
+        // collapse during clamping; return a valid empty slice at the
+        // appropriate boundary so replace_range is still a no-op.
+        let bs = s.char_indices().nth(char_start).map(|(b, _)| b).unwrap_or(s.len());
+        return (bs, bs);
+    }
+    let mut iter = s.char_indices();
+    let byte_start = iter.by_ref().nth(char_start).map(|(b, _)| b).unwrap_or(s.len());
+    // We've consumed `char_start + 1` items from iter. To advance to the
+    // `char_end`th codepoint, step forward `char_end - char_start - 1` more.
+    let extra = char_end - char_start - 1;
+    let byte_end = iter.nth(extra).map(|(b, _)| b).unwrap_or(s.len());
+    (byte_start, byte_end)
+}
+
 impl StringChunkUtils {
     pub fn delete(
         player: &mut DirPlayer,
@@ -127,7 +154,11 @@ impl StringChunkUtils {
                 let mut new_string = string.to_owned();
                 let (start, end) =
                     Self::vm_range_to_host((chunk_expr.start, chunk_expr.end), string.chars().count());
-                new_string.replace_range(start..end, "");
+                // (start, end) are CHAR indices; replace_range wants BYTE
+                // indices. Convert via char_indices so `delete char 3 of
+                // "öäüß"` doesn't try to slice mid-codepoint.
+                let (byte_start, byte_end) = char_range_to_byte_range(string, start, end);
+                new_string.replace_range(byte_start..byte_end, "");
                 Ok(new_string)
             }
             StringChunkType::Item => {
@@ -186,7 +217,8 @@ impl StringChunkUtils {
                 let mut new_string = string.to_owned();
                 let (start, end) =
                     Self::vm_range_to_host((chunk_expr.start, chunk_expr.end), string.chars().count());
-                new_string.replace_range(start..end, &replace_with);
+                let (byte_start, byte_end) = char_range_to_byte_range(string, start, end);
+                new_string.replace_range(byte_start..byte_end, replace_with);
                 Ok(new_string)
             }
             _ => Err(ScriptError::new(
@@ -376,7 +408,8 @@ impl StringChunkUtils {
                 let mut new_string = string.to_owned();
                 let (start, end) =
                     StringChunkUtils::vm_range_to_host((chunk_expr.start, chunk_expr.end), string.chars().count());
-                new_string.replace_range(start..end, replace_with);
+                let (byte_start, byte_end) = char_range_to_byte_range(string, start, end);
+                new_string.replace_range(byte_start..byte_end, replace_with);
                 Ok(new_string)
             }
             StringChunkType::Item | StringChunkType::Word | StringChunkType::Line => {

--- a/vm-rust/src/player/handlers/net.rs
+++ b/vm-rust/src/player/handlers/net.rs
@@ -140,14 +140,12 @@ impl NetHandlers {
             let task_state = player.net_manager.get_task_state(task_id).ok_or_else(|| ScriptError::new("Network task not found".to_string()))?;
             let is_ok = task_state.is_done() && task_state.result.as_ref().unwrap().is_ok();
             let text = if is_ok {
-                let text = task_state.result.as_ref().unwrap().as_ref().unwrap();
-                // Strip UTF-8 BOM (0xEF 0xBB 0xBF) if present
-                let text = if text.starts_with(&[0xEF, 0xBB, 0xBF]) {
-                    &text[3..]
-                } else {
-                    text
-                };
-                Datum::String(String::from_utf8_lossy(text).to_string())
+                let bytes = task_state.result.as_ref().unwrap().as_ref().unwrap();
+                // UTF-8 strict first (modern editors), Win-1252 fallback
+                // (legacy Director-authored external_texts_*.txt etc.).
+                // Strips a UTF-8 BOM if present. See io::encoding for why
+                // strict-then-fallback is unambiguous in practice.
+                Datum::String(crate::io::encoding::decode_text_auto(bytes))
             } else {
                 Datum::String("".to_owned())
             };

--- a/vm-rust/src/player/keyboard.rs
+++ b/vm-rust/src/player/keyboard.rs
@@ -65,7 +65,18 @@ impl KeyboardManager {
     }
 
     pub fn is_alt_down(&self) -> bool {
-        self.is_key_down("Alt")
+        // German / Nordic / many EU layouts assign the right Alt key the
+        // "AltGraph" identifier instead of "Alt". Treat both as the same
+        // modifier so `the optionDown`/`the altDown` Lingo accessors stay
+        // truthy when the user is holding AltGr.
+        self.is_key_down("Alt") || self.is_key_down("AltGraph")
+    }
+
+    /// True specifically when the AltGr key (right-Alt on German/Nordic
+    /// layouts) is held. Used by text-insertion to distinguish "typing a
+    /// layout-modified character like @, €, |" from "Ctrl+letter shortcut".
+    pub fn is_alt_graph_down(&self) -> bool {
+        self.is_key_down("AltGraph")
     }
 
     pub fn key_code(&self) -> u16 {

--- a/vm-rust/src/player/keyboard_events.rs
+++ b/vm-rust/src/player/keyboard_events.rs
@@ -92,19 +92,37 @@ pub(crate) fn apply_text_edit(
     }
 
     let bytes_for_nav = text.as_bytes().to_vec();
-    let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
+    // Word-character predicate at byte level for the line-break helpers
+    // (which only consult ASCII \r / \n -- safe with bytes).
+    let _ = bytes_for_nav.len(); // suppress unused warning if only line helpers consult bytes
+    // Char-aware "is word char": alphanumeric or underscore. Unlike the
+    // earlier byte-based check, this returns true for umlauts (ä, é, ñ,
+    // å, etc.) so Ctrl+Arrow / double-click word-select treats "café" as
+    // one word instead of stopping at the multi-byte boundary.
+    let is_word_ch = |c: char| c.is_alphanumeric() || c == '_';
+
+    // Pre-snapshot (byte_pos, char) for the whole text. Allocates once per
+    // apply_text_edit call; text in real fields is short (chat input, name
+    // fields, descriptions) so memory is fine.
+    let nav_chars: Vec<(usize, char)> = text.char_indices().collect();
+    // Find the char-index in nav_chars whose byte_pos == `byte_pos`, or
+    // the index where it would be inserted (== nav_chars.len() for EOS).
+    let char_idx_of = |byte_pos: i32| -> usize {
+        let bp = byte_pos.clamp(0, len) as usize;
+        nav_chars.iter().position(|(b, _)| *b >= bp).unwrap_or(nav_chars.len())
+    };
     let prev_word_boundary = |from: i32| -> i32 {
-        let mut p = from.clamp(0, len) as usize;
-        while p > 0 && !is_word(bytes_for_nav[p - 1]) { p -= 1; }
-        while p > 0 && is_word(bytes_for_nav[p - 1]) { p -= 1; }
-        p as i32
+        let mut i = char_idx_of(from);
+        while i > 0 && !is_word_ch(nav_chars[i - 1].1) { i -= 1; }
+        while i > 0 && is_word_ch(nav_chars[i - 1].1) { i -= 1; }
+        nav_chars.get(i).map(|(b, _)| *b as i32).unwrap_or(len)
     };
     let next_word_boundary = |from: i32| -> i32 {
-        let n = bytes_for_nav.len();
-        let mut p = from.clamp(0, len) as usize;
-        while p < n && is_word(bytes_for_nav[p]) { p += 1; }
-        while p < n && !is_word(bytes_for_nav[p]) { p += 1; }
-        p as i32
+        let n = nav_chars.len();
+        let mut i = char_idx_of(from);
+        while i < n && is_word_ch(nav_chars[i].1) { i += 1; }
+        while i < n && !is_word_ch(nav_chars[i].1) { i += 1; }
+        nav_chars.get(i).map(|(b, _)| *b as i32).unwrap_or(len)
     };
     // Char-boundary helpers. The text buffer is UTF-8 (Rust String), so a
     // single visible character like 'ä' or '€' is 2-3 bytes. Stepping the
@@ -184,13 +202,23 @@ pub(crate) fn apply_text_edit(
         "ArrowUp" => {
             let cur_line_start = line_start_of(active);
             let col = active - cur_line_start;
-            let new_pos = if cur_line_start == 0 {
+            let mut new_pos = if cur_line_start == 0 {
                 0
             } else {
                 let prev_line_end = cur_line_start - 1;
                 let prev_line_start = line_start_of(prev_line_end);
                 prev_line_start + col.min(prev_line_end - prev_line_start)
             };
+            // `col` is a byte offset; preserving it across lines with
+            // different multi-byte char counts can land mid-codepoint
+            // (panic on next edit). Snap to the nearest legal char
+            // boundary, walking backwards so visual column stays close
+            // to where the user expects.
+            while (new_pos as usize) < text.len()
+                && !text.is_char_boundary(new_pos as usize)
+            {
+                new_pos -= 1;
+            }
             if shift {
                 extend(sel_start, sel_end, anchor, new_pos, len);
             } else {
@@ -201,13 +229,18 @@ pub(crate) fn apply_text_edit(
             let cur_line_start = line_start_of(active);
             let col = active - cur_line_start;
             let cur_line_end = line_end_of(active);
-            let new_pos = if cur_line_end >= len {
+            let mut new_pos = if cur_line_end >= len {
                 len
             } else {
                 let next_line_start = cur_line_end + 1;
                 let next_line_end = line_end_of(next_line_start);
                 next_line_start + col.min(next_line_end - next_line_start)
             };
+            while (new_pos as usize) < text.len()
+                && !text.is_char_boundary(new_pos as usize)
+            {
+                new_pos -= 1;
+            }
             if shift {
                 extend(sel_start, sel_end, anchor, new_pos, len);
             } else {
@@ -325,6 +358,15 @@ pub(crate) fn set_caret_at_screen(
         let sprite_loc_h = sprite.loc_h;
         let sprite_loc_v = sprite.loc_v;
         let sprite_width = sprite.width;
+        // Match the renderer's stage-scaling: the GPU/PFR text path
+        // rasterises glyphs at `font_size * stage_scale` (see
+        // rendering_gpu/webgl2/mod.rs render-text entry), so the rasterised
+        // atlas's `char_widths` reflect the scaled-up glyph widths. Without
+        // applying the same scale here, `xy_to_caret_index` walks a
+        // differently-sized font's char_widths than the renderer drew --
+        // the click maps to half the visual position on a 2x-scaled stage.
+        let (scale_x, scale_y) = crate::player::stage::stage_scale(player);
+        let stage_scale = scale_x.min(scale_y);
 
         // Resolve which editable member kind we have, and its text + style
         // properties needed to drive xy_to_caret_index. We work on a snapshot
@@ -381,40 +423,63 @@ pub(crate) fn set_caret_at_screen(
         let caret_idx = match &snapshot {
             MemberSnapshot::Field { text, font, font_size, font_id, alignment,
                                     fixed_line_space, top_spacing, word_wrap: _ } => {
-                let font_opt = crate::rendering::get_or_load_font_with_id(
-                    &mut player.font_manager,
-                    &player.movie.cast_manager,
+                // Mirror the renderer: rasterise the font at the SAME scaled
+                // size the PFR atlas uses (`font_size * stage_scale`), AND
+                // use the SAME font-lookup path as the renderer so we get
+                // the exact same cached BitmapFont (same char_widths, same
+                // first_char_num). The previous `get_or_load_font_with_id`
+                // path had a different cache-key scheme (case-sensitive)
+                // and could fall through to a fuzzy `starts_with` match
+                // that returned a DIFFERENT-size font than the renderer
+                // used -- when char_widths differed, multibyte chars
+                // diverged from ASCII chars because per-char proportional
+                // widths don't scale uniformly.
+                let scaled_font_size = ((*font_size as f64) * stage_scale)
+                    .round().max(1.0) as u16;
+                let font_opt = player.font_manager.get_font_with_cast_and_bitmap(
                     font,
-                    Some(*font_size),
+                    &player.movie.cast_manager,
+                    &mut player.bitmap_manager,
+                    Some(scaled_font_size),
                     None,
-                    *font_id,
-                );
+                ).or_else(|| {
+                    // Same font_id fallback the renderer uses when the
+                    // name-based lookup misses (rich-text spans reference
+                    // fonts by ID).
+                    font_id.and_then(|id| {
+                        player.font_manager.font_by_id.get(&id).copied()
+                            .and_then(|fr| player.font_manager.fonts.get(&fr).cloned())
+                    })
+                });
                 let Some(f) = font_opt else { return false };
-                let local_x = movie_x - sprite_loc_h;
-                let local_y = movie_y - sprite_loc_v - *top_spacing as i32;
+                // Scale the click coords into the renderer's coordinate
+                // space too. movie_x is in unscaled movie space; the
+                // renderer's char_widths sum is in scaled space.
+                let local_x = ((movie_x - sprite_loc_h) as f64 * stage_scale).round() as i32;
+                let local_y = ((movie_y - sprite_loc_v - *top_spacing as i32) as f64 * stage_scale).round() as i32;
+                let scaled_width = ((sprite_width as f64) * stage_scale).round() as i32;
                 let line_h = effective_line_height(&f, *fixed_line_space);
-                // Always pass sprite_width so xy_to_caret_index can compute the
-                // per-line alignment offset for centered/right text. Setting
-                // max_width to 0 when word_wrap is off makes the helper assume
-                // left alignment, which sends every click to the left edge of
-                // the sprite even when the visible glyphs are centered.
                 crate::player::bitmap::bitmap::Bitmap::xy_to_caret_index(
-                    text, &f, sprite_width, alignment, line_h, local_x, local_y,
+                    text, &f, scaled_width, alignment, line_h, local_x, local_y,
                 )
             }
             MemberSnapshot::Text { text, font, font_size, fixed_line_space, top_spacing } => {
-                let font_opt = crate::rendering::get_or_load_font(
-                    &mut player.font_manager,
-                    &player.movie.cast_manager,
+                // Same stage-scaled font lookup + coord scaling as the
+                // Field branch above. See its comment for the rationale.
+                let scaled_font_size = ((*font_size as f64) * stage_scale)
+                    .round().max(1.0) as u16;
+                let font_opt = player.font_manager.get_font_with_cast_and_bitmap(
                     font,
-                    Some(*font_size),
+                    &player.movie.cast_manager,
+                    &mut player.bitmap_manager,
+                    Some(scaled_font_size),
                     None,
                 );
                 let Some(f) = font_opt else { return false };
                 // For TextMember bitmap path we treat width as unbounded, matching
                 // the renderer (see rendering.rs draw_text-with-caret block).
-                let local_x = movie_x - sprite_loc_h;
-                let local_y = movie_y - sprite_loc_v - *top_spacing as i32;
+                let local_x = ((movie_x - sprite_loc_h) as f64 * stage_scale).round() as i32;
+                let local_y = ((movie_y - sprite_loc_v - *top_spacing as i32) as f64 * stage_scale).round() as i32;
                 let line_h = effective_line_height(&f, *fixed_line_space);
                 crate::player::bitmap::bitmap::Bitmap::xy_to_caret_index(
                     text, &f, 0, "left", line_h, local_x, local_y,
@@ -454,20 +519,41 @@ pub(crate) fn set_caret_at_screen(
                 *sel_end_ref = anchor.max(clamped);
             }
             CaretAtMode::SelectWord => {
-                let is_word = |b: u8| b.is_ascii_alphanumeric() || b == b'_';
-                let mut start = clamped as usize;
-                let mut end = clamped as usize;
-                let n = bytes.len();
-                if start < n && is_word(bytes[start]) {
-                    while start > 0 && is_word(bytes[start - 1]) { start -= 1; }
-                    while end < n && is_word(bytes[end]) { end += 1; }
-                } else if start > 0 && is_word(bytes[start - 1]) {
-                    while start > 0 && is_word(bytes[start - 1]) { start -= 1; }
-                    end = clamped as usize;
+                // Char-aware word selection: double-clicking inside "café"
+                // selects the whole word instead of stopping at the lead
+                // byte of 'é'. We use `text_snapshot` (Rust String) and
+                // walk char_indices to find the surrounding word boundaries.
+                let click_b = clamped as usize;
+                let is_word_ch = |c: char| c.is_alphanumeric() || c == '_';
+                // Materialise (byte_pos, char) for the line. Strings in
+                // editable fields are short -- one-shot collection is fine.
+                let chars: Vec<(usize, char)> =
+                    text_ref.char_indices().collect();
+                // Locate the char-index whose byte_pos straddles click_b.
+                // `i` is the first char-index whose byte_pos >= click_b;
+                // if there's a char strictly before that, prefer it for
+                // the "click_b is on a char boundary" case.
+                let i = chars.iter().position(|(b, _)| *b >= click_b)
+                    .unwrap_or(chars.len());
+                let (mut s, mut e) = (i, i);
+                // If the click lands on a word char, expand both sides;
+                // if it's right after one (caret between word and non-
+                // word), grab the trailing word -- matches the byte
+                // behaviour for ASCII text.
+                let on_word = chars.get(i).map_or(false, |(_, c)| is_word_ch(*c));
+                let after_word = i > 0 && is_word_ch(chars[i - 1].1);
+                if on_word {
+                    while s > 0 && is_word_ch(chars[s - 1].1) { s -= 1; }
+                    while e < chars.len() && is_word_ch(chars[e].1) { e += 1; }
+                } else if after_word {
+                    while s > 0 && is_word_ch(chars[s - 1].1) { s -= 1; }
+                    e = i;
                 }
-                *sel_start_ref = start as i32;
-                *sel_end_ref = end as i32;
-                *sel_anchor_ref = start as i32;
+                let start_b = chars.get(s).map(|(b, _)| *b).unwrap_or(text_ref.len());
+                let end_b = chars.get(e).map(|(b, _)| *b).unwrap_or(text_ref.len());
+                *sel_start_ref = start_b as i32;
+                *sel_end_ref = end_b as i32;
+                *sel_anchor_ref = start_b as i32;
             }
             CaretAtMode::SelectLine => {
                 let mut start = clamped as usize;

--- a/vm-rust/src/player/keyboard_events.rs
+++ b/vm-rust/src/player/keyboard_events.rs
@@ -106,6 +106,28 @@ pub(crate) fn apply_text_edit(
         while p < n && !is_word(bytes_for_nav[p]) { p += 1; }
         p as i32
     };
+    // Char-boundary helpers. The text buffer is UTF-8 (Rust String), so a
+    // single visible character like 'ä' or '€' is 2-3 bytes. Stepping the
+    // caret by 1 byte would land inside a multi-byte sequence and make
+    // `text.replace_range` panic on the next edit. These walk to the
+    // nearest legal char boundary using `str::is_char_boundary`, which is
+    // O(1) per step.
+    let prev_char_boundary = |from: i32| -> i32 {
+        if from <= 0 { return 0; }
+        let mut p = (from as usize).min(text.len());
+        if p == 0 { return 0; }
+        p -= 1;
+        while p > 0 && !text.is_char_boundary(p) { p -= 1; }
+        p as i32
+    };
+    let next_char_boundary = |from: i32| -> i32 {
+        let n = text.len();
+        let mut p = (from as usize).min(n);
+        if p >= n { return n as i32; }
+        p += 1;
+        while p < n && !text.is_char_boundary(p) { p += 1; }
+        p as i32
+    };
     let line_start_of = |from: i32| -> i32 {
         let mut p = from.clamp(0, len) as usize;
         while p > 0 && bytes_for_nav[p - 1] != b'\r' && bytes_for_nav[p - 1] != b'\n' { p -= 1; }
@@ -137,7 +159,7 @@ pub(crate) fn apply_text_edit(
             } else if ctrl_or_meta {
                 prev_word_boundary(active)
             } else {
-                (active - 1).max(0)
+                prev_char_boundary(active)
             };
             if shift {
                 extend(sel_start, sel_end, anchor, new_pos, len);
@@ -151,7 +173,7 @@ pub(crate) fn apply_text_edit(
             } else if ctrl_or_meta {
                 next_word_boundary(active)
             } else {
-                (active + 1).min(len)
+                next_char_boundary(active)
             };
             if shift {
                 extend(sel_start, sel_end, anchor, new_pos, len);
@@ -213,8 +235,9 @@ pub(crate) fn apply_text_edit(
                 text.replace_range(lo as usize..hi as usize, "");
                 collapse(sel_start, sel_end, sel_anchor, lo, text.len() as i32);
             } else if lo > 0 {
-                text.replace_range((lo - 1) as usize..lo as usize, "");
-                collapse(sel_start, sel_end, sel_anchor, lo - 1, text.len() as i32);
+                let prev = prev_char_boundary(lo);
+                text.replace_range(prev as usize..lo as usize, "");
+                collapse(sel_start, sel_end, sel_anchor, prev, text.len() as i32);
             }
         }
         "Delete" => {
@@ -222,7 +245,8 @@ pub(crate) fn apply_text_edit(
                 text.replace_range(lo as usize..hi as usize, "");
                 collapse(sel_start, sel_end, sel_anchor, lo, text.len() as i32);
             } else if lo < len {
-                text.replace_range(lo as usize..(lo + 1) as usize, "");
+                let next = next_char_boundary(lo);
+                text.replace_range(lo as usize..next as usize, "");
                 collapse(sel_start, sel_end, sel_anchor, lo, text.len() as i32);
             }
         }
@@ -244,10 +268,24 @@ pub(crate) fn apply_text_edit(
             collapse(sel_start, sel_end, sel_anchor, new_caret, text.len() as i32);
         }
         _ => {
-            // Single ASCII char insertion. Any modifier other than Shift
+            // Single-character insertion. Browser keydown delivers printable
+            // chars as 1-codepoint strings: "a", "Ä", "ä", "ñ", "€", "ß".
+            // Named keys (Tab, Backspace, ArrowLeft, F5, ...) arrive as
+            // multi-char strings and are filtered out here. The previous
+            // `key.len() == 1` byte-length check rejected umlauts because
+            // "ä" is 2 bytes in UTF-8. Any modifier other than Shift still
             // suppresses insertion (Cmd+S, Ctrl+B, etc.).
-            if key.len() == 1 && !ctrl_or_meta {
+            let one_printable_char = {
+                let mut it = key.chars();
+                match (it.next(), it.next()) {
+                    (Some(c), None) => !c.is_control(),
+                    _ => false,
+                }
+            };
+            if one_printable_char && !ctrl_or_meta {
                 text.replace_range(lo as usize..hi as usize, key);
+                // `key.len()` is the UTF-8 byte length -- correct here
+                // because sel_start/sel_end are byte indices into `text`.
                 let new_caret = lo + key.len() as i32;
                 collapse(sel_start, sel_end, sel_anchor, new_caret, text.len() as i32);
             }
@@ -526,8 +564,22 @@ pub async fn player_key_down(key: String, code: u16) -> Result<DatumRef, ScriptE
                 return;
             }
             let shift = player.keyboard_manager.is_shift_down();
-            let ctrl_or_meta = player.keyboard_manager.is_control_down()
-                || player.keyboard_manager.is_command_down();
+            let ctrl = player.keyboard_manager.is_control_down();
+            let cmd = player.keyboard_manager.is_command_down();
+            let alt = player.keyboard_manager.is_alt_down();
+            let alt_graph = player.keyboard_manager.is_alt_graph_down();
+            // AltGr detection: German / Nordic / many EU layouts make the
+            // right Alt key produce printable characters like @, €, |, [, ].
+            // The browser tells us this two ways depending on platform:
+            //   (a) it fires `event.key = "AltGraph"` for the key itself
+            //   (b) Windows synthesizes Ctrl+Alt and the event also has
+            //       ctrlKey=true alongside altKey=true.
+            // Both signal "the user is typing a layout-modified character,
+            // not invoking a Ctrl shortcut". Treat either as AltGr and let
+            // insertion proceed. Cmd (Mac Meta) is never AltGr -- those
+            // shortcuts (Cmd+S, Cmd+C) keep getting suppressed.
+            let is_alt_gr = alt_graph || (ctrl && alt);
+            let ctrl_or_meta = cmd || (ctrl && !is_alt_gr);
 
             // Tab handled separately (advances focus across editable members);
             // hand off so apply_text_edit doesn't see it.

--- a/vm-rust/src/player/xtra/fileio/mod.rs
+++ b/vm-rust/src/player/xtra/fileio/mod.rs
@@ -101,7 +101,8 @@ impl FileIoXtraInstance {
             }
             end += 1;
         }
-        let result = String::from_utf8_lossy(&self.data[start..end]).to_string();
+        // UTF-8 strict first, Win-1252 fallback. See io::encoding.
+        let result = crate::io::encoding::decode_text_auto(&self.data[start..end]);
         // Advance past delimiter/newline
         self.position = end;
         if self.position < self.data.len() {
@@ -317,7 +318,7 @@ impl FileIoXtraManager {
             "readfile" => {
                 let instance = manager.instances.get_mut(&instance_id).unwrap();
                 let result = if instance.is_open {
-                    String::from_utf8_lossy(&instance.data[instance.position..]).to_string()
+                    crate::io::encoding::decode_text_auto(&instance.data[instance.position..])
                 } else {
                     instance.last_error = -1;
                     String::new()
@@ -380,7 +381,7 @@ impl FileIoXtraManager {
                     }
                     instance.position += 1;
                 }
-                let token = String::from_utf8_lossy(&instance.data[start..instance.position]).to_string();
+                let token = crate::io::encoding::decode_text_auto(&instance.data[start..instance.position]);
                 reserve_player_mut(|player| {
                     Ok(player.alloc_datum(Datum::String(token)))
                 })

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -92,9 +92,14 @@ fn draw_text_selection_rects(
         // Compute x positions inline for THIS line — caret_index_to_xy snaps
         // soft-wrap-boundary indices to the FOLLOWING visual line, which
         // would collapse a multi-line selection's right edge onto the wrong
-        // row. Walking the line's own bytes keeps every rect bound to its
-        // own visual line.
-        let line_w: i32 = line.text.bytes().map(|b| font.get_char_advance(b) as i32).sum();
+        // row. Walking the line's own chars (not bytes!) keeps every rect
+        // bound to its own visual line AND counts one glyph advance per
+        // visible character — the byte-walk variant gave umlauts and other
+        // multi-byte codepoints 2x width, stretching the highlight past
+        // the actual text.
+        let line_w: i32 = line.text.chars()
+            .map(|c| font.get_char_advance_for(c) as i32)
+            .sum();
         let x_offset: i32 = if max_width > 0 {
             match alignment_key.as_str() {
                 "center" => ((max_width - line_w) / 2).max(0),
@@ -104,12 +109,19 @@ fn draw_text_selection_rects(
         } else {
             0
         };
+        // `start` and `end` are absolute byte indices into `text` (sel_lo /
+        // sel_hi clamped to this line). Subtract `line.start` to get a
+        // byte offset into `line.text`, snap any non-boundary positions
+        // forward, then slice and walk chars.
         let advance_for = |start: usize, end: usize| -> i32 {
-            let s = start.saturating_sub(line.start).min(line.text.len());
-            let e = end.saturating_sub(line.start).min(line.text.len());
-            line.text.as_bytes()[s..e]
-                .iter()
-                .map(|&b| font.get_char_advance(b) as i32)
+            let mut s = start.saturating_sub(line.start).min(line.text.len());
+            let mut e = end.saturating_sub(line.start).min(line.text.len());
+            while s < line.text.len() && !line.text.is_char_boundary(s) { s += 1; }
+            while e < line.text.len() && !line.text.is_char_boundary(e) { e += 1; }
+            if e < s { return 0; }
+            line.text[s..e]
+                .chars()
+                .map(|c| font.get_char_advance_for(c) as i32)
                 .sum()
         };
         let y = base_y + (i as i32) * line_h;

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -4994,14 +4994,18 @@ impl WebGL2Renderer {
                     let mut x = start_x;
                     let mut char_i: usize = 0;
                     for ch in line.chars() {
-                        let adv = font.get_char_advance(ch as u8) as i32;
+                        let adv = font.get_char_advance_for(ch) as i32;
                         if ch == ' ' {
                             x += adv;
                             char_i += 1;
                             continue;
                         }
 
-                        let mut glyph_code = ch as u8;
+                        // Win-1252 glyph slot for `ch` -- a plain `as u8`
+                        // truncates higher codepoints like € (U+20AC) to
+                        // the wrong byte (0xAC = ¬), so use the proper
+                        // reverse map. ASCII pass-through is preserved.
+                        let mut glyph_code = crate::io::encoding::glyph_byte_for(ch);
                         if force_uppercase_fallback && ch.is_ascii_lowercase() {
                             let lower = ch as u8;
                             let upper = lower.saturating_sub(32);
@@ -5487,10 +5491,16 @@ impl WebGL2Renderer {
                         let run_start_x = x;
 
                         for ch in run.text.chars() {
+                            // Map Unicode char -> Win-1252 atlas slot before
+                            // looking up glyph width/cell. `c as u8` truncates
+                            // codepoints like € (U+20AC=0x20AC) to 0xAC, so the
+                            // renderer would pull the wrong glyph from the
+                            // atlas.
+                            let glyph_b = crate::io::encoding::glyph_byte_for(ch);
                             let advance = if span_is_default_size {
-                                font.get_char_advance(ch as u8) as i32
+                                font.get_char_advance(glyph_b) as i32
                             } else {
-                                ((font.get_char_advance(ch as u8) as i32) * span_scale_num / span_scale_den)
+                                ((font.get_char_advance(glyph_b) as i32) * span_scale_num / span_scale_den)
                                     .max(1)
                             };
 
@@ -5509,15 +5519,15 @@ impl WebGL2Renderer {
                             let draw_glyph = |dest: &mut Bitmap, dx: i32| {
                                 if italic_default_size {
                                     bitmap_font_copy_char_italic(
-                                        &font, font_bitmap, ch as u8, dest, dx, y, &palettes, &run_params,
+                                        &font, font_bitmap, glyph_b, dest, dx, y, &palettes, &run_params,
                                     );
                                 } else if span_is_default_size {
                                     bitmap_font_copy_char(
-                                        &font, font_bitmap, ch as u8, dest, dx, y, &palettes, &run_params,
+                                        &font, font_bitmap, glyph_b, dest, dx, y, &palettes, &run_params,
                                     );
                                 } else {
                                     bitmap_font_copy_char_scaled(
-                                        &font, font_bitmap, ch as u8, dest, dx, y,
+                                        &font, font_bitmap, glyph_b, dest, dx, y,
                                         char_w, char_h, &palettes, &run_params,
                                     );
                                 }

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -5915,7 +5915,14 @@ impl WebGL2Renderer {
                     // returns the start of the next line for byte indices that
                     // sit at a soft-wrap boundary, which makes a multi-line
                     // selection's right edge on line N collapse onto line N+1.
-                    let line_w: i32 = line.text.bytes().map(|b| font.get_char_advance(b) as i32).sum();
+                    // Walk chars, not bytes. Each visible character is one
+                    // glyph advance regardless of UTF-8 byte length; the
+                    // earlier byte-iteration variant gave umlauts 2x width
+                    // and stretched the selection-highlight past the end
+                    // of the actual text.
+                    let line_w: i32 = line.text.chars()
+                        .map(|c| font.get_char_advance_for(c) as i32)
+                        .sum();
                     let x_offset: i32 = if caret_max_width > 0 {
                         match alignment_key.as_str() {
                             "center" => ((caret_max_width - line_w) / 2).max(0),
@@ -5926,11 +5933,14 @@ impl WebGL2Renderer {
                         0
                     };
                     let advance_for = |start: usize, end: usize| -> i32 {
-                        let s = start.saturating_sub(line.start).min(line.text.len());
-                        let e = end.saturating_sub(line.start).min(line.text.len());
-                        line.text.as_bytes()[s..e]
-                            .iter()
-                            .map(|&b| font.get_char_advance(b) as i32)
+                        let mut s = start.saturating_sub(line.start).min(line.text.len());
+                        let mut e = end.saturating_sub(line.start).min(line.text.len());
+                        while s < line.text.len() && !line.text.is_char_boundary(s) { s += 1; }
+                        while e < line.text.len() && !line.text.is_char_boundary(e) { e += 1; }
+                        if e < s { return 0; }
+                        line.text[s..e]
+                            .chars()
+                            .map(|c| font.get_char_advance_for(c) as i32)
                             .sum()
                     };
                     let mut left = x_offset + advance_for(line.start, from);


### PR DESCRIPTION
fixes #131 

cb0aa5f text: selection + caret math agrees with the renderer on multibyte text
ea096bf input: type umlauts and AltGr characters in editable fields
7fab2e5 text: Unicode-safe bitmap font pipeline (codepoint mapping + char-aware layout)
9c1b894 font: rasterize the full Win-1252 atlas (256 cells) instead of ASCII-only
3364374 text: decode HTTP and FileIO responses with UTF-8-strict then Win-1252 fallback
7d75357 text: decode Director chunks as Windows-1252 instead of from_utf8_lossy