### PR TITLE
supporting tennis game "15_love"

### DIFF
--- a/vm-rust/lingo.pest
+++ b/vm-rust/lingo.pest
@@ -160,11 +160,34 @@ set_statement = { ^"set" ~ expr ~ ^"to" ~ expr }
 // Delete statement: "delete char 1 of s", "delete word 3 of myStr"
 delete_statement = { ^"delete" ~ chunk_expr }
 
+// Lingo "go" command. "to", "frame", and "movie" are syntactic noise; only
+// the destination value (and optional movie path) need to reach the
+// handler. Accepts: "go", "go N", "go "label"", "go to "label"",
+// "go to frame N", "go frame N of movie "path"", "go to N of movie "path"".
+// Skipped when followed by "(" so go(...) still parses as a normal
+// handler_call.
+//
+// Each keyword is an atomic rule so the word-boundary lookahead is checked
+// adjacent to the keyword (in a non-atomic context pest's implicit
+// WHITESPACE would be eaten between the keyword and the lookahead, making
+// it always pass).
+go_kw      = @{ ^"go"    ~ !(alpha | digit | "_") }
+go_to_kw   = @{ ^"to"    ~ !(alpha | digit | "_") }
+go_frame_kw = @{ ^"frame" ~ !(alpha | digit | "_") }
+go_movie_kw = @{ ^"movie" ~ !(alpha | digit | "_") }
+go_of_kw   = @{ ^"of"    ~ !(alpha | digit | "_") }
+go_inline = {
+    go_kw ~ !(WHITESPACE* ~ "(")
+    ~ go_to_kw?
+    ~ go_frame_kw?
+    ~ (term_arg ~ (go_of_kw ~ go_movie_kw? ~ term_arg)?)?
+}
+
 // Assignment can be to any expression (identifier, property access, list index, etc.)
 // The parser will validate that the left side is a valid lvalue
 assignment_expr = { term ~ (obj_prop ~ (prop_name | term) | list_index)* }
 assignment = { assignment_expr ~ "=" ~ expr }
-command    = _{ set_statement | delete_statement | assignment | put_statement | command_inline | expr }
+command    = _{ set_statement | delete_statement | assignment | put_statement | go_inline | command_inline | expr }
 obj_prop   =  { "." }
 add        =  { "+" }
 subtract   =  { "-" }

--- a/vm-rust/src/director/chunks/score.rs
+++ b/vm-rust/src/director/chunks/score.rs
@@ -1185,7 +1185,7 @@ impl ScoreChunk {
                 ScoreFrameData::default()
             };
 
-            let frame_intervals = Self::analyze_behavior_attachment_entries(&entries)?;
+            let frame_intervals = Self::analyze_behavior_attachment_entries(&entries, dir_version)?;
             let sprite_details = Self::parse_sprite_details_from_entries(&entries);
 
             Ok(ScoreChunk {
@@ -1583,6 +1583,7 @@ impl ScoreChunk {
     /// Analyze score entries beyond Entry[0] for behavior attachment data
     fn analyze_behavior_attachment_entries(
         entries: &Vec<Vec<u8>>,
+        dir_version: u16,
     ) -> Result<Vec<(FrameIntervalPrimary, Option<FrameIntervalSecondary>)>, String> {
         let mut results = vec![];
         let mut i = 2; // Start at 2, skip entries 0 and 1
@@ -1615,10 +1616,21 @@ impl ScoreChunk {
                 continue;
             }
 
+            // Primary entries: 40 bytes base (5 x u32 fields + 20-byte
+            // TweenInfo) plus zero or more trailing u32s of authored
+            // keyframe indices. v8.0 movies only ever produce 40/44/48
+            // byte primaries (0-2 trailing keyframes); v8.5+ adds a
+            // 52-byte size for spans with 3 trailing keyframes (where
+            // path tweens with authored interior keyframes live —
+            // sprite 2 / sprites 41-42 of 15love_hs). Accepting 52+
+            // unconditionally previously over-matched non-primary
+            // chunks in Junkbot (v8.0), so we gate the wider sizes
+            // strictly on movie version.
+            let accept_extended = dir_version >= 850;
+            let size_accepted = matches!(entry_bytes.len(), 40 | 44 | 48)
+                || (accept_extended && entry_bytes.len() == 52);
             match entry_bytes.len() {
-                // Primary entries: 40 bytes base (10 x u32) + optional trailing data.
-                // D6/D7 typically produce 44 bytes, D8+ may produce 40 or 48.
-                40 | 44 | 48 => {
+                _ if size_accepted => {
                     // Primary entry
                     let mut reader = BinaryReader::from_u8(entry_bytes);
                     reader.set_endian(Endian::Big);
@@ -1671,7 +1683,11 @@ impl ScoreChunk {
                             // cast_lib/cast_member.  If the first u32 looks like a valid
                             // start_frame (1–10000) and the second u32 >= first, treat it as a
                             // primary rather than a behavior list.
-                            let looks_like_primary = if (next_size == 40 || next_size == 44 || next_size == 48) && next_size >= 8 {
+                            let primary_size_match = next_size == 40
+                                || next_size == 44
+                                || next_size == 48
+                                || (accept_extended && next_size == 52);
+                            let looks_like_primary = if primary_size_match && next_size >= 8 {
                                 let b = &entries[j];
                                 let first_u32 = u32::from_be_bytes([b[0], b[1], b[2], b[3]]);
                                 let second_u32 = u32::from_be_bytes([b[4], b[5], b[6], b[7]]);

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -841,6 +841,18 @@ pub fn parse_lingo_rule_runtime(
 
             Ok(LingoExpr::HandlerCall("put".to_string(), args))
         }
+        Rule::go_inline => {
+            // Skip the syntactic-noise keyword nodes (go/to/frame/of/movie).
+            // First term_arg is the destination, second (if any) is the
+            // movie path.
+            let mut args = vec![];
+            for child in pair.into_inner() {
+                if let Rule::term_arg = child.as_rule() {
+                    args.push(parse_lingo_rule_runtime(child, pratt)?);
+                }
+            }
+            Ok(LingoExpr::HandlerCall("go".to_owned(), args))
+        }
         Rule::handler_call | Rule::command_inline => {
             let mut inner = pair.into_inner();
             let handler_name_pair = inner.next().ok_or_else(|| ScriptError::new("Expected handler name".to_string()))?;

--- a/vm-rust/src/player/handlers/datum_handlers/int.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/int.rs
@@ -32,6 +32,7 @@ impl IntDatumHandlers {
             }
             "string" => Ok(player.alloc_datum(Datum::String(int_value.to_string()))),
             "magnitude" => Ok(player.alloc_datum(Datum::Int(int_value.abs()))),
+            "sprite" => Ok(player.alloc_datum(Datum::SpriteRef(int_value as i16))),
             _ => Err(ScriptError::new(format!(
                 "Cannot get int property {}",
                 prop

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -3622,9 +3622,17 @@ pub async fn run_single_frame() -> (bool, bool) {
             (player.has_frame_changed_in_go, player.go_same_frame));
 
         if go_same_frame {
-            // go(the frame) — stay on current frame, no advancement
+            // go(the frame) — stay on current frame, no advancement.
+            // Clear next_frame too: the go() handler sets it to Some(current)
+            // when it sets go_same_frame, and if we don't clear it here the
+            // stale value leaks into the next tick. On a subsequent tick where
+            // no go() is called the main loop would otherwise hit the "normal
+            // advance" path and feed the stale next_frame into advance_frame,
+            // pinning the playhead to the previously-go'd frame even though
+            // the script wanted to fall through.
             reserve_player_mut(|player| {
                 player.go_same_frame = false;
+                player.next_frame = None;
             });
             stayed_on_same_frame = true;
         } else if has_frame_changed {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -195,15 +195,24 @@ pub fn get_channel_number_from_index(index: u32) -> u32 {
 }
 
 /// Convert raw blend byte from score data to a 0-100 percentage.
-/// D8+ uses inverted 0-255 scale: 0 → 100% (opaque), 255 → 0% (transparent).
+/// D8+ uses inverted 0-255 scale: 0 → 100% (opaque), 255 → 0% (transparent
+/// / default not-set, treated as opaque).
 /// D5-D7 uses direct 0-100 percentage: 0 → 100% (opaque/not set).
+///
+/// Director quirk: both extremes of the score byte (0 AND 255) are treated
+/// as "default opaque" at render time. A v850 sprite authored without an
+/// explicit blend has raw=255, which our Lingo getter would otherwise
+/// report as `the blend = 0` and our renderer would draw at 0% alpha —
+/// invisible. Director's runtime instead skips blending entirely when the
+/// score byte is 0 or 255 and only applies blend for intermediate values.
+/// We mirror that by mapping raw=255 to 100% so the sprite renders
+/// normally. Scripts that need a sprite hidden should use `the visibility
+/// of sprite` (or set blend to a small non-zero value, matching Director).
 pub(crate) fn convert_raw_blend(raw: u8, dir_version: u16) -> i32 {
     if dir_version > 600 {
-        // D8+: inverted 0-255 scale
-        if raw == 0 {
+        // D8+: inverted 0-255 scale, both 0 and 255 are "default opaque"
+        if raw == 0 || raw == 255 {
             100
-        } else if raw == 255 {
-            0
         } else {
             ((255.0 - raw as f32) * 100.0 / 255.0) as i32
         }

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -3526,10 +3526,10 @@ fn sprite_set_prop_is_noop(
                     Ok(sprite.loc_h == x && sprite.loc_v == y)
                 }
                 Datum::Void => Ok(true),
-                _ => Err(ScriptError::new(format!(
-                    "loc must be a Point (received {})",
-                    value.type_str()
-                ))),
+                // Mirror the assignment path: silently ignore type-mismatched
+                // values so a value-equality check on a never-applied
+                // assignment doesn't error.
+                _ => Ok(false),
             },
             "rect" => {
                 let rect_values = match value {
@@ -4053,10 +4053,16 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                         })
                     }
                     Datum::Void => Ok(()), // no-op
-                    _ => Err(ScriptError::new(format!(
-                        "loc must be a Point (received {})",
-                        value.type_str()
-                    ))),
+                    // Director silently ignores type-mismatched assignments
+                    // here (e.g. `sprite.loc = 116`, a known script typo for
+                    // `.locV`). Mirror that — warn but keep the game running.
+                    _ => {
+                        log::warn!(
+                            "Ignoring sprite {} loc assignment with non-Point value ({})",
+                            sprite_id, value.type_str()
+                        );
+                        Ok(())
+                    }
                 }
             },
         ),

--- a/vm-rust/src/player/score_keyframes.rs
+++ b/vm-rust/src/player/score_keyframes.rs
@@ -1312,9 +1312,14 @@ impl SpritePathKeyframes {
             .map(|i| (i.start_frame, i.end_frame))
             .collect();
 
-        // Process each interval
+        // Process each interval independently. The score's per-interval
+        // primary record carries the start_frame/end_frame for that
+        // tween span and (for 52+ byte primaries on v8.5+) the explicit
+        // authored keyframe indices. For 40/44/48-byte primaries the
+        // span has only its endpoint keyframes — `collect_property_keyframes`
+        // picks those up from the first/last entries in frame_channel_data.
         for interval in intervals {
-            // Ignore single-frame intervals
+            // Ignore single-frame intervals (can't tween in zero time)
             if interval.start_frame == interval.end_frame {
                 continue;
             }
@@ -1327,7 +1332,7 @@ impl SpritePathKeyframes {
             let start_frame = interval.start_frame;
             let end_frame = interval.end_frame;
 
-            // 1️⃣ Collect frames in Director frame range AND matching this channel
+            // Collect frames in Director frame range AND matching this channel
             let frames: Vec<_> = frame_channel_data
                 .iter()
                 .filter(|(frame_num, ch, _)| {
@@ -1342,7 +1347,7 @@ impl SpritePathKeyframes {
                 continue;
             }
 
-            // 2️⃣ Deduplicate by frame number (shouldn't be needed now, but keep for safety)
+            // Deduplicate by frame number (shouldn't be needed now, but keep for safety)
             let mut dedup: HashMap<u32, &(u32, u16, ScoreFrameChannelData)> = HashMap::new();
 
             for frame in frames {
@@ -1353,20 +1358,12 @@ impl SpritePathKeyframes {
             let mut sorted_frames: Vec<_> = dedup.into_iter().map(|(_, v)| v.clone()).collect();
             sorted_frames.sort_by_key(|(frame_num, _, _)| *frame_num);
 
-            // 3️⃣ Only treat as a real path tween if the span has at least one
-            // non-zero authored keyframe index in its trailing u32 list.
-            // See size-tween gate for details on why the single `0` padding
-            // u32 doesn't count as an authored keyframe.
-            if !interval.key_frames.iter().any(|&f| f != 0) {
-                continue;
-            }
-
-            // 4️⃣ Check if position ACTUALLY animates in this interval
+            // Check if position ACTUALLY animates in this interval
             if !has_real_animation::<Position>(&sorted_frames) {
                 continue;
             }
 
-            // 5️⃣ Collect effective keyframes for this interval
+            // Collect effective keyframes for this interval
             let property_frames = collect_property_keyframes::<Position>(&sorted_frames);
             // TODO: research if this is correct when, yes change also
             // other tweening properties to 1-based Director frame


### PR DESCRIPTION
fixes #120 

cb5ab9f score: parse 52-byte sprite-span primaries on v8.5+
3542be4 score: silently ignore type-mismatched sprite.loc assignments
f8cfa29 score: treat raw blend byte 255 as opaque on v8.0+
269b549 score: clear stale next_frame after go(the frame)
cf6d563 lingo: int.sprite namespace property returns SpriteRef
5cd9198 lingo: parse "go to" and "go to frame N" command forms

e2e test can follow as soon the game files have been uploaded