### PR TITLE
supporting story scramble movie

### DIFF
--- a/dirplayer-js-api/index.d.ts
+++ b/dirplayer-js-api/index.d.ts
@@ -52,8 +52,8 @@ type TVmCallbacks = {
   onChannelChanged: (channelNumber: number, channelData: ScoreSpriteSnapshot) => void,
   onChannelDisplayNameChanged: (channelNumber: number, displayName: string) => void,
   onExternalEvent?: (event: string) => void,
-  onFlashMemberLoaded?: (castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number) => void,
-  onFlashMemberUnloaded?: (castLib: number, castMember: number) => void,
+  onFlashMemberLoaded?: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean) => void,
+  onFlashMemberUnloaded?: (spriteNum: number) => void,
   onStageSizeChanged?: (width: number, height: number, center: boolean) => void,
 }
 declare let vmCallbacks: TVmCallbacks | undefined;

--- a/dirplayer-js-api/index.js
+++ b/dirplayer-js-api/index.js
@@ -103,19 +103,19 @@ export function onExternalEvent(event) {
   }
 }
 
-export function onFlashMemberLoaded(castLib, castMember, swfData, width, height) {
+export function onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart) {
   if (vmCallbacks?.onFlashMemberLoaded) {
-    vmCallbacks.onFlashMemberLoaded(castLib, castMember, swfData, width, height);
+    vmCallbacks.onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart);
   } else {
-    console.log('Flash member loaded:', castLib, castMember, width, height, swfData.length, 'bytes');
+    console.log('Flash member loaded:', 'sprite#' + spriteNum, castLib, castMember, width, height, swfData.length, 'bytes', 'pausedAtStart=' + pausedAtStart);
   }
 }
 
-export function onFlashMemberUnloaded(castLib, castMember) {
+export function onFlashMemberUnloaded(spriteNum) {
   if (vmCallbacks?.onFlashMemberUnloaded) {
-    vmCallbacks.onFlashMemberUnloaded(castLib, castMember);
+    vmCallbacks.onFlashMemberUnloaded(spriteNum);
   } else {
-    console.log('Flash member unloaded:', castLib, castMember);
+    console.log('Flash member unloaded: sprite#' + spriteNum);
   }
 }
 

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -4,9 +4,9 @@
  * Manages Ruffle player instances for Flash cast members, reads rendered frames,
  * and sends pixel data to dirplayer's WASM rendering pipeline so Flash content
  * can be composited with Director sprites (Director sprites can layer on top).
- */
+ */ 
 
-import { update_flash_frame, trigger_lingo_callback_on_script } from 'vm-rust';
+import { update_flash_frame, trigger_lingo_callback_on_script, dispatch_flash_event } from 'vm-rust';
 import {
   isBridgeRequired,
   waitForBridge,
@@ -17,7 +17,8 @@ import {
 } from './ruffleBridgeClient';
 
 interface FlashInstance {
-  castLib: number;
+  spriteNum: number;     // Director sprite number this instance belongs to
+  castLib: number;       // SWF source cast member (diagnostics + cleanup)
   castMember: number;
   rufflePlayer: any; // RufflePlayerElement (direct) or stub element (bridge mode)
   bridgeId: string | null; // Set when this instance is driven by the main-world bridge
@@ -26,9 +27,25 @@ interface FlashInstance {
   width: number;
   height: number;
   animFrameId: number | null;
+  /// Becomes true only after the SWF has loaded AND the 3s AS init wait
+  /// has elapsed AND the inheritance/queue replay has finished. Lingo
+  /// calls (goTo / play / stop / rewind) that arrive before this is
+  /// true are queued instead of going to the half-initialised player.
+  ready: boolean;
+  /// Mirrors the Director Flash member property of the same name.
+  /// When true we pass `autoplay: 'off'` to Ruffle's loadConfig (so
+  /// the SWF stays parked at frame 1 instead of running), AND the
+  /// queue flush re-fires any queued `play` op — because nothing is
+  /// playing automatically and Lingo's `play(sprite)` is required to
+  /// actually start the SWF. When false, autoplay covers it and the
+  /// queued `play` op is a redundant restart we skip.
+  pausedAtStart: boolean;
 }
 
-// Map of "castLib:castMember" -> FlashInstance
+// Per-sprite Flash instance map. Each Flash sprite gets its own Ruffle
+// player so multiple sprites that share a single Flash cast member can
+// display different frames simultaneously (e.g. storyscramble's 3 story
+// tiles all use cast 2:1 but show poster frames 2/4/6).
 const instances = new Map<string, FlashInstance>();
 
 // Track pending Flash instance creations so the WASM frame loop can wait for them
@@ -46,12 +63,9 @@ function getFetchRewriteRules(): Array<{pathPrefix: string, targetHost: string, 
   if (win.__dirplayerFlashConfig?.fetchRewriteRules) {
     return win.__dirplayerFlashConfig.fetchRewriteRules;
   }
-  // Local dev fallback — when running against the local dev proxy
-  // (`127.0.0.1:3456`), rewrite Flash AMF gateway requests so the
-  // SWF's relative `/sf/*` POST goes there instead of the dev server.
-  // Production deployments populate
-  // `window.__dirplayerFlashConfig.fetchRewriteRules` via the polyfill's
-  // `configureFlash()` API and never hit this fallback.
+  // Production: host page provides rewrite rules via
+  // `__dirplayerFlashConfig.fetchRewriteRules` (set by `configureFlash`).
+  // Without any, fetch goes direct to the original URL.
   return [];
 }
 
@@ -112,15 +126,132 @@ const origGetContext = HTMLCanvasElement.prototype.getContext;
 
 function getSocketProxyConfig(): Array<{host: string, port: number, proxyUrl: string}> {
   const win = window as any;
-  if (win.__dirplayerFlashConfig?.socketProxy) {
-    return win.__dirplayerFlashConfig.socketProxy;
-  }
-  // Local dev fallback
-  return [];
+  return (win.__dirplayerFlashConfig?.socketProxy as
+    | Array<{ host: string; port: number; proxyUrl: string }>
+    | undefined) ?? [];
 }
 
-function instanceKey(castLib: number, castMember: number): string {
-  return `${castLib}:${castMember}`;
+// Install the global socket-URL resolver immediately so the WASM-side
+// Multiuser Xtra (which calls `window.dirplayerResolveSocketUrl`) finds
+// it even when the host page doesn't call `configureFlashManager`.
+// Re-evaluates `getSocketProxyConfig` on every call so dev defaults +
+// runtime-supplied entries both stay live.
+(window as any).dirplayerResolveSocketUrl = (host: string, port: number): string => {
+  const proxies = getSocketProxyConfig();
+  for (const entry of proxies) {
+    if (entry.host.toLowerCase() === host.toLowerCase() && entry.port === port) {
+      return entry.proxyUrl;
+    }
+  }
+  return "";
+};
+
+// Each Flash sprite has its own Ruffle instance — keyed by the Director
+// sprite number. Sprite numbers are unique within a movie so castLib /
+// castMember don't need to be part of the key.
+function instanceKey(spriteNum: number): string {
+  return `${spriteNum}`;
+}
+
+/**
+ * Forward a Director sprite mouse event into a Ruffle player so the SWF's
+ * own AS1 button handlers (`on (press)` / `on (release)`) actually run.
+ *
+ * Ruffle's canvas lives in a hidden container at `left: -9999px`, so real
+ * browser clicks never reach it — meaning AS1 button handlers (which fire
+ * on pointer events the Flash player receives) never run. Director still
+ * sees the click on its stage and resolves the Flash sprite; we then
+ * synthesise PointerEvents on the Ruffle canvas so the SWF processes the
+ * click as if it had been delivered natively.
+ *
+ * Coordinates are sprite-local (origin at the sprite's top-left in stage
+ * coords). They're rebased to canvas client coords here so Ruffle's input
+ * code computes the correct Flash-stage position.
+ */
+function dispatchMouseEvent(
+  spriteNum: number,
+  type: 'down' | 'up' | 'move',
+  localX: number,
+  localY: number,
+): boolean {
+  const inst = instances.get(instanceKey(spriteNum));
+  if (!inst) {
+    console.warn(`[Flash mouse] no instance for sprite#${spriteNum}; known=`,
+      Array.from(instances.keys()));
+    return false;
+  }
+
+  let canvasX = localX;
+  let canvasY = localY;
+  if (inst.canvas) {
+    const rect = inst.canvas.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      canvasX = (localX / rect.width) * inst.canvas.width;
+      canvasY = (localY / rect.height) * inst.canvas.height;
+    }
+  }
+
+  const player = inst.rufflePlayer as
+    | { dirplayer_dispatchPointer?: (t: string, x: number, y: number) => boolean }
+    | undefined;
+  if (typeof player?.dirplayer_dispatchPointer !== 'function') {
+    console.warn(`[Flash mouse] sprite#${spriteNum} player has no dirplayer_dispatchPointer; ` +
+      `bridgeId=${inst.bridgeId}, player keys=`, player ? Object.keys(player as object) : 'no player');
+    return false;
+  }
+  return !!player.dirplayer_dispatchPointer(type, canvasX, canvasY);
+}
+
+/**
+ * Forward a Flash `event: …` URL body into Director's event chain.
+ *
+ * Director's Flash Asset Xtra intercepts `getURL("event: …")` (e.g. the
+ * storyscramble bubble's `getURL("event: send #done", "")` at frame 11
+ * and frame 21) and routes the body into the host movie's event chain.
+ * Returns true if the body was understood and dispatched.
+ *
+ * Also exposed as `window.dirplayer_dispatchFlashEvent` so the chain can
+ * be hand-fired from DevTools while debugging.
+ */
+export function dispatchFlashEvent(castLib: number, castMember: number, body: string): boolean {
+  try {
+    return dispatch_flash_event(castLib, castMember, body);
+  } catch (e) {
+    console.warn('[Flash] dispatchFlashEvent error:', e);
+    return false;
+  }
+}
+
+/**
+ * Register an open-URL handler on a Ruffle player so `getURL("event: …")`
+ * is routed into Director instead of being denied. Requires the dirplayer
+ * Ruffle fork's `dirplayer_addOpenUrlHandler` patch; until it lands the
+ * call is a no-op and navigations stay denied via `openUrlMode: 'deny'`.
+ */
+function registerEventUrlHandler(player: any, castLib: number, castMember: number): void {
+  if (typeof player?.dirplayer_addOpenUrlHandler !== 'function') {
+    console.warn(
+      `[Flash] ${castLib}:${castMember}: dirplayer_addOpenUrlHandler missing on Ruffle player — ` +
+      `event:URLs from the SWF will be denied. ` +
+      `Use window.dirplayer_dispatchFlashEvent(${castLib}, ${castMember}, "send #done") to fire dispatch manually.`
+    );
+    return;
+  }
+  player.dirplayer_addOpenUrlHandler((url: string, _target: string): boolean => {
+    if (typeof url !== 'string' || !url.startsWith('event:')) {
+      return false; // not ours — let Ruffle's openUrlMode decide
+    }
+    const body = url.slice('event:'.length).trim();
+    const handled = dispatchFlashEvent(castLib, castMember, body);
+    if (!handled) {
+      console.warn(
+        `[Flash] ${castLib}:${castMember}: unrecognised event URL body: ${JSON.stringify(body)}`
+      );
+    }
+    // Always swallow the navigation: even an unrecognised event:URL must
+    // not open a popup. Director silently ignores malformed event: bodies.
+    return true;
+  });
 }
 
 /**
@@ -149,7 +280,7 @@ async function loadRuffle(): Promise<any> {
       return ruffle;
     }
 
-    throw new Error('dirplayer Ruffle fork not found. Ensure ruffle.js is loaded via a script tag.');
+    throw new Error('dirplayer Ruffle fork not found. Ensure dirplayer_ruffle.js is loaded via a script tag.');
   })();
 
   return rufflePromise;
@@ -171,17 +302,20 @@ function isFlashDisabled(): boolean {
 }
 
 /**
- * Create a Ruffle player instance for a Flash cast member.
- * The player renders to a hidden container; frames are read back and sent to WASM.
+ * Create a Ruffle player instance for a specific Flash sprite.
+ * Each sprite gets its own player so multiple sprites that share a single
+ * Flash cast member can display different frames simultaneously.
  */
 export async function createFlashInstance(
+  spriteNum: number,
   castLib: number,
   castMember: number,
   swfData: Uint8Array,
   width: number,
   height: number,
+  pausedAtStart: boolean = false,
 ): Promise<void> {
-  const key = instanceKey(castLib, castMember);
+  const key = instanceKey(spriteNum);
 
   // Skip when Flash is explicitly disabled by the host. The Lingo
   // bridge functions all early-return on missing instance, so the
@@ -194,8 +328,57 @@ export async function createFlashInstance(
     return;
   }
 
-  // Destroy existing instance if any
-  destroyFlashInstance(castLib, castMember);
+  // Capture the about-to-die instance's current frame BEFORE destroy so
+  // we can carry it across a member change. storyscramble does
+  // `gotoFrame(sprite 2, 31)` in BS38 while sprite 2 holds member 1:31;
+  // when the scene change swaps sprite 2 to member 1:45 (bubble) we
+  // destroy the old instance and have no record of frame 31. Stash it
+  // here keyed by sprite number, then check below after sibling
+  // inheritance. Mimics Director's per-sprite frame property which
+  // survives member swaps.
+  const priorIntendedFrame: number | null = (() => {
+    const prior = instances.get(key);
+    if (!prior) return null;
+    try {
+      const f = parseInt(prior.rufflePlayer.GetVariable?.('/:_currentframe') || '0', 10);
+      return f >= 1 ? f : null;
+    } catch { return null; }
+  })();
+
+  // Destroy existing instance for this sprite if any.
+  destroyFlashInstance(spriteNum);
+
+  // Playhead inheritance — preserve Director's "Flash member state is
+  // shared across sprites using that member" semantic the old cast-keyed
+  // architecture used to give us for free. With per-sprite instances,
+  // sprite 2 in storyscramble's main scene would spin up a fresh Ruffle
+  // player and autoplay the bubble SWF (1:45) from frame 1→11, hiding
+  // the frame-21 state sprite 17 already advanced it to. Scan live
+  // siblings here for the same member and capture their current frame;
+  // we'll seed the new instance to that frame in the finally block
+  // below, after the SWF has loaded and AS initialisation finishes.
+  let inheritedFrame: number | null = null;
+  const siblings = Array.from(instances.values());
+  for (const sibling of siblings) {
+    if (sibling.castLib === castLib && sibling.castMember === castMember) {
+      try {
+        const cur = parseInt(
+          sibling.rufflePlayer.GetVariable?.('/:_currentframe') || '0', 10
+        );
+        if (cur >= 1) {
+          inheritedFrame = cur;
+          break;
+        }
+      } catch { /* getVariable failed (bridge mode etc.) — fall through to autoplay */ }
+    }
+  }
+
+  // Per-sprite intent wins over sibling inheritance: if BS38 set this
+  // sprite to frame N before the member changed, the new member should
+  // also land at frame N (Director's per-sprite frame attribute).
+  if (priorIntendedFrame !== null) {
+    inheritedFrame = priorIntendedFrame;
+  }
 
   flashLoadingCount++;
   console.log(`[Flash] Instance ${key} creation started (pending: ${flashLoadingCount})`);
@@ -243,6 +426,7 @@ export async function createFlashInstance(
   }
 
   const instance: FlashInstance = {
+    spriteNum,
     castLib,
     castMember,
     rufflePlayer: player,
@@ -252,6 +436,8 @@ export async function createFlashInstance(
     width,
     height,
     animFrameId: null,
+    ready: false,
+    pausedAtStart,
   };
 
   instances.set(key, instance);
@@ -291,10 +477,28 @@ export async function createFlashInstance(
     data: actualSwfData,
     allowScriptAccess: true,
     openUrlMode: 'deny',
+    // Always autoplay. Tried gating this on `pausedAtStart` (so the
+    // SWF would load paused at frame 1 like Director's docs suggest),
+    // but Ruffle's `autoplay: 'off'` leaves the player in a preroll
+    // state where `_currentframe` reads 0 and `GotoFrame(N, …)` has
+    // no effect until something kicks the SWF — which broke tile
+    // poster-frame pinning AND the bubble's frame-31 seed. The
+    // microtask pin in `applyGotoAndPin` already keeps tiles from
+    // cycling visibly, so we don't need to suppress autoplay to fix
+    // that. We still track `pausedAtStart` on the instance for the
+    // queue-flush `play` heuristic below.
     autoplay: 'on',
     unmuteOverlay: 'hidden',
     logLevel: 'info',
     splashScreen: false,
+    // Transparent stage so SWFs that layer over other Director sprites
+    // (mello's fire/marshmello/stick) composite correctly. The downside:
+    // SWFs that bake their stage color in (e.g. storyscramble's chat
+    // bubble's white interior) lose that fill — Director would normally
+    // overlay member.bgColor + handle ink modes (especially ink 36
+    // "Background Transparent") to manage transparency. Our renderer
+    // takes over those responsibilities on the dirplayer side; this
+    // wmode just makes the Ruffle canvas itself transparent-where-empty.
     wmode: 'transparent',
     renderer: 'canvas',  // Force Canvas2D so we can read pixels back
     socketProxy: getSocketProxyConfig(),
@@ -307,6 +511,35 @@ export async function createFlashInstance(
     const ruffleInstance = player.ruffle();
     await ruffleInstance.load(loadConfig);
   }
+
+  // Honour Director's `pausedAtStart` Flash member property.
+  // Ruffle's own `autoplay: 'off'` leaves the SWF in a preroll state
+  // where `_currentframe=0` and `GotoFrame` is a no-op, so we keep
+  // autoplay on for SWF initialisation — then immediately pin the
+  // MovieClip at frame 1 (rendered + stopped) so it doesn't visibly
+  // cycle during the 3-second AS-init wait below. Subsequent Lingo
+  // `mySprite.play()` (via playFlash) unsticks it normally.
+  if (pausedAtStart) {
+    try {
+      // Two-step pin: gotoAndPlay so Ruffle paints frame 1, wait one
+      // browser RAF so the paint lands on the canvas, then gotoAndStop
+      // to halt the MovieClip. Mirrors applyGotoAndPin's strategy
+      // (Ruffle skips paint for already-stopped MovieClips).
+      player.GotoFrame(1, false);
+      await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+      player.GotoFrame(1, true);
+    } catch (e) {
+      console.warn(`[Flash] Instance ${key} pausedAtStart pin failed:`, e);
+    }
+  }
+
+  // Director's Flash Asset Xtra intercepts `getURL("event: …")` and routes
+  // the body into the host movie's event chain (e.g. `event: send #done`
+  // fires the `done` handler). Register the handler speculatively — when
+  // the Ruffle-fork patch is present, navigations whose URL starts with
+  // `event:` get routed into dispatch_flash_event and the real open is
+  // suppressed. Otherwise it's a safe no-op.
+  registerEventUrlHandler(player, castLib, castMember);
 
   // Find the internal canvas element that Ruffle renders to
   await new Promise<void>((resolve) => {
@@ -335,6 +568,40 @@ export async function createFlashInstance(
     flashLoadingCount--;
     flashAccessBeforeReady = false;
     console.log(`[Flash] Instance ${key} fully ready (pending: ${flashLoadingCount})`);
+
+    // Seed the new instance with the frame captured from a sibling
+    // sprite using the same member (see scan above). Bubbles in
+    // storyscramble's main scene rely on this — sprite 2 picks up
+    // sprite 17's frame-21 state instead of autoplaying back to 11.
+    //
+    // By the time this runs (3s after instance creation), the SWF has
+    // already autoplayed 1→11 and AS `stop()` has parked the MovieClip.
+    // A bare `GotoFrame(N, false)` against an AS-stopped MovieClip
+    // doesn't reliably seek — we have to mirror the playFlash
+    // workaround: call `play()` first to flip the player-level paused
+    // flag, THEN `GotoFrame(N, false)` to hit MovieClip's goto_frame
+    // (which seeks AND clears the stopped flag). Frame N's own AS
+    // `stop()` then re-parks the playhead at N.
+    const live = instances.get(key);
+    // Mark ready BEFORE the seed and queue replay so the internal
+    // `live.rufflePlayer.GotoFrame(...)` calls aren't seen as targeting
+    // a not-yet-ready instance (they're the seed itself). After this
+    // point any Lingo goTo/play/stop calls bypass the queue.
+    if (live) live.ready = true;
+    if (inheritedFrame !== null && live) {
+      try {
+        live.rufflePlayer.play();
+        live.rufflePlayer.GotoFrame(inheritedFrame, false);
+      } catch (e) {
+        console.warn(`[Flash] inherit seed failed for ${key}:`, e);
+      }
+    }
+
+    // Replay any beginSprite-time `gotoFrame(sprite,N)` / `play(sprite)` /
+    // `stop(sprite)` Lingo calls that arrived before this instance was
+    // created. Runs AFTER the inheritance seed so an explicit
+    // `gotoFrame(31)` from BS38 wins over an inherited frame 21.
+    flushPendingGoto(spriteNum);
   }
 }
 
@@ -362,7 +629,7 @@ function startFrameCapture(key: string): void {
         if (offCtx) {
           offCtx.drawImage(canvas, 0, 0);
           const imageData = offCtx.getImageData(0, 0, width, height);
-          update_flash_frame(inst.castLib, inst.castMember, width, height, new Uint8Array(imageData.data.buffer));
+          update_flash_frame(inst.spriteNum, width, height, new Uint8Array(imageData.data.buffer));
         }
       }
     } catch (e) {
@@ -378,8 +645,8 @@ function startFrameCapture(key: string): void {
 /**
  * Destroy a Flash instance and clean up resources.
  */
-export function destroyFlashInstance(castLib: number, castMember: number): void {
-  const key = instanceKey(castLib, castMember);
+export function destroyFlashInstance(spriteNum: number): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return;
 
@@ -412,14 +679,34 @@ function translateLevel0(path: string): string {
   if (path.startsWith('_level0')) {
     return '_root' + path.substring('_level0'.length);
   }
+  // Director's getVariable/setVariable/callFunction accept bare names
+  // and resolve them as `_root.<name>`. Ruffle's GetVariable is strict
+  // — a bare path returns Void. Rewrite bare names (no path
+  // separator, no leading `_root`/`_level0`/`this`/`super`) into the
+  // `/:<name>` form Ruffle handles, so e.g. JunkbotUndercover's
+  // `getVariable(sprite(15), "sceneNumber")` actually reads the SWF's
+  // `_root.sceneNumber`.
+  const isBareName = !/[\/:.]/.test(path) && !/^_?(root|level\d+|this|super|parent)\b/i.test(path);
+  if (isBareName && path.length > 0) {
+    return '/:' + path;
+  }
   return path;
 }
 
-function getVariable(castLib: number, castMember: number, path: string): string | null {
-  const key = instanceKey(castLib, castMember);
+// Bridge mode (extension content scripts) can't make synchronous calls
+// across the world boundary, so the Lingo Flash getter/setter handlers
+// below can't reach the main-world Ruffle player. In bridge mode each
+// `instance.rufflePlayer` is a plain DOM element (no `GetVariable` /
+// `SetVariable` / etc.); calls fall into the existing try/catch and
+// safely return defaults. SWF playback (the path that goes through
+// `createFlashInstance` / `bridgeCallMethod`) still works; only
+// Lingo-driven Flash interactivity is degraded.
+
+function getVariable(spriteNum: number, path: string): string | null {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) {
-    console.warn(`ruffleGetVariable: no instance for ${key}`);
+    console.warn(`ruffleGetVariable: no instance for sprite#${spriteNum}`);
     flashAccessBeforeReady = true;
     return null;
   }
@@ -436,11 +723,11 @@ function getVariable(castLib: number, castMember: number, path: string): string 
  * Set a Flash variable on a Ruffle instance.
  * Called from WASM via window.dirplayer_ruffleSetVariable.
  */
-function setVariable(castLib: number, castMember: number, path: string, value: string): boolean {
-  const key = instanceKey(castLib, castMember);
+function setVariable(spriteNum: number, path: string, value: string): boolean {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) {
-    console.warn(`ruffleSetVariable: no instance for ${key}`);
+    console.warn(`ruffleSetVariable: no instance for sprite#${spriteNum}`);
     return false;
   }
 
@@ -453,22 +740,270 @@ function setVariable(castLib: number, castMember: number, path: string, value: s
 }
 
 /**
- * Go to a specific frame on a Ruffle instance.
- * Called from WASM via window.dirplayer_ruffleGoToFrame.
- * frame is 1-based (Director convention).
+ * Pre-instance method-call queue.
+ *
+ * A sprite's `beginSprite` script can call `gotoFrame(sprite, N)`,
+ * `play(sprite)`, `stop(sprite)` etc. BEFORE the renderer triggers
+ * the lazy Flash member load — so the very first calls would otherwise
+ * no-op (no instance to act on). storyscramble hits this on sprite 2's
+ * BehaviorScript 38, whose beginSprite runs `gotoFrame(31); stop()`
+ * to park the help-bubble at the "Read the words…" frame; without
+ * queueing, those calls vanish and the bubble sits at frame 11.
+ *
+ * We queue them in order and replay against the live instance once
+ * `createFlashInstance` has loaded the SWF and finished AS init
+ * (after the inheritance seed — so explicit `gotoFrame(N)` from
+ * beginSprite wins over an inherited sibling frame).
  */
-function goToFrame(castLib: number, castMember: number, frame: number): void {
-  const key = instanceKey(castLib, castMember);
-  const instance = instances.get(key);
-  if (!instance) {
-    console.warn(`ruffleGoToFrame: no instance for ${key}`);
-    return;
-  }
+type PendingOp =
+  | { kind: 'goto'; frame: number }
+  | { kind: 'gotoLabel'; label: string }
+  | { kind: 'play' }
+  | { kind: 'stop' }
+  | { kind: 'rewind' };
+const pendingOps = new Map<number, PendingOp[]>();
 
+/**
+ * Pending goto-and-pin target per sprite. Director's `the frame of
+ * sprite N = X` is implicitly gotoAndStop, but Ruffle's `GotoFrame(X,
+ * true)` (goto+stop) skips paint when the MovieClip is stopped — so the
+ * canvas stays blank. Work around it in two steps:
+ *   1. `GotoFrame(X, false)` (goto+play) — forces a paint of frame X
+ *   2. On the next browser RAF, `GotoFrame(X, true)` — stops the
+ *      MovieClip after the paint has landed
+ *
+ * The map exists so a subsequent `play(sprite N)` (BS69's
+ * `mySprite.frame=N; mySprite.play()` shrink pattern) can cancel the
+ * deferred stop before it fires — otherwise the shrink animation gets
+ * pinned at its first frame and never advances to frame 21.
+ */
+const pinTarget = new Map<number, number>();
+
+/**
+ * Numeric seek that LEAVES THE PLAYHEAD RUNNING — matches Director's
+ * `sprite(N).gotoFrame(frame)` method semantic (the Flash Asset Xtra's
+ * `gotoFrame` calls `gotoAndPlay`, not `gotoAndStop`). Used by
+ * `sprite.gotoFrame(N)` Lingo method calls; the SWF continues playing
+ * from frame N afterwards. Required for mello's Fire/Marshmello where
+ * each label points to an animated frame range that must keep playing.
+ */
+function applyGotoPlay(instance: FlashInstance, frame: number): void {
   try {
     instance.rufflePlayer.GotoFrame(frame, false);
   } catch (e) {
-    console.warn(`ruffleGoToFrame error:`, e);
+    console.warn(`[Flash gotoPlay] error:`, e);
+  }
+  // Cancel any pending pin from a previous gotoAndStop on this sprite —
+  // play-mode wins over a stale pin target.
+  pinTarget.delete(instance.spriteNum);
+}
+
+/**
+ * Label variant of applyGotoPlay. Ruffle's `GotoFrame(n, …)` only takes
+ * numeric frame indices; label resolution lives in AS1, so we call
+ * `_root.gotoAndPlay(label)` via CallFunction.
+ */
+function applyGotoLabelPlay(instance: FlashInstance, label: string): void {
+  const player = instance.rufflePlayer as unknown as {
+    CallFunction?: (path: string, args: unknown[]) => unknown;
+  };
+  if (typeof player.CallFunction !== 'function') {
+    console.warn(`[Flash gotoLabelPlay] sprite#${instance.spriteNum} player has no CallFunction`);
+    return;
+  }
+  try {
+    player.CallFunction('_root.gotoAndPlay', [label]);
+  } catch (e) {
+    console.warn(`[Flash gotoLabelPlay] error:`, e);
+  }
+}
+
+/**
+ * Numeric seek that STOPS at the target frame (gotoAndStop semantic).
+ * Director's `sprite.frame = N` property setter uses this — required for
+ * storyscramble's tiles which must pin at a poster frame (2/4/6) and not
+ * advance through the SWF's other frames. Uses a microtask-pin to avoid
+ * a render race against Ruffle's RAF; see schedulePin for the rationale.
+ */
+function applyGotoAndPin(instance: FlashInstance, frame: number): void {
+  try {
+    // Goto+play first forces Ruffle to render frame N synchronously
+    // (Ruffle skips paint for already-stopped MovieClips, so a bare
+    // gotoAndStop wouldn't show frame N until something else triggered
+    // a repaint).
+    instance.rufflePlayer.GotoFrame(frame, false);
+  } catch (e) {
+    console.warn(`[Flash goto] play-step error:`, e);
+    return;
+  }
+  pinTarget.set(instance.spriteNum, frame);
+  schedulePin(instance, frame);
+}
+
+/**
+ * Label variant of applyGotoAndPin — gotoAndPlay followed by stop via
+ * AS1 CallFunction.
+ */
+function applyGotoLabelAndPin(instance: FlashInstance, label: string): void {
+  const player = instance.rufflePlayer as unknown as {
+    CallFunction?: (path: string, args: unknown[]) => unknown;
+  };
+  if (typeof player.CallFunction !== 'function') {
+    console.warn(`[Flash gotoLabel] sprite#${instance.spriteNum} player has no CallFunction`);
+    return;
+  }
+  try {
+    player.CallFunction('_root.gotoAndPlay', [label]);
+  } catch (e) {
+    console.warn(`[Flash gotoLabel] play-step error:`, e);
+    return;
+  }
+  queueMicrotask(() => {
+    try {
+      player.CallFunction!('_root.stop', []);
+    } catch (e) {
+      console.warn(`[Flash gotoLabel] pin-step error:`, e);
+    }
+  });
+}
+
+/**
+ * Shared microtask-pin used by the numeric goto path.
+ */
+function schedulePin(instance: FlashInstance, frame: number): void {
+  // Pin via microtask, NOT requestAnimationFrame: browser RAFs fire in
+  // registration order, and Ruffle's render-loop RAF (registered first
+  // on player init) runs before ours. If Ruffle's per-frame
+  // accumulator has crossed the SWF tick interval by then, it advances
+  // the MovieClip from N to N+1, paints N+1, captureFrame snapshots
+  // N+1, and *then* our pin runs — too late to prevent the wrong
+  // frame being displayed (and Ruffle won't repaint after the stop
+  // because it skips paint on stopped MovieClips). A microtask runs
+  // after the current synchronous Lingo dispatch but BEFORE the next
+  // browser frame, so Ruffle gets no chance to tick in between. The
+  // tile poster-frame race during rapid hover (`mySprite.frame =
+  // tileFrame ± 1`) goes away.
+  queueMicrotask(() => {
+    // Only pin if no one (play/stop/rewind, or a later goto to a
+    // different frame) cleared / overwrote our target in the meantime.
+    if (pinTarget.get(instance.spriteNum) !== frame) return;
+    pinTarget.delete(instance.spriteNum);
+    try {
+      instance.rufflePlayer.GotoFrame(frame, true);
+    } catch (e) {
+      console.warn(`[Flash goto] pin-step error:`, e);
+    }
+  });
+}
+
+function queueOp(spriteNum: number, op: PendingOp): void {
+  const list = pendingOps.get(spriteNum) ?? [];
+  list.push(op);
+  pendingOps.set(spriteNum, list);
+}
+
+function flushPendingGoto(spriteNum: number): void {
+  const ops = pendingOps.get(spriteNum);
+  if (!ops || ops.length === 0) return;
+  pendingOps.delete(spriteNum);
+  const instance = instances.get(instanceKey(spriteNum));
+  if (!instance) return;
+  for (const op of ops) {
+    try {
+      switch (op.kind) {
+        case 'goto':
+          applyGotoAndPin(instance, op.frame);
+          break;
+        case 'gotoLabel':
+          applyGotoLabelAndPin(instance, op.label);
+          break;
+        case 'play':
+          // Queued `play` ops fire only on instances we just created —
+          // at which point autoplay has already started the SWF. Re-
+          // firing play() / GotoFrame(_currentframe, false) here is
+          // redundant AND visually disruptive: it seeks back to the
+          // queued goto target and makes the bubble grow animation
+          // restart from frame 1 after autoplay already played it.
+          //
+          // All we need to do is cancel any pending pin from a queued
+          // goto earlier in the same queue so the deferred stop
+          // doesn't undo the implicit play.
+          pinTarget.delete(spriteNum);
+          break;
+        case 'stop':
+          pinTarget.delete(spriteNum);
+          instance.rufflePlayer.pause();
+          break;
+        case 'rewind':
+          pinTarget.delete(spriteNum);
+          instance.rufflePlayer.GotoFrame(1, true);
+          break;
+      }
+    } catch (e) {
+      console.warn(`[Flash flush] sprite#${spriteNum} op ${op.kind} error:`, e);
+    }
+  }
+}
+
+/**
+ * `sprite(N).gotoFrame(frameOrLabel)` method call — seek and KEEP
+ * PLAYING (Director's gotoFrame is gotoAndPlay-semantic). Called from
+ * WASM via window.dirplayer_ruffleGoToFrame.
+ *
+ * The numeric-detection regex requires the entire trimmed string to be
+ * an optional sign plus digits — odd labels that happen to start with a
+ * digit (`"3frame"`) stay on the label path instead of getting
+ * parseInt'd to `3`.
+ *
+ * For the `sprite.frame = N` property setter (gotoAndStop semantic) use
+ * goToFrameAndStop below.
+ */
+function goToFrame(spriteNum: number, frameOrLabel: string): void {
+  const key = instanceKey(spriteNum);
+  const instance = instances.get(key);
+  const trimmed = frameOrLabel.trim();
+  const isNumeric = /^-?\d+$/.test(trimmed);
+
+  if (!instance || !instance.ready) {
+    if (isNumeric) {
+      queueOp(spriteNum, { kind: 'goto', frame: parseInt(trimmed, 10) });
+    } else {
+      queueOp(spriteNum, { kind: 'gotoLabel', label: frameOrLabel });
+    }
+    return;
+  }
+  if (isNumeric) {
+    applyGotoPlay(instance, parseInt(trimmed, 10));
+  } else {
+    applyGotoLabelPlay(instance, frameOrLabel);
+  }
+}
+
+/**
+ * `the frame of sprite N = X` property setter — seek and STOP (Director's
+ * frame setter is gotoAndStop-semantic). Called from WASM via
+ * window.dirplayer_ruffleGoToFrameAndStop. Used for poster-frame Flash
+ * sprites like storyscramble's tiles where the playhead must not advance
+ * past the chosen frame.
+ */
+function goToFrameAndStop(spriteNum: number, frameOrLabel: string): void {
+  const key = instanceKey(spriteNum);
+  const instance = instances.get(key);
+  const trimmed = frameOrLabel.trim();
+  const isNumeric = /^-?\d+$/.test(trimmed);
+
+  if (!instance || !instance.ready) {
+    if (isNumeric) {
+      queueOp(spriteNum, { kind: 'goto', frame: parseInt(trimmed, 10) });
+    } else {
+      queueOp(spriteNum, { kind: 'gotoLabel', label: frameOrLabel });
+    }
+    return;
+  }
+  if (isNumeric) {
+    applyGotoAndPin(instance, parseInt(trimmed, 10));
+  } else {
+    applyGotoLabelAndPin(instance, frameOrLabel);
   }
 }
 
@@ -476,11 +1011,11 @@ function goToFrame(castLib: number, castMember: number, frame: number): void {
  * Call a Flash function on a Ruffle instance.
  * Called from WASM via window.dirplayer_ruffleCallFunction.
  */
-function callFunction(castLib: number, castMember: number, path: string, argsXml: string): string | null {
-  const key = instanceKey(castLib, castMember);
+function callFunction(spriteNum: number, path: string, argsXml: string): string | null {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) {
-    console.warn(`ruffleCallFunction: no instance for ${key}`);
+    console.warn(`ruffleCallFunction: no instance for sprite#${spriteNum}`);
     flashAccessBeforeReady = true;
     return null;
   }
@@ -503,10 +1038,14 @@ function callFunction(castLib: number, castMember: number, path: string, argsXml
 /**
  * Stop playback of a Ruffle instance (stays on current frame).
  */
-function stopFlash(castLib: number, castMember: number): void {
-  const key = instanceKey(castLib, castMember);
+function stopFlash(spriteNum: number): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
-  if (!instance) return;
+  if (!instance || !instance.ready) {
+    queueOp(spriteNum, { kind: 'stop' });
+    return;
+  }
+  pinTarget.delete(spriteNum);
   try {
     instance.rufflePlayer.pause();
   } catch (e) {
@@ -516,13 +1055,32 @@ function stopFlash(castLib: number, castMember: number): void {
 
 /**
  * Start/resume playback of a Ruffle instance.
+ *
+ * `mySprite.play()` must resume the SWF even after AS has called `stop()`
+ * inside the movie (e.g. storyscramble's bubble at frame 11). Ruffle's
+ * `Player::play()` only flips the player-level paused flag and doesn't
+ * clear the MovieClip's own stopped state set by AS; the playhead stays
+ * frozen and frame-21's `getURL("event: send #done")` never fires.
+ * Routing through `GotoFrame(currentFrame, false)` hits MovieClip's
+ * `goto_frame`, which both re-seats the playhead and clears that flag.
  */
-function playFlash(castLib: number, castMember: number): void {
-  const key = instanceKey(castLib, castMember);
+function playFlash(spriteNum: number): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
-  if (!instance) return;
+  if (!instance || !instance.ready) {
+    queueOp(spriteNum, { kind: 'play' });
+    return;
+  }
+  // Cancel any in-flight pin from a `mySprite.frame = N` call earlier
+  // in this same Lingo dispatch — otherwise the scheduled RAF stop
+  // would undo our play() a frame later (BS69 shrink animation).
+  pinTarget.delete(spriteNum);
   try {
     instance.rufflePlayer.play();
+    const cur = parseInt(
+      instance.rufflePlayer.GetVariable?.('/:_currentframe') || '1', 10
+    ) || 1;
+    instance.rufflePlayer.GotoFrame(cur, false);
   } catch (e) {
     console.warn(`rufflePlay error:`, e);
   }
@@ -531,10 +1089,14 @@ function playFlash(castLib: number, castMember: number): void {
 /**
  * Rewind a Ruffle instance to frame 1 and stop.
  */
-function rewindFlash(castLib: number, castMember: number): void {
-  const key = instanceKey(castLib, castMember);
+function rewindFlash(spriteNum: number): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
-  if (!instance) return;
+  if (!instance || !instance.ready) {
+    queueOp(spriteNum, { kind: 'rewind' });
+    return;
+  }
+  pinTarget.delete(spriteNum);
   try {
     instance.rufflePlayer.GotoFrame(1, true);
   } catch (e) {
@@ -545,8 +1107,8 @@ function rewindFlash(castLib: number, castMember: number): void {
 /**
  * Check if a Ruffle instance is currently playing.
  */
-function isPlaying(castLib: number, castMember: number): boolean {
-  const key = instanceKey(castLib, castMember);
+function isPlaying(spriteNum: number): boolean {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return false;
   try {
@@ -559,8 +1121,8 @@ function isPlaying(castLib: number, castMember: number): boolean {
 /**
  * Get the total frame count of a Ruffle instance.
  */
-function getFrameCount(castLib: number, castMember: number): number {
-  const key = instanceKey(castLib, castMember);
+function getFrameCount(spriteNum: number): number {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return 0;
   try {
@@ -574,8 +1136,8 @@ function getFrameCount(castLib: number, castMember: number): number {
 /**
  * Get the current frame of a Ruffle instance (1-based).
  */
-function getCurrentFrame(castLib: number, castMember: number): number {
-  const key = instanceKey(castLib, castMember);
+function getCurrentFrame(spriteNum: number): number {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return 0;
   try {
@@ -590,8 +1152,8 @@ function getCurrentFrame(castLib: number, castMember: number): number {
  * In Director, callFrame() executes the frame's scripts.
  * We implement this as goToFrame + immediate return (best effort).
  */
-function callFrame(castLib: number, castMember: number, frame: number): void {
-  const key = instanceKey(castLib, castMember);
+function callFrame(spriteNum: number, frame: number): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return;
   try {
@@ -606,29 +1168,22 @@ function callFrame(castLib: number, castMember: number, frame: number): void {
 /**
  * Find a frame label and return its frame number (1-based), or -1 if not found.
  */
-function findLabel(castLib: number, castMember: number, label: string): number {
-  const key = instanceKey(castLib, castMember);
+function findLabel(spriteNum: number, _label: string): number {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return -1;
-  try {
-    // Use TellTarget + GetVariable to find label frame
-    // Flash's /:_framesloaded and label lookup via GetVariable
-    const result = instance.rufflePlayer.GetVariable("/:_currentframe");
-    // Try navigating to the label using SetVariable approach
-    // Unfortunately there's no direct label lookup in Flash Player API
-    // Best effort: use CallFunction if the SWF has a findLabel method
-    return -1;
-  } catch (e) {
-    return -1;
-  }
+  // No direct label lookup in the legacy Flash Player JS API; if the SWF
+  // exposes a `findLabel` AS function we could call it, otherwise return
+  // -1 and let the script fall through.
+  return -1;
 }
 
 /**
  * Perform a hit test on a Ruffle instance.
  * Returns true if the point (in Flash coordinates) hits content.
  */
-function hitTest(castLib: number, castMember: number, x: number, y: number): boolean {
-  const key = instanceKey(castLib, castMember);
+function hitTest(spriteNum: number, x: number, y: number): boolean {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return false;
   try {
@@ -644,8 +1199,8 @@ function hitTest(castLib: number, castMember: number, x: number, y: number): boo
  * Get a Flash property by property number (matching Director's getFlashProperty).
  * Property numbers follow the original Flash Player property indices.
  */
-function getFlashProperty(castLib: number, castMember: number, target: string, propNum: number): string | null {
-  const key = instanceKey(castLib, castMember);
+function getFlashProperty(spriteNum: number, target: string, propNum: number): string | null {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return null;
 
@@ -673,8 +1228,8 @@ function getFlashProperty(castLib: number, castMember: number, target: string, p
 /**
  * Set a Flash property by property number.
  */
-function setFlashProperty(castLib: number, castMember: number, target: string, propNum: number, value: string): void {
-  const key = instanceKey(castLib, castMember);
+function setFlashProperty(spriteNum: number, target: string, propNum: number, value: string): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return;
 
@@ -699,8 +1254,8 @@ function setFlashProperty(castLib: number, castMember: number, target: string, p
  * Execute a tellTarget command on a Ruffle instance.
  * In Flash, tellTarget changes the target timeline for subsequent actions.
  */
-function tellTarget(castLib: number, castMember: number, target: string, action: string): void {
-  const key = instanceKey(castLib, castMember);
+function tellTarget(spriteNum: number, target: string, action: string): void {
+  const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return;
   try {
@@ -785,6 +1340,7 @@ export function initFlashBridge(): void {
   win.dirplayer_ruffleSetVariable = setVariable;
   win.dirplayer_ruffleCallFunction = callFunction;
   win.dirplayer_ruffleGoToFrame = goToFrame;
+  win.dirplayer_ruffleGoToFrameAndStop = goToFrameAndStop;
   win.dirplayer_ruffleStop = stopFlash;
   win.dirplayer_rufflePlay = playFlash;
   win.dirplayer_ruffleRewind = rewindFlash;
@@ -827,6 +1383,19 @@ export function initFlashBridge(): void {
   // Also returns true if scripts tried to access a Flash instance that doesn't exist yet
   // (the rendering loop will dispatch it shortly).
   win.dirplayer_isFlashLoading = () => flashLoadingCount > 0 || flashAccessBeforeReady;
+
+  // Hand-fired test entry for Flash `event: …` dispatch — lets you prove
+  // the WASM dispatch chain end-to-end from DevTools without waiting for
+  // a real SWF `getURL("event: …")` call. Example:
+  //   dirplayer_dispatchFlashEvent(1, 45, "send #done")
+  win.dirplayer_dispatchFlashEvent = dispatchFlashEvent;
+
+  // Mouse forwarding: dirplayer's WASM-side mouseDown/mouseUp handlers
+  // call this when the click lands on a Flash sprite, so the SWF's own
+  // AS1 button handlers actually fire (Ruffle's canvas is hidden
+  // offscreen and never receives real browser clicks). See
+  // dispatchMouseEvent above.
+  win.dirplayer_ruffleDispatchMouse = dispatchMouseEvent;
 
   // Ensure dirplayer_RufflePlayer config is set up before any instances are
   // created. Skip when the host disabled Flash — they may already have stock
@@ -889,16 +1458,8 @@ export function configureFlashManager(partial: Partial<FlashManagerConfig>): voi
   const win = window as any;
   const existing = win.__dirplayerFlashConfig || {};
   win.__dirplayerFlashConfig = { ...existing, ...partial };
-
-  // Set up the global socket URL resolver for the Multiuser Xtra (WASM side)
-  if (partial.socketProxy && partial.socketProxy.length > 0) {
-    win.dirplayerResolveSocketUrl = (host: string, port: number): string => {
-      for (const entry of partial.socketProxy!) {
-        if (entry.host === host && entry.port === port) {
-          return entry.proxyUrl;
-        }
-      }
-      return '';
-    };
-  }
+  // Note: `dirplayerResolveSocketUrl` is installed unconditionally near
+  // the top of this file and reads from `getSocketProxyConfig()` on every
+  // call, so it picks up `partial.socketProxy` automatically without
+  // needing to be re-bound here.
 }

--- a/src/vm/callbacks.ts
+++ b/src/vm/callbacks.ts
@@ -144,15 +144,15 @@ export function initVmCallbacks() {
     onChannelDisplayNameChanged: (channelNumber: number, displayName: string) => {
       store.dispatch(channelDisplayNameChanged({ channelNumber, displayName }));
     },
-    onFlashMemberLoaded: (castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number) => {
+    onFlashMemberLoaded: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean) => {
       // Copy immediately - swfData is a view into WASM memory that may be invalidated
       const swfDataCopy = new Uint8Array(swfData);
-      console.log(`Flash member loaded: ${castLib}:${castMember} ${width}x${height} (${swfDataCopy.length} bytes, first=[${Array.from(swfDataCopy.slice(0, 4)).join(',')}])`);
-      createFlashInstance(castLib, castMember, swfDataCopy, width, height)
+      console.log(`Flash member loaded: sprite#${spriteNum} ${castLib}:${castMember} ${width}x${height} (${swfDataCopy.length} bytes, first=[${Array.from(swfDataCopy.slice(0, 4)).join(',')}], pausedAtStart=${pausedAtStart})`);
+      createFlashInstance(spriteNum, castLib, castMember, swfDataCopy, width, height, pausedAtStart)
         .catch(e => console.error('Failed to create Flash instance:', e));
     },
-    onFlashMemberUnloaded: (castLib: number, castMember: number) => {
-      destroyFlashInstance(castLib, castMember);
+    onFlashMemberUnloaded: (spriteNum: number) => {
+      destroyFlashInstance(spriteNum);
     },
     onStageSizeChanged: (width: number, height: number, center: boolean) => {
       const inner = document.getElementById('stage_canvas_container');

--- a/vm-rust/lingo.pest
+++ b/vm-rust/lingo.pest
@@ -92,6 +92,12 @@ chunk_type = { &reserved_keyword ~ (^"char" | ^"word" | ^"line" | ^"item") }
 chunk_range = { ^"to" ~ expr }
 chunk_expr  = { chunk_type ~ expr ~ chunk_range? ~ ^"of" ~ (the_prop_of | the_prop | chunk_expr | field_ref | handler_call | lang_ident) }
 
+// Director's legacy "the number of <chunk> in/of <expr>" — counts lines /
+// words / items / chars in a string. Used by classic behavior scripts:
+//     numMarkers = the number of lines in the labelList
+chunk_count_kind = { ^"chars" | ^"characters" | ^"words" | ^"lines" | ^"items" }
+the_chunk_count  = { ^"the" ~ ^"number" ~ ^"of" ~ chunk_count_kind ~ (^"of" | ^"in") ~ expr }
+
 parens_expr = _{ "(" ~ expr ~ ")" }
 parens_list = { "(" ~ expr ~ ("," ~ expr)+ ~ ")" }
 parens_empty = { "(" ~ ")" }
@@ -115,7 +121,7 @@ ge_op = { ">=" }
 // Property name after dot - can be any identifier including reserved keywords
 prop_name  =  { ident }
 
-primitive       = _{ put_handler_call | sprite_ref | castlib_ref | member_ref | field_ref | handler_call | the_prop_of | the_prop | symbol | list | string | prop_list | number_float | number_int | rgb_color | rect | void | bool_true | bool_false | string_empty | point | return_const | parens_list | parens_expr | chunk_expr | castlib_of_expr | sprite_of_expr | prop_of_expr | lang_ident }
+primitive       = _{ put_handler_call | sprite_ref | castlib_ref | member_ref | field_ref | handler_call | the_chunk_count | the_prop_of | the_prop | symbol | list | string | prop_list | number_float | number_int | rgb_color | rect | void | bool_true | bool_false | string_empty | point | return_const | parens_list | parens_expr | chunk_expr | castlib_of_expr | sprite_of_expr | prop_of_expr | lang_ident }
 eval_expr       = _{ SOI ~ expr ~ EOI }
 ident_list      = _{ !digit ~ ident ~ (" " ~ ident)+ }
 
@@ -187,7 +193,23 @@ go_inline = {
 // The parser will validate that the left side is a valid lvalue
 assignment_expr = { term ~ (obj_prop ~ (prop_name | term) | list_index)* }
 assignment = { assignment_expr ~ "=" ~ expr }
-command    = _{ set_statement | delete_statement | assignment | put_statement | go_inline | command_inline | expr }
+
+// `if EXPR then COMMAND` inline form (no `else`, no `end if`). Director's
+// runtime text-eval contexts (keyUpScript / mouseUpScript / `do "…"`) use
+// this; the multi-line `if … end if` form lives in the compiled-bytecode
+// path. The keywords are atomic-with-word-boundary so e.g. an identifier
+// `iffy` doesn't tokenise as `if` + `fy`.
+if_kw       = @{ ^"if"   ~ !(alpha | digit | "_") }
+then_kw     = @{ ^"then" ~ !(alpha | digit | "_") }
+if_inline   =  { if_kw ~ expr ~ then_kw ~ command }
+
+// `pass` — "let the event keep propagating to the next handler in the
+// chain". In a text-eval context (where there's no handler chain being
+// walked) it's a no-op; the evaluator returns Void.
+pass_kw     = @{ ^"pass" ~ !(alpha | digit | "_") }
+pass_stmt   =  { pass_kw }
+
+command    = _{ if_inline | pass_stmt | set_statement | delete_statement | assignment | put_statement | go_inline | command_inline | expr }
 obj_prop   =  { "." }
 add        =  { "+" }
 subtract   =  { "-" }

--- a/vm-rust/src/director/enums.rs
+++ b/vm-rust/src/director/enums.rs
@@ -1158,17 +1158,26 @@ impl FlashInfo {
         // Header: u32 string_len + "flash" + u32 data_len + "FLSH" + u32 data_len2 + u32 count
         let str_len = reader.read_u32().unwrap_or(0) as usize;
         if str_len == 0 || bytes.len() < 4 + str_len + 16 {
+            debug!(
+                "[FlashInfo::from] bail: str_len={} too small or bytes.len()={} < {}",
+                str_len, bytes.len(), 4 + str_len + 16
+            );
             return None;
         }
         let name_bytes = reader.read_bytes(str_len).ok()?;
         let name = String::from_utf8_lossy(name_bytes).to_string();
         if name != "flash" {
+            debug!("[FlashInfo::from] bail: name={:?} != \"flash\"", name);
             return None;
         }
 
         let _data_len = reader.read_u32().unwrap_or(0);
         let fourcc = reader.read_bytes(4).ok()?;
         if fourcc != b"FLSH" {
+            debug!(
+                "[FlashInfo::from] bail: fourcc={:?} != \"FLSH\"",
+                String::from_utf8_lossy(fourcc)
+            );
             return None;
         }
         let _data_len2 = reader.read_u32().unwrap_or(0);
@@ -1189,6 +1198,11 @@ impl FlashInfo {
         let sound_enabled = u32s[15] != 0;
         let paused_at_start = u32s[16] != 0;
         let loop_enabled = u32s[17] != 0;
+        debug!(
+            "[FlashInfo] direct_to_stage={} image={} sound={} paused_at_start={} loop={} (raw u32s[14..18]={:?})",
+            direct_to_stage, image_enabled, sound_enabled, paused_at_start, loop_enabled,
+            &u32s[14..18]
+        );
         // u32s[18], u32s[19] unknown
         let scale_mode = match u32s[20] {
             1 => FlashScaleMode::NoScale,

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -250,8 +250,8 @@ extern "C" {
     pub fn onDatumSnapshot(datum_id: DatumId, data: js_sys::Object);
     pub fn onScriptInstanceSnapshot(script_ref: ScriptInstanceId, data: js_sys::Object);
     pub fn onExternalEvent(event: &str);
-    pub fn onFlashMemberLoaded(cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32);
-    pub fn onFlashMemberUnloaded(cast_lib: i32, cast_member: i32);
+    pub fn onFlashMemberLoaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool);
+    pub fn onFlashMemberUnloaded(sprite_num: i32);
     pub fn onStageSizeChanged(width: u32, height: u32, center: bool);
 }
 
@@ -285,11 +285,11 @@ impl JsApi {
     pub fn dispatch_clear_timeouts() {
         onClearTimeouts();
     }
-    pub fn dispatch_flash_member_loaded(cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32) {
-        onFlashMemberLoaded(cast_lib, cast_member, swf_data, width, height);
+    pub fn dispatch_flash_member_loaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool) {
+        onFlashMemberLoaded(sprite_num, cast_lib, cast_member, swf_data, width, height, paused_at_start);
     }
-    pub fn dispatch_flash_member_unloaded(cast_lib: i32, cast_member: i32) {
-        onFlashMemberUnloaded(cast_lib, cast_member);
+    pub fn dispatch_flash_member_unloaded(sprite_num: i32) {
+        onFlashMemberUnloaded(sprite_num);
     }
     pub fn dispatch_stage_size_changed(width: u32, height: u32, center: bool) {
         onStageSizeChanged(width, height, center);
@@ -1876,8 +1876,8 @@ impl JsApi {
     pub fn dispatch_clear_timeouts() {}
     pub fn dispatch_movie_loaded(_: &DirectorFile) {}
     pub fn dispatch_movie_load_failed(_: &str, _: &str) {}
-    pub fn dispatch_flash_member_loaded(_: i32, _: i32, _: &[u8], _: u32, _: u32) {}
-    pub fn dispatch_flash_member_unloaded(_: i32, _: i32) {}
+    pub fn dispatch_flash_member_loaded(_: i32, _: i32, _: i32, _: &[u8], _: u32, _: u32, _: bool) {}
+    pub fn dispatch_flash_member_unloaded(_: i32) {}
     pub fn dispatch_stage_size_changed(_: u32, _: u32, _: bool) {}
     pub fn dispatch_cast_name_changed(_: u32) {}
     pub fn dispatch_cast_list_changed() {}

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -927,10 +927,14 @@ pub fn provide_net_task_error(task_id: u32) {
     });
 }
 
-/// Receive a rendered Flash frame from JavaScript (Ruffle) and store it as a bitmap.
-/// This allows Flash content to be composited into the Director stage rendering pipeline.
+/// Receive a rendered Flash frame from JavaScript (Ruffle) and store it as a
+/// per-sprite bitmap. Each Flash sprite has its own Ruffle player instance
+/// (so multiple sprites that share a single Flash cast member can display
+/// different frames at the same time — e.g. storyscramble's 3 story tiles
+/// pinned to poster frames 2/4/6 of one shared SWF). The renderer reads
+/// `flash_frame_buffers[sprite_num]` directly.
 #[wasm_bindgen]
-pub fn update_flash_frame(cast_lib: i32, cast_member: i32, width: u32, height: u32, rgba_data: &[u8]) {
+pub fn update_flash_frame(sprite_num: i32, width: u32, height: u32, rgba_data: &[u8]) {
     use player::bitmap::bitmap::{Bitmap, PaletteRef, get_system_default_palette};
 
     let expected_len = (width * height * 4) as usize;
@@ -955,18 +959,11 @@ pub fn update_flash_frame(cast_lib: i32, cast_member: i32, width: u32, height: u
 
     unsafe {
         if let Some(player) = PLAYER_OPT.as_mut() {
-            let key = (cast_lib, cast_member);
+            let key = sprite_num as i16;
             if let Some(&existing_ref) = player.flash_frame_buffers.get(&key) {
-                if existing_ref == 0 {
-                    // Sentinel value — first real frame, allocate new bitmap
-                    let bitmap_ref = player.bitmap_manager.add_bitmap(bitmap);
-                    player.flash_frame_buffers.insert(key, bitmap_ref);
-                } else {
-                    // Replace existing bitmap to reuse the BitmapRef
-                    player.bitmap_manager.replace_bitmap(existing_ref, bitmap);
-                }
+                // Replace existing bitmap to reuse the BitmapRef.
+                player.bitmap_manager.replace_bitmap(existing_ref, bitmap);
             } else {
-                // No entry at all — allocate a new bitmap
                 let bitmap_ref = player.bitmap_manager.add_bitmap(bitmap);
                 player.flash_frame_buffers.insert(key, bitmap_ref);
             }
@@ -1122,6 +1119,67 @@ pub fn trigger_lingo_callback_on_script(cast_lib: i32, cast_member: i32, handler
         handler_name,
         args: arg_refs,
     })
+}
+
+/// Dispatch a Flash `getURL("event: …")` body into Director's event chain.
+///
+/// Called from the JS Flash bridge whenever a SWF tries to navigate to a
+/// `event:`-scheme URL — Director's Flash Asset Xtra convention for sending a
+/// Lingo message back to the host movie.
+///
+/// The body is whitespace-tokenised: the first token is the handler name,
+/// the rest are arguments (symbols if they start with `#`, integers if
+/// numeric, otherwise plain strings). So `send #done` invokes `on send`
+/// with `#done` as its first arg — `send` is not a keyword, it's just the
+/// most common handler name games define for routing to sendSprite /
+/// sendAllSprites (e.g. storyscramble's BehaviorScript 24).
+///
+/// `cast_lib` / `cast_member` identify the Flash member that fired the
+/// navigation, so a future revision can target the host sprite first; for now
+/// the dispatch is global via `player_invoke_global_event`.
+///
+/// Returns true when the body was understood and queued, false when the form
+/// is unrecognised (caller may then fall through to a real navigation).
+#[wasm_bindgen]
+pub fn dispatch_flash_event(cast_lib: i32, cast_member: i32, body: String) -> bool {
+    use director::lingo::datum::Datum;
+
+    let trimmed = body.trim();
+    let mut tokens = trimmed.split_whitespace();
+    let Some(handler_token) = tokens.next() else {
+        warn!("[dispatch_flash_event] empty event body: {:?}", body);
+        return false;
+    };
+    // The handler token MAY have a leading `#` in Director's UI conventions
+    // (e.g. `event: #done`), but the canonical `event: send …` form uses a
+    // bare identifier. Strip the prefix in either case so handler lookup
+    // matches the script-side spelling.
+    let handler_name = handler_token.trim_start_matches('#').to_string();
+
+    let mut arg_refs: Vec<player::datum_ref::DatumRef> = Vec::new();
+    for tok in tokens {
+        // Token typing matches what Director's interpreter would produce
+        // when re-tokenising the event body before invoking the handler:
+        // - leading `#` → Symbol
+        // - parses as i32 → Int
+        // - otherwise → String (downstream handlers can `value()` / `integer()`)
+        let datum = if let Some(sym) = tok.strip_prefix('#') {
+            Datum::Symbol(sym.to_string())
+        } else if let Ok(n) = tok.parse::<i32>() {
+            Datum::Int(n)
+        } else {
+            Datum::String(tok.to_string())
+        };
+        arg_refs.push(player::player_alloc_datum(datum));
+    }
+
+    player_dispatch(PlayerVMCommand::DispatchFlashEvent {
+        cast_lib,
+        cast_member,
+        handler_name,
+        args: arg_refs,
+    });
+    true
 }
 
 #[wasm_bindgen]

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -2577,15 +2577,44 @@ impl CastMember {
     }
 
     fn make_swf_member(number: u32, chunk: &CastMemberChunk, data: Vec<u8>) -> CastMember {
-        let flash_info = chunk.specific_data.flash_info().cloned();
+        // For native Flash members the FlashInfo was parsed during chunk
+        // ingest (cast_member.rs:140 `MemberType::Flash` branch). For
+        // OLE-wrapped SWFs that path never fires — the chunk comes in
+        // as `MemberType::Ole` and `specific_data` is `None`. The OLE
+        // wrapper, however, still contains a "flash" / "FLSH" payload
+        // in `specific_data_raw` that FlashInfo::from can parse. Try it
+        // here so properties like `pausedAtStart`, `directToStage`,
+        // `scaleMode` etc. are populated for OLE-wrapped Flash too.
+        let flash_info = chunk
+            .specific_data
+            .flash_info()
+            .cloned()
+            .or_else(|| crate::director::enums::FlashInfo::from(&chunk.specific_data_raw));
+        // Director's `centerRegPoint=true` semantically means "draw the SWF
+        // centered on the sprite's loc". The renderer computes
+        // `screen_pos = sprite.loc - member.reg_point`, so to get a centered
+        // draw we set reg_point to (W/2, H/2) — i.e. the same outcome
+        // `sprite.loc_h - W/2` would give in a screen-position formulation,
+        // just expressed at member-construction time.
+        //
+        // Prefer the actual SWF header dimensions over FlashInfo's
+        // cached `reg_point` field: FlashInfo's value can be stale /
+        // wrong (the old code halved it, getting quarter-size offsets),
+        // while parse_swf_dimensions reads straight from the SWF's
+        // FrameSize record so it always matches what Ruffle renders.
         let reg_point = if let Some(ref info) = flash_info {
             if info.center_reg_point {
-                (info.reg_point.0 as i16, info.reg_point.1 as i16)
+                if let Some((w, h)) = Self::parse_swf_dimensions(&data) {
+                    ((w / 2) as i16, (h / 2) as i16)
+                } else {
+                    (info.reg_point.0 as i16, info.reg_point.1 as i16)
+                }
             } else {
                 (info.origin_h as i16, info.origin_v as i16)
             }
         } else {
-            // OLE-wrapped SWF: default to center registration from SWF dimensions
+            // OLE-wrapped SWF without a parseable FlashInfo header:
+            // default to center registration from SWF dimensions
             if let Some((w, h)) = Self::parse_swf_dimensions(&data) {
                 ((w / 2) as i16, (h / 2) as i16)
             } else {
@@ -3799,18 +3828,31 @@ impl CastMember {
                 if let Some(cm) = Self::scan_children_for_ole(member_def, number, chunk, bitmap_manager) {
                     return cm;
                 }
-                // Fallback: use first child bytes if available
+                // Fallback: use first child bytes if available. Hoist the
+                // bytes lookup BEFORE reg_point so the centered branch can
+                // read true SWF dimensions for centering (see the OLE
+                // make_swf_member site for the same rationale —
+                // FlashInfo.reg_point can be stale; parse_swf_dimensions
+                // reads the SWF FrameSize header directly).
                 let flash_info = chunk.specific_data.flash_info().cloned();
+                let bytes_opt = Self::get_first_child_bytes(member_def);
                 let reg_point = if let Some(ref info) = flash_info {
                     if info.center_reg_point {
-                        (info.reg_point.0 as i16, info.reg_point.1 as i16)
+                        if let Some((w, h)) = bytes_opt
+                            .as_deref()
+                            .and_then(Self::parse_swf_dimensions)
+                        {
+                            ((w / 2) as i16, (h / 2) as i16)
+                        } else {
+                            (info.reg_point.0 as i16, info.reg_point.1 as i16)
+                        }
                     } else {
                         (info.origin_h as i16, info.origin_v as i16)
                     }
                 } else {
                     (0, 0)
                 };
-                if let Some(bytes) = Self::get_first_child_bytes(member_def) {
+                if let Some(bytes) = bytes_opt {
                     CastMemberType::Flash(FlashMember { data: bytes, reg_point, flash_info })
                 } else {
                     warn!("Flash cast member has no data chunk or it is invalid.");

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -69,6 +69,16 @@ pub enum PlayerVMCommand {
         prop_name: String,
         value: DatumRef,
     },
+    /// Dispatch a Flash `getURL("event: …")` body into Director's event chain.
+    /// Mirrors the Flash Asset Xtra: `send <handler> [args...]` becomes a global
+    /// event invocation that walks active sprite behaviors → frame script → movie
+    /// scripts, so any `on <handler>` in scope picks it up.
+    DispatchFlashEvent {
+        cast_lib: i32,
+        cast_member: i32,
+        handler_name: String,
+        args: Vec<DatumRef>,
+    },
 }
 
 pub fn _format_player_cmd(command: &PlayerVMCommand) -> String {
@@ -102,6 +112,9 @@ pub fn _format_player_cmd(command: &PlayerVMCommand) -> String {
         }
         PlayerVMCommand::SetLingoScriptProperty { cast_lib, cast_member, prop_name, .. } => {
             format!("SetLingoScriptProperty(cast_lib: {}, cast_member: {}, prop: {})", cast_lib, cast_member, prop_name)
+        }
+        PlayerVMCommand::DispatchFlashEvent { cast_lib, cast_member, handler_name, .. } => {
+            format!("DispatchFlashEvent(cast_lib: {}, cast_member: {}, handler: {})", cast_lib, cast_member, handler_name)
         }
     }
 }
@@ -435,7 +448,109 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                 } else {
                     player.mouse_down_sprite = -1;
                 }
+                debug!(
+                    "[mouseDown] mouse_down_sprite={} (scripted lookup at {},{})",
+                    player.mouse_down_sprite, x, y
+                );
             });
+
+            // If the click landed on a Flash sprite, forward the press into
+            // the SWF so its own AS1 `on (press)` / button handlers run.
+            // Director normally delivers these by passing the event straight
+            // through to the embedded Flash player; in our setup Ruffle's
+            // canvas is offscreen so the click never reaches it organically.
+            // Use unscripted lookup here — Flash members don't always carry
+            // a Director-side behaviour, but their internal buttons still
+            // need the event.
+            let (flash_forward, debug_info) = reserve_player_ref(|player| {
+                let any_sprite = get_sprite_at(player, x, y, false);
+                if any_sprite.is_none() {
+                    return (None, format!("no sprite at ({},{})", x, y));
+                }
+                let any_sprite = any_sprite.unwrap();
+                let sprite = match player.movie.score.get_sprite(any_sprite as i16) {
+                    Some(s) => s,
+                    None => return (None, format!("sprite#{} not found", any_sprite)),
+                };
+                let member_ref = match sprite.member.as_ref() {
+                    Some(m) => m,
+                    None => return (None, format!("sprite#{} has no member", any_sprite)),
+                };
+                let member = match player.movie.cast_manager.find_member_by_ref(member_ref) {
+                    Some(m) => m,
+                    None => return (None, format!("member {:?} not resolvable", member_ref)),
+                };
+                let type_str = member.member_type.type_string();
+                if !matches!(member.member_type, CastMemberType::Flash(_)) {
+                    return (None, format!("sprite#{} member type='{}' (not Flash)", any_sprite, type_str));
+                }
+                let rect = super::score::get_concrete_sprite_rect(player, sprite);
+                (
+                    Some((any_sprite as i32, x - rect.left, y - rect.top)),
+                    format!("Flash sprite#{} member={}:{} rect=({},{})-({},{})",
+                        any_sprite, member_ref.cast_lib, member_ref.cast_member,
+                        rect.left, rect.top, rect.right, rect.bottom),
+                )
+            });
+            debug!("[Flash mouseDown] click@({},{}) → {}", x, y, debug_info);
+
+            // Diagnostic: dump the script names attached to the clicked sprite
+            // so we can see what behaviours (if any) have a chance to handle
+            // mouseUp. If the list is empty / has no on mouseUp, clicking is a
+            // no-op regardless of Flash forwarding.
+            let sprite_scripts_dump = reserve_player_ref(|player| {
+                let any_sprite = match get_sprite_at(player, x, y, false) {
+                    Some(s) => s,
+                    None => return "none".to_string(),
+                };
+                let sprite = match player.movie.score.get_sprite(any_sprite as i16) {
+                    Some(s) => s,
+                    None => return format!("sprite#{} missing", any_sprite),
+                };
+                let names: Vec<String> = sprite
+                    .script_instance_list
+                    .iter()
+                    .map(|inst_ref| {
+                        let inst = player.allocator.get_script_instance(inst_ref);
+                        let script = player.movie.cast_manager.get_script_by_ref(&inst.script);
+                        let script_name = script.map(|s| s.name.clone()).unwrap_or_else(|| "?".to_string());
+                        let handlers = script
+                            .map(|s| {
+                                s.handlers
+                                    .iter()
+                                    .map(|(name, _def)| name.to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(",")
+                            })
+                            .unwrap_or_default();
+                        format!("{}({}/{}: handlers=[{}])",
+                            script_name,
+                            inst.script.cast_lib, inst.script.cast_member,
+                            handlers)
+                    })
+                    .collect();
+                if names.is_empty() {
+                    format!("sprite#{} has 0 behaviours", any_sprite)
+                } else {
+                    format!("sprite#{} behaviours: {}", any_sprite, names.join(" | "))
+                }
+            });
+            debug!("[click sprite scripts] {}", sprite_scripts_dump);
+            if let Some((sn, lx, ly)) = flash_forward {
+                // AVM1 button hit-testing reads the stage-mouse position
+                // that's last updated by MouseMove. A real browser always
+                // emits pointermove before pointerdown, so the position is
+                // current. Our injected MouseDown alone leaves the stage
+                // mouse at its previous location (often 0,0 if no organic
+                // input ever reached the SWF), and Ruffle's button test
+                // misses the click. Send a MouseMove first to seed it.
+                let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
+                    sn, "move", lx, ly,
+                );
+                let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
+                    sn, "down", lx, ly,
+                );
+            }
 
             // Temporarily clear ALL is_yield_safe() flags so that updateStage()
             // called from within mouseDown handlers will render (but not yield).
@@ -664,9 +779,39 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                 saved
             });
 
+            // Mirror the mouseDown forwarding: if the cursor is currently
+            // over a Flash sprite, hand the release into Ruffle so the SWF's
+            // own AS1 button handlers (`on (release)`) can fire. Uses the
+            // current cursor position — AS1 buttons need press+release on the
+            // same Flash member to register a click, so resolving by cursor
+            // position handles the common click-and-release-in-place case.
+            // (releaseOutside semantics for drag-off-the-button can be added
+            // later by tracking the press sprite separately.)
+            let flash_forward_up = reserve_player_ref(|player| {
+                let any_sprite = get_sprite_at(player, x, y, false)?;
+                let sprite = player.movie.score.get_sprite(any_sprite as i16)?;
+                let member_ref = sprite.member.as_ref()?;
+                let member = player.movie.cast_manager.find_member_by_ref(member_ref)?;
+                if !matches!(member.member_type, CastMemberType::Flash(_)) {
+                    return None;
+                }
+                let rect = super::score::get_concrete_sprite_rect(player, sprite);
+                Some((any_sprite as i32, x - rect.left, y - rect.top))
+            });
+            if let Some((sn, lx, ly)) = flash_forward_up {
+                // Same MouseMove-before-MouseUp seeding as the down handler.
+                let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
+                    sn, "move", lx, ly,
+                );
+                let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
+                    sn, "up", lx, ly,
+                );
+            }
+
             // Dispatch to the sprite that originally received mouseDown,
             // or fall through to frame/movie scripts if no sprite was involved.
             let dispatched_to_sprite = if let Some((_, _, sprite_num)) = result.as_ref() {
+                debug!("[mouseUp] dispatching to sprite#{} (event={})", sprite_num, event_name);
                 if *sprite_num > 0 {
                     player_dispatch_event_to_sprite_targeted(
                         &event_name.to_string(),
@@ -678,6 +823,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                     false
                 }
             } else {
+                debug!("[mouseUp] no sprite to dispatch to (result was None)");
                 false
             };
 
@@ -818,32 +964,54 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
 
                 let hovered_sprite = player.hovered_sprite;
                 let sprite_num = get_sprite_at(player, x, y, false);
-                if let Some(sprite_num) = sprite_num {
-                    player.hovered_sprite = Some(sprite_num as i16);
-                }
+                // Always update hovered_sprite — set to Some(N) when the
+                // cursor is over a sprite, clear to None when it's not.
+                // Without the None case, a tile we hovered last would
+                // stay marked as hovered forever and never receive its
+                // mouseLeave event (storyscramble's BS65 #highlight
+                // would then be permanently stuck on the last tile that
+                // got the cursor — visible as a "perma highlight" gray
+                // mask on whichever tile the cursor exited from when
+                // moving off all tiles).
+                player.hovered_sprite = sprite_num.map(|n| n as i16);
                 (sprite_num, hovered_sprite)
             });
-            if let Some(sprite_num) = sprite_num {
-                let hovered_sprite = hovered_sprite.unwrap_or(-1);
-                if hovered_sprite != sprite_num as i16 {
-                    if hovered_sprite != -1 {
+            let prev_hover = hovered_sprite.unwrap_or(-1);
+            match sprite_num {
+                Some(sprite_num) => {
+                    if prev_hover != sprite_num as i16 {
+                        if prev_hover != -1 {
+                            player_dispatch_event_to_sprite(
+                                &"mouseLeave".to_string(),
+                                &vec![],
+                                prev_hover as u16,
+                            )
+                        }
+                        player_dispatch_event_to_sprite(
+                            &"mouseEnter".to_string(),
+                            &vec![],
+                            sprite_num as u16,
+                        );
+                    } else {
+                        player_dispatch_event_to_sprite(
+                            &"mouseWithin".to_string(),
+                            &vec![],
+                            sprite_num as u16,
+                        );
+                    }
+                }
+                None => {
+                    // Cursor moved off all sprites. Fire mouseLeave on
+                    // whatever sprite we were previously hovering so
+                    // behaviours can react (BS65 unHighlight, custom
+                    // tooltip teardown, etc.).
+                    if prev_hover != -1 {
                         player_dispatch_event_to_sprite(
                             &"mouseLeave".to_string(),
                             &vec![],
-                            hovered_sprite as u16,
+                            prev_hover as u16,
                         )
                     }
-                    player_dispatch_event_to_sprite(
-                        &"mouseEnter".to_string(),
-                        &vec![],
-                        sprite_num as u16,
-                    );
-                } else {
-                    player_dispatch_event_to_sprite(
-                        &"mouseWithin".to_string(),
-                        &vec![],
-                        sprite_num as u16,
-                    );
                 }
             }
         }
@@ -1020,6 +1188,54 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                     let _ = script_set_prop(player, &instance_ref, &prop_name, &value, false);
                 }
             });
+        }
+        PlayerVMCommand::DispatchFlashEvent { cast_lib, cast_member, handler_name, args } => {
+            // Director's Flash Asset Xtra targets the SPRITE that owns the
+            // Flash member — semantically `sendSprite(flashSpriteNum, …)`,
+            // NOT a global broadcast. Going global made `on send` fire once
+            // per sprite that defined it (e.g. storyscramble's
+            // BehaviorScript 24 attached to multiple sprites).
+            //
+            // Resolve the host sprite by member match. In typical Director
+            // movies there's one sprite per Flash member at any frame; if
+            // multiple sprites share the same member we dispatch to each
+            // (each behaves independently, mirroring the Xtra's behaviour
+            // when the same SWF is on stage twice).
+            let sprite_nums: Vec<u16> = reserve_player_ref(|player| {
+                player
+                    .movie
+                    .score
+                    .channels
+                    .iter()
+                    .filter_map(|channel| {
+                        let m = channel.sprite.member.as_ref()?;
+                        if m.cast_lib == cast_lib && m.cast_member == cast_member {
+                            Some(channel.number as u16)
+                        } else {
+                            None
+                        }
+                    })
+                    .collect()
+            });
+
+            if sprite_nums.is_empty() {
+                // Member exists but isn't on stage right now — fall back to
+                // the global path so movie / frame scripts still get a chance
+                // (matches Director's behaviour of dispatching even when the
+                // Flash sprite has just been removed from the score).
+                use super::events::player_invoke_global_event;
+                let _ = player_invoke_global_event(&handler_name, &args).await;
+            } else {
+                use super::events::player_dispatch_event_to_sprite_targeted;
+                for sprite_num in sprite_nums {
+                    player_dispatch_event_to_sprite_targeted(
+                        &handler_name,
+                        &args,
+                        sprite_num,
+                    )
+                    .await;
+                }
+            }
         }
     }
     Ok(DatumRef::Void)

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -71,6 +71,18 @@ pub enum LingoExpr {
     ThePropOf(Box<LingoExpr>, String), // "the X of Y" constructs
     ChunkExpr(String, Box<LingoExpr>, Option<Box<LingoExpr>>, Box<LingoExpr>),
     DeleteChunk(Box<LingoExpr>), // delete <chunk_expr>
+    /// `if EXPR then COMMAND` inline form (no `else`, no `end if`). Used
+    /// by Director's text-eval contexts like `keyUpScript`, where the
+    /// assigned source is typically a single line: `if the key = "d"
+    /// then sendAllSprites(#toggleDebug)`. Multi-line `if … end if`
+    /// blocks live in the compiled bytecode path and aren't parsed by
+    /// the AST evaluator.
+    IfThen(Box<LingoExpr>, Box<LingoExpr>),
+    /// `pass` keyword — Lingo's "don't consume this event, let it
+    /// propagate". In a script-text context (where no event-dispatch
+    /// chain is being walked) it's effectively a no-op; we evaluate to
+    /// Void.
+    Pass,
 }
 
 /// Evaluate a static Lingo expression. This does not support function calls.
@@ -443,6 +455,18 @@ fn get_eval_top_level_prop(
 ) -> Result<DatumRef, ScriptError> {
     if prop_name.starts_with("the ") {
         let actual_prop = &prop_name[4..];
+        // `the paramCount` reads from the current handler's scope, not the
+        // movie. Bytecode handles it via the_built_in; route AST eval too so
+        // the message window and `do` strings can read it.
+        if actual_prop.eq_ignore_ascii_case("paramCount") {
+            if player.scope_count > 0 && (player.scope_count as usize) <= player.scopes.len() {
+                let scope_idx = (player.scope_count - 1) as usize;
+                if let Some(scope) = player.scopes.get(scope_idx) {
+                    return Ok(player.alloc_datum(Datum::Int(scope.args.len() as i32)));
+                }
+            }
+            return Ok(player.alloc_datum(Datum::Int(0)));
+        }
         let result = player.get_movie_prop(actual_prop)?;
         return Ok(result);
     }
@@ -853,6 +877,30 @@ pub fn parse_lingo_rule_runtime(
             }
             Ok(LingoExpr::HandlerCall("go".to_owned(), args))
         }
+        Rule::if_inline => {
+            // `if EXPR then COMMAND` — children are the keyword nodes
+            // (if_kw, then_kw) interleaved with the condition expression
+            // and the body command. The keyword nodes carry no data
+            // beyond their text, so skip them and pick up the two
+            // non-keyword children.
+            let mut content = pair.into_inner().filter(|p| !matches!(p.as_rule(), Rule::if_kw | Rule::then_kw));
+            let cond_pair = content
+                .next()
+                .ok_or_else(|| ScriptError::new("if_inline: missing condition".to_string()))?;
+            let body_pair = content
+                .next()
+                .ok_or_else(|| ScriptError::new("if_inline: missing then-body".to_string()))?;
+            let cond = parse_lingo_rule_runtime(cond_pair, pratt)?;
+            let mut body = parse_lingo_rule_runtime(body_pair, pratt)?;
+            // Same identifier→handler-call promotion the top-level
+            // command path does — a bare identifier in command context
+            // is a no-arg handler invocation.
+            if let LingoExpr::Identifier(name) = body {
+                body = LingoExpr::HandlerCall(name, vec![]);
+            }
+            Ok(LingoExpr::IfThen(Box::new(cond), Box::new(body)))
+        }
+        Rule::pass_stmt => Ok(LingoExpr::Pass),
         Rule::handler_call | Rule::command_inline => {
             let mut inner = pair.into_inner();
             let handler_name_pair = inner.next().ok_or_else(|| ScriptError::new("Expected handler name".to_string()))?;
@@ -1125,6 +1173,18 @@ pub fn parse_lingo_rule_runtime(
             let full_text = pair.as_str();
             // Return an identifier that will be resolved at runtime
             Ok(LingoExpr::Identifier(full_text.to_string()))
+        }
+        Rule::the_chunk_count => {
+            // `the number of <chunk_kind> in/of <expr>` — Director's legacy
+            // chunk-count form. Translates to the compound property
+            // "number of <kind>" on the target expr; the runtime get_obj_prop
+            // path on String resolves it to chunk count.
+            let mut inner = pair.into_inner();
+            let kind_pair = inner.next().ok_or_else(|| ScriptError::new("Expected chunk kind after 'the number of'".to_string()))?;
+            let kind = kind_pair.as_str().to_ascii_lowercase();
+            let target_pair = inner.next().ok_or_else(|| ScriptError::new("Expected target after 'in'/'of'".to_string()))?;
+            let target_expr = parse_lingo_expr_runtime(target_pair.into_inner(), pratt)?;
+            Ok(LingoExpr::ThePropOf(Box::new(target_expr), format!("number of {}", kind)))
         }
         Rule::the_prop_of => {
             let mut inner = pair.into_inner();
@@ -2030,18 +2090,34 @@ pub async fn eval_lingo_expr_ast_runtime(expr: &LingoExpr) -> Result<DatumRef, S
                 let left_datum = player.get_datum(&left);
                 let right_datum = player.get_datum(&right);
                 let is_eq = crate::player::compare::datum_equals(
-                    left_datum, 
-                    right_datum, 
+                    left_datum,
+                    right_datum,
                     &player.allocator
                 )?;
                 let is_gt = crate::player::compare::datum_greater_than(
-                    left_datum, 
+                    left_datum,
                     right_datum,
                     &player.allocator
                 )?;
                 Ok(player.alloc_datum(Datum::Int(if is_eq || is_gt { 1 } else { 0 })))
             })
         },
+        LingoExpr::IfThen(cond, body) => {
+            let cond_ref = Box::pin(eval_lingo_expr_ast_runtime(cond)).await?;
+            let cond_true = reserve_player_mut(|player| {
+                player.get_datum(&cond_ref).bool_value()
+            })?;
+            if cond_true {
+                Box::pin(eval_lingo_expr_ast_runtime(body)).await
+            } else {
+                Ok(DatumRef::Void)
+            }
+        }
+        LingoExpr::Pass => {
+            // `pass` in a text-eval context has no handler chain to
+            // forward to — treat as a successful no-op.
+            Ok(DatumRef::Void)
+        }
     }
 }
 
@@ -2123,8 +2199,30 @@ fn create_lingo_pratt_parser() -> PrattParser<Rule> {
 }
 
 pub async fn eval_lingo_command(expr: String) -> Result<DatumRef, ScriptError> {
-    let ast = parse_lingo_expr_ast_runtime(Rule::command_eval_expr, expr)?;
-    eval_lingo_expr_ast_runtime(&ast).await
+    // Director's runtime text-eval contexts (keyUpScript, mouseUpScript,
+    // timeoutScript, `do "…"`) often contain MULTIPLE statements separated
+    // by CR/LF. The grammar's `command_eval_expr` is `SOI ~ command ~ EOI`
+    // — a single statement — so we split first and evaluate each line as
+    // its own command. Empty lines and `--` comments are skipped.
+    // Returns the result of the LAST executed statement (matches Director
+    // `do` semantics).
+    //
+    // For a single-line input this is a fast path: one alloc + one parse.
+    let lines: Vec<&str> = expr
+        .split(|c| c == '\r' || c == '\n')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && !s.starts_with("--"))
+        .collect();
+    if lines.len() <= 1 {
+        let ast = parse_lingo_expr_ast_runtime(Rule::command_eval_expr, expr)?;
+        return eval_lingo_expr_ast_runtime(&ast).await;
+    }
+    let mut last = DatumRef::Void;
+    for line in lines {
+        let ast = parse_lingo_expr_ast_runtime(Rule::command_eval_expr, line.to_string())?;
+        last = eval_lingo_expr_ast_runtime(&ast).await?;
+    }
+    Ok(last)
 }
 
 // Helper functions for testing config parsing without requiring player instance

--- a/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
@@ -18,15 +18,51 @@ use log::warn;
 // src/services/flashPlayerManager.ts::initFlashBridge.
 #[wasm_bindgen]
 extern "C" {
+    // Per-sprite Flash bridge — see datum_handlers/sprite.rs for the full
+    // signature comment. FlashObjectRef-driven calls go through these
+    // externs after resolving the host sprite from the FlashObjectRef.
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetVariable", catch)]
-    fn ruffle_get_variable_global(cast_lib: i32, cast_member: i32, path: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_get_variable_global(sprite_num: i32, path: &str) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetVariable", catch)]
-    fn ruffle_set_variable_global(cast_lib: i32, cast_member: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_set_variable_global(sprite_num: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFunction", catch)]
-    fn ruffle_call_function_global(cast_lib: i32, cast_member: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_call_function_global(sprite_num: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
 
+    /// Forward a Director sprite mouse event into a Flash sprite's Ruffle
+    /// instance. Called from the mouseDown/mouseUp command handlers. The
+    /// SWF's own AS1 button handlers don't otherwise fire because Ruffle's
+    /// canvas is hidden offscreen and never receives real browser clicks.
+    /// `event_type` is "down", "up", or "move"; coordinates are sprite-local
+    /// (origin at the sprite's top-left in Director stage coords).
+    #[wasm_bindgen(js_name = "dirplayer_ruffleDispatchMouse", catch)]
+    pub fn ruffle_dispatch_mouse_event_global(
+        sprite_num: i32,
+        event_type: &str,
+        local_x: i32,
+        local_y: i32,
+    ) -> Result<JsValue, JsValue>;
+}
+
+/// Find the sprite number that currently displays the given Flash cast
+/// member. With per-sprite Ruffle instances we need a sprite-num key for
+/// the JS bridge; FlashObjectRef only carries cast_lib/cast_member, so we
+/// scan the score for the first sprite that references this member.
+/// Most movies have at most one sprite per Flash member; storyscramble's
+/// 3-tile case shares a member but those tiles don't use FlashObjectRef
+/// (they only set frame), so this lookup is fine for the existing surface.
+pub fn find_sprite_for_flash_member(cast_lib: i32, cast_member: i32) -> Option<i32> {
+    crate::player::reserve_player_ref(|player| {
+        for channel in &player.movie.score.channels {
+            if let Some(member_ref) = &channel.sprite.member {
+                if member_ref.cast_lib == cast_lib && member_ref.cast_member == cast_member {
+                    return Some(channel.number as i32);
+                }
+            }
+        }
+        None
+    })
 }
 
 // Global counter for dynamic Flash objects.
@@ -43,10 +79,12 @@ impl FlashObjectDatumHandlers {
 
             if let Datum::FlashObjectRef(flash_ref) = obj_datum {
                 let full_path = format!("{}.{}", flash_ref.path, prop_name);
-                let cl = flash_ref.cast_lib;
-                let cm = flash_ref.cast_member;
+                let sprite_num = match find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member) {
+                    Some(n) => n,
+                    None => return Ok(player.alloc_datum(Datum::Void)),
+                };
 
-                match ruffle_get_variable_global(cl, cm, &full_path) {
+                match ruffle_get_variable_global(sprite_num, &full_path) {
                     Ok(result) => {
                         if result.is_null() || result.is_undefined() {
                             Ok(player.alloc_datum(Datum::Void))
@@ -61,12 +99,12 @@ impl FlashObjectDatumHandlers {
                         } else if let Some(b) = result.as_bool() {
                             Ok(player.alloc_datum(Datum::Int(if b { 1 } else { 0 })))
                         } else {
-                            let new_flash_ref = FlashObjectRef::from_path_with_member(&full_path, cl, cm);
+                            let new_flash_ref = FlashObjectRef::from_path_with_member(&full_path, flash_ref.cast_lib, flash_ref.cast_member);
                             Ok(player.alloc_datum(Datum::FlashObjectRef(new_flash_ref)))
                         }
                     }
                     Err(_) => {
-                        let new_flash_ref = FlashObjectRef::from_path_with_member(&full_path, cl, cm);
+                        let new_flash_ref = FlashObjectRef::from_path_with_member(&full_path, flash_ref.cast_lib, flash_ref.cast_member);
                         Ok(player.alloc_datum(Datum::FlashObjectRef(new_flash_ref)))
                     }
                 }
@@ -101,7 +139,11 @@ impl FlashObjectDatumHandlers {
             }
             let args_str = format!("[{}]", js_args_parts.join(","));
 
-            match ruffle_call_function_global(flash_ref.cast_lib, flash_ref.cast_member, &method_path, &args_str) {
+            let sprite_num = match find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member) {
+                Some(n) => n,
+                None => return Ok(player.alloc_datum(Datum::Void)),
+            };
+            match ruffle_call_function_global(sprite_num, &method_path, &args_str) {
                 Ok(result) => {
                     // Special handling for getGatewayConnection
                     if handler_name == "getGatewayConnection" {
@@ -145,7 +187,11 @@ impl FlashObjectDatumHandlers {
                 _ => "null".to_string(),
             };
 
-            match ruffle_set_variable_global(flash_ref.cast_lib, flash_ref.cast_member, &prop_path, &value_str) {
+            let sprite_num = match find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member) {
+                Some(n) => n,
+                None => return Err(ScriptError::new(format!("No sprite for Flash member {}:{}", flash_ref.cast_lib, flash_ref.cast_member))),
+            };
+            match ruffle_set_variable_global(sprite_num, &prop_path, &value_str) {
                 Ok(_) => Ok(()),
                 Err(e) => {
                     warn!("Failed to set Flash property {}: {:?}", prop_path, e);

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -1050,11 +1050,28 @@ impl SoundManager {
         self.channels.get(channel).cloned()
     }
 
-    pub fn update(&mut self, delta_time: f64, player: &mut DirPlayer) -> Result<(), ScriptError> {
+    pub fn update(&self, delta_time: f64, player: &mut DirPlayer) -> Result<(), ScriptError> {
+        // Takes `&self` (not `&mut self`) so callers can hand in
+        // `player.sound_manager` without double-borrowing the player
+        // — the channels live inside Rc<RefCell<…>> and provide their
+        // own interior mutability, so we don't actually need to mutate
+        // the SoundManager itself here.
+        //
+        // Fast-path: skip the borrow_mut + dispatch loop entirely when
+        // there's nothing to update. This is called once per frame from
+        // the global frame loop, so the steady state (no playing
+        // sounds, no fades) shouldn't pay for an N-channel iteration
+        // every frame. The per-channel `update` is itself an early-
+        // return when idle, but the borrow_mut on Rc<RefCell<…>> still
+        // costs a refcell counter touch per call.
+        let any_active = self.channels.iter().any(|c| {
+            let ch = c.borrow();
+            ch.is_fading || ch.status == SoundStatus::Playing
+        });
+        if !any_active {
+            return Ok(());
+        }
         for channel in &self.channels {
-            // debug: log that update tick is processing this channel
-            debug!("[CH{}] update tick", channel.borrow().channel_num);
-
             channel.borrow_mut().update(delta_time, player)?;
         }
         Ok(())
@@ -1433,26 +1450,34 @@ impl SoundChannel {
     async fn play_current_segment_async(channel_rc: Rc<RefCell<Self>>) {
         use web_sys::console;
 
-        // quick checks and gather data while holding short borrow
-        let (member_ref, audio_context, channel_num, is_decoding) = {
-            let ch = channel_rc.borrow();
-            let idx = match ch.current_segment_index {
-                Some(i) => i,
-                None => {
-                    warn!("⚠️ No current segment to play");
-                    return;
-                }
-            };
+        // `current_segment_index` may have been reset to `None` between
+        // `handle_play`'s spawn and this task actually running.
+        // Canonical trigger: JunkbotUndercover's intro — `handle_play`
+        // sets index=Some(0) + status=Playing + spawns; before the
+        // spawn runs, `SndCheckPlaylist`'s per-frame `SndLinearQueue`
+        // sees `playlist[1..].count < 1` (single-entry playlist) and
+        // calls `setPlayList([:])` then `setPlayList([new entries])`.
+        // The second call sees `status==Playing` and clears the
+        // segment index — leaving playlist_segments populated but
+        // index=None. Falling back to segment 0 keeps playback alive
+        // in that race; otherwise we silently bail and `status` stays
+        // Playing forever with no actual audio.
+        let (member_ref, channel_num, is_decoding) = {
+            let mut ch = channel_rc.borrow_mut();
+            if ch.current_segment_index.is_none() && !ch.playlist_segments.is_empty() {
+                ch.current_segment_index = Some(0);
+            }
+            let idx = ch.current_segment_index.unwrap_or(0);
             let seg = match ch.playlist_segments.get(idx) {
                 Some(s) => s.clone(),
                 None => {
-                    warn!("⚠️ Invalid segment index");
+                    warn!("⚠️ Invalid segment index {} (segments={})",
+                          idx, ch.playlist_segments.len());
                     return;
                 }
             };
             (
                 seg.member_ref.clone(),
-                ch.audio_context.clone().expect("Audio context not initialized"),
                 ch.channel_num,
                 ch.is_decoding.clone(),
             )
@@ -1945,19 +1970,39 @@ impl SoundChannel {
 
                 drop(ch);
 
-                // Set up ended callback
+                // Set up ended callback. Generation guard: when a previous
+                // source was explicitly stopped via `stop_with_when(0.0)`
+                // (from `play_file`'s reentrant `stop_playback_nodes()`
+                // call), its `ended` event fires asynchronously and can
+                // land AFTER a NEW source has already been wired up on
+                // this channel. Without this guard the stale closure
+                // would null the new source's state and trigger an
+                // erroneous `start_next_segment` mid-playback —
+                // exactly the JunkbotUndercover playlist-advancement
+                // bug (every "real" segment end was followed by a
+                // stale-callback segment skip).
                 let self_rc_clone2 = self_rc_clone.clone();
+                let ended_generation = my_generation;
                 let closure = Closure::<dyn FnMut()>::new(move || {
+                    let current_gen = {
+                        let ch = self_rc_clone2.borrow();
+                        *ch.decode_generation.borrow()
+                    };
+                    if current_gen != ended_generation {
+                        debug!("⏭️ Channel {} stale ended (gen {} != {})",
+                            channel_num, ended_generation, current_gen);
+                        return;
+                    }
                     debug!("🔚 Channel {} sound ended", channel_num);
 
                     let mut ch = self_rc_clone2.borrow_mut();
-                    
+
                     // Only proceed if we were actually playing (not stopped early)
                     if ch.status != SoundStatus::Playing {
                         warn!("⚠️ Channel {} was already stopped, ignoring ended event", channel_num);
                         return;
                     }
-                    
+
                     ch.status = SoundStatus::Idle;
                     ch.source_node = None;
                     ch.start_next_segment();
@@ -2273,18 +2318,35 @@ impl SoundChannel {
             source.set_loop(false);
         }
 
+        // Generation guard — see the PCM-resample path for full rationale.
+        // tl;dr: `stop_playback_nodes()` triggers an async `ended` event
+        // on the source it stops, and that event can land after a new
+        // source has been wired up on the same channel. Without this
+        // check the stale callback would null `source_node` and fire
+        // an erroneous `start_next_segment` mid-playback (the
+        // JunkbotUndercover playlist-advancement bug).
+        let ended_generation = my_generation;
         let closure = Closure::<dyn FnMut()>::new(move || {
+            let current_gen = {
+                let ch = self_rc_clone.borrow();
+                *ch.decode_generation.borrow()
+            };
+            if current_gen != ended_generation {
+                debug!("⏭️ Channel {} stale MP3 ended (gen {} != {})",
+                    channel_num, ended_generation, current_gen);
+                return;
+            }
             debug!("🔚 Channel {} MP3 ended", channel_num);
-            
+
             let mut ch = self_rc_clone.borrow_mut();
             debug!("Setting status from {:?} to Idle", ch.status);
-            
+
             // Only proceed if we were actually playing (not stopped early)
             if ch.status != SoundStatus::Playing {
                 warn!("⚠️ Channel {} was already stopped, ignoring ended event", channel_num);
                 return;
             }
-            
+
             ch.status = SoundStatus::Idle;
             ch.source_node = None;  // Clear the source node
             ch.start_next_segment();
@@ -3665,16 +3727,18 @@ impl SoundChannel {
 
         self.elapsed_time += delta_time;
 
-        // Safety net: if elapsed time exceeds the sound duration, force status
-        // to Idle. The onended callback should handle this, but it can fire late
-        // due to async decode/resampling overhead.
-        if self.sample_rate > 0 && self.sample_count > 0 && self.loop_count != 0 {
-            let duration_secs = self.sample_count as f64 / self.sample_rate as f64;
-            if self.elapsed_time > duration_secs + 0.1 {
-                self.status = SoundStatus::Idle;
-                self.source_node = None;
-            }
-        }
+        // Note: previously had a "safety net" here that forced status to
+        // Idle when `elapsed_time > sample_count/sample_rate + 0.1s`.
+        // That heuristic used Director's authored duration (from the cast
+        // member header) which can be *shorter* than the actual Web Audio
+        // buffer length — MP3 decode produces extra samples vs the
+        // ADPCM-authored sample_count, for instance (JunkbotUndercover's
+        // mi_l1: authored 2.001s, decoded 2.376s). The safety net would
+        // fire mid-playback, set status=Idle, and the real `ended`
+        // event then bailed on the `status != Playing` check — breaking
+        // playlist advancement after the first segment ended naturally.
+        // Trust the `ended` event; `stop_playback_nodes` handles
+        // explicit interruption.
 
         Ok(())
     }
@@ -3684,7 +3748,18 @@ impl SoundChannel {
         // Set status to Idle FIRST, before stopping the source
         // This prevents the onended callback from calling start_next_segment
         self.status = SoundStatus::Idle;
-        
+
+        // Bump the generation BEFORE we trigger source.stop_with_when —
+        // the resulting `ended` event will fire async, and by then a
+        // new source may already be wired up. The ended closure compares
+        // its captured `ended_generation` against the current
+        // `decode_generation`; a mismatch means stale-callback → ignore.
+        // Without this, an explicit stop on channel 1 (e.g. play_file's
+        // pre-emption when looping a playlist) would later null the
+        // new segment's source_node and trigger an erroneous
+        // start_next_segment, advancing the playlist by an extra step.
+        *self.decode_generation.borrow_mut() += 1;
+
         if let Some(source) = self.source_node.take() {
             debug!("🛑 Stopping channel {}", self.channel_num);
             let _ = source.stop_with_when(0.0);
@@ -3699,7 +3774,7 @@ impl SoundChannel {
         self.source_node = None;
         self.gain_node = None;
         self.pan_node = None;
-        
+
         // Cancel any in-progress async decode by clearing the flag
         *self.is_decoding.borrow_mut() = false;
     }

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -21,28 +21,38 @@ use super::script_instance::ScriptInstanceUtils;
 // src/services/flashPlayerManager.ts::initFlashBridge.
 #[wasm_bindgen]
 extern "C" {
+    // All Lingo Flash bridge calls now take `sprite_num` because each Flash
+    // sprite has its own Ruffle instance (per-sprite refactor — multiple
+    // sprites sharing one cast member each get an independent player).
+    /// `frame_or_label` is the raw Lingo argument as a string. Director's
+    /// `sprite(N).gotoFrame(...)` accepts either a frame number (e.g. `3`)
+    /// or a label (e.g. `"warm0"`); the JS side parses and routes to
+    /// the appropriate Ruffle call. Always passing a string here lets us
+    /// preserve labels — `.int_value()` on the Rust side silently parses
+    /// non-numeric strings to `0`, and `GotoFrame(0, true)` is treated as
+    /// a stop, which froze mello's Fire/Marshmello SWFs.
     #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrame")]
-    fn ruffle_goto_frame(cast_lib: i32, cast_member: i32, frame: i32);
+    fn ruffle_goto_frame(sprite_num: i32, frame_or_label: &str);
     #[wasm_bindgen(js_name = "dirplayer_ruffleStop")]
-    fn ruffle_stop(cast_lib: i32, cast_member: i32);
+    fn ruffle_stop(sprite_num: i32);
     #[wasm_bindgen(js_name = "dirplayer_rufflePlay")]
-    fn ruffle_play(cast_lib: i32, cast_member: i32);
+    fn ruffle_play(sprite_num: i32);
     #[wasm_bindgen(js_name = "dirplayer_ruffleRewind")]
-    fn ruffle_rewind(cast_lib: i32, cast_member: i32);
+    fn ruffle_rewind(sprite_num: i32);
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFrame")]
-    fn ruffle_call_frame(cast_lib: i32, cast_member: i32, frame: i32);
+    fn ruffle_call_frame(sprite_num: i32, frame: i32);
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetVariable", catch)]
-    fn ruffle_get_variable(cast_lib: i32, cast_member: i32, path: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_get_variable(sprite_num: i32, path: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetVariable", catch)]
-    fn ruffle_set_variable(cast_lib: i32, cast_member: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_set_variable(sprite_num: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFunction", catch)]
-    fn ruffle_call_function(cast_lib: i32, cast_member: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_call_function(sprite_num: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleHitTest")]
-    fn ruffle_hit_test(cast_lib: i32, cast_member: i32, x: f64, y: f64) -> bool;
+    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> bool;
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetFlashProperty", catch)]
-    fn ruffle_get_flash_property(cast_lib: i32, cast_member: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
+    fn ruffle_get_flash_property(sprite_num: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetFlashProperty")]
-    fn ruffle_set_flash_property(cast_lib: i32, cast_member: i32, target: &str, prop_num: i32, value: &str);
+    fn ruffle_set_flash_property(sprite_num: i32, target: &str, prop_num: i32, value: &str);
 }
 
 pub struct SpriteDatumHandlers {}
@@ -117,8 +127,11 @@ impl SpriteDatumUtils {
 }
 
 impl SpriteDatumHandlers {
-    /// Resolve a sprite datum to (cast_lib, cast_member) for Flash bridge calls.
-    fn resolve_sprite_flash_member(datum: &DatumRef) -> Result<Option<(i32, i32)>, ScriptError> {
+    /// Resolve a sprite datum to (sprite_num, cast_lib, cast_member). The
+    /// sprite_num is the lookup key for the per-sprite Ruffle instance;
+    /// cast_lib/cast_member are still needed by callers that build
+    /// `FlashObjectRef`s. Returns None when the sprite has no member.
+    fn resolve_sprite_flash_member(datum: &DatumRef) -> Result<Option<(i32, i32, i32)>, ScriptError> {
         reserve_player_ref(|player| {
             let sprite_num = player.get_datum(datum).to_sprite_ref()?;
             let sprite = match player.movie.score.get_sprite(sprite_num) {
@@ -126,7 +139,11 @@ impl SpriteDatumHandlers {
                 None => return Ok(None),
             };
             match &sprite.member {
-                Some(member_ref) => Ok(Some((member_ref.cast_lib, member_ref.cast_member))),
+                Some(member_ref) => Ok(Some((
+                    sprite_num as i32,
+                    member_ref.cast_lib,
+                    member_ref.cast_member,
+                ))),
                 None => Ok(None),
             }
         })
@@ -548,45 +565,50 @@ impl SpriteDatumHandlers {
             }
             // Flash (SWF) sprite methods
             "gotoframe" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
-                    let frame = reserve_player_ref(|player| {
-                        if args.is_empty() { return Ok(1); }
-                        player.get_datum(&args[0]).int_value()
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
+                    // Pass the raw arg as a string — Lingo callers use
+                    // either a numeric frame or a string label (e.g.
+                    // `sprite(N).gotoFrame("warm0")`). The JS bridge
+                    // parses the string and routes to GotoFrame(int) or
+                    // an AS1 `gotoAndStop(label)` call as appropriate.
+                    let frame_or_label = reserve_player_ref(|player| {
+                        if args.is_empty() { return Ok("1".to_string()); }
+                        player.get_datum(&args[0]).string_value()
                     })?;
-                    ruffle_goto_frame(cl, cm, frame);
+                    ruffle_goto_frame(sn, &frame_or_label);
                 }
                 Ok(DatumRef::Void)
             }
             "callframe" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let frame = reserve_player_ref(|player| {
                         if args.is_empty() { return Ok(1); }
                         player.get_datum(&args[0]).int_value()
                     })?;
-                    ruffle_call_frame(cl, cm, frame);
+                    ruffle_call_frame(sn, frame);
                 }
                 Ok(DatumRef::Void)
             }
             "stop" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
-                    ruffle_stop(cl, cm);
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
+                    ruffle_stop(sn);
                 }
                 Ok(DatumRef::Void)
             }
             "play" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
-                    ruffle_play(cl, cm);
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
+                    ruffle_play(sn);
                 }
                 Ok(DatumRef::Void)
             }
             "rewind" | "hold" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
-                    ruffle_rewind(cl, cm);
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
+                    ruffle_rewind(sn);
                 }
                 Ok(DatumRef::Void)
             }
             "getvariable" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let (path, return_as_object) = reserve_player_ref(|player| {
                         if args.is_empty() { return Ok((String::new(), false)); }
                         let p = player.get_datum(&args[0]).string_value()?;
@@ -606,7 +628,7 @@ impl SpriteDatumHandlers {
                         // if it returns a JS string, return as Datum::String so that
                         // stringp() works. If it returns an object or undefined, return
                         // a FlashObjectRef for setCallback/call usage.
-                        match ruffle_get_variable(cl, cm, &path) {
+                        match ruffle_get_variable(sn, &path) {
                             Ok(val) => {
                                 if val.is_string() {
                                     // Simple string variable - return as string
@@ -626,7 +648,7 @@ impl SpriteDatumHandlers {
                         });
                     }
 
-                    match ruffle_get_variable(cl, cm, &path) {
+                    match ruffle_get_variable(sn, &path) {
                         Ok(val) => {
                             if let Some(s) = val.as_string() {
                                 return reserve_player_mut(|player| {
@@ -640,21 +662,21 @@ impl SpriteDatumHandlers {
                 Ok(DatumRef::Void)
             }
             "setvariable" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let path = reserve_player_ref(|player| {
                         player.get_datum(&args[0]).string_value()
                     })?;
                     let value = reserve_player_ref(|player| {
                         player.get_datum(&args[1]).string_value()
                     })?;
-                    if let Err(e) = ruffle_set_variable(cl, cm, &path, &value) {
+                    if let Err(e) = ruffle_set_variable(sn, &path, &value) {
                         warn!("sprite.setVariable error: {:?}", e);
                     }
                 }
                 Ok(DatumRef::Void)
             }
             "callfunction" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let path = reserve_player_ref(|player| {
                         player.get_datum(&args[0]).string_value()
                     })?;
@@ -665,7 +687,7 @@ impl SpriteDatumHandlers {
                     } else {
                         String::new()
                     };
-                    match ruffle_call_function(cl, cm, &path, &args_xml) {
+                    match ruffle_call_function(sn, &path, &args_xml) {
                         Ok(val) => {
                             if let Some(s) = val.as_string() {
                                 return reserve_player_mut(|player| {
@@ -679,10 +701,10 @@ impl SpriteDatumHandlers {
                 Ok(DatumRef::Void)
             }
             "hittest" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let x = reserve_player_ref(|player| player.get_datum(&args[0]).int_value())?;
                     let y = reserve_player_ref(|player| player.get_datum(&args[1]).int_value())?;
-                    let result = ruffle_hit_test(cl, cm, x as f64, y as f64);
+                    let result = ruffle_hit_test(sn, x as f64, y as f64);
                     return reserve_player_mut(|player| {
                         Ok(player.alloc_datum(Datum::Int(if result { 1 } else { 0 })))
                     });
@@ -690,10 +712,10 @@ impl SpriteDatumHandlers {
                 Ok(DatumRef::Void)
             }
             "getflashproperty" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let target = reserve_player_ref(|player| player.get_datum(&args[0]).string_value())?;
                     let prop_num = reserve_player_ref(|player| player.get_datum(&args[1]).int_value())?;
-                    match ruffle_get_flash_property(cl, cm, &target, prop_num) {
+                    match ruffle_get_flash_property(sn, &target, prop_num) {
                         Ok(val) => {
                             if let Some(s) = val.as_string() {
                                 return reserve_player_mut(|player| {
@@ -707,11 +729,11 @@ impl SpriteDatumHandlers {
                 Ok(DatumRef::Void)
             }
             "setflashproperty" => {
-                if let Some((cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let target = reserve_player_ref(|player| player.get_datum(&args[0]).string_value())?;
                     let prop_num = reserve_player_ref(|player| player.get_datum(&args[1]).int_value())?;
                     let value = reserve_player_ref(|player| player.get_datum(&args[2]).string_value())?;
-                    ruffle_set_flash_property(cl, cm, &target, prop_num, &value);
+                    ruffle_set_flash_property(sn, &target, prop_num, &value);
                 }
                 Ok(DatumRef::Void)
             }

--- a/vm-rust/src/player/handlers/datum_handlers/string.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string.rs
@@ -102,6 +102,22 @@ impl StringDatumUtils {
                     Ok(Datum::Int(frame_num))
                 })
             }
+            // Director's `the number of <chunk> in <str>` form lands here as
+            // a compound property name "number of lines/words/items/chars".
+            // Returns the chunk count.
+            "number of chars" | "number of characters" => {
+                Ok(Datum::Int(value.chars().count() as i32))
+            }
+            "number of lines" => {
+                Ok(Datum::Int(string_get_lines(value).len() as i32))
+            }
+            "number of words" => {
+                Ok(Datum::Int(string_get_words(value).len() as i32))
+            }
+            "number of items" => {
+                let delim = reserve_player_ref(|player| Ok(player.movie.item_delimiter))?;
+                Ok(Datum::Int(string_get_items(value, delim).len() as i32))
+            }
             _ => Err(ScriptError::new(format!(
                 "Invalid string built-in property {prop_name}"
             ))),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -34,58 +34,63 @@ use crate::{
 // src/services/flashPlayerManager.ts::initFlashBridge.
 #[wasm_bindgen]
 extern "C" {
-    /// Call into Ruffle's JS API to get a Flash variable
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetVariable", catch)]
-    fn ruffle_get_variable(cast_lib: i32, cast_member: i32, path: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_get_variable(sprite_num: i32, path: &str) -> Result<JsValue, JsValue>;
 
-    /// Call into Ruffle's JS API to set a Flash variable
+    // Per-sprite Flash bridge — each Flash sprite has its own Ruffle
+    // instance keyed by sprite_num.
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetVariable", catch)]
-    fn ruffle_set_variable(cast_lib: i32, cast_member: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_set_variable(sprite_num: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
 
-    /// Call a Flash function via Ruffle's JS API
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFunction", catch)]
-    fn ruffle_call_function(cast_lib: i32, cast_member: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
+    fn ruffle_call_function(sprite_num: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
 
-    /// Go to a specific frame on a Flash instance
+    /// Always pass a string here — JS-side parses int vs label.
+    /// Director's gotoFrame accepts both `gotoFrame(5)` (numeric) and
+    /// `gotoFrame("warm0")` (label); routing labels through `int_value()`
+    /// silently parses to 0 and breaks animation.
     #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrame")]
-    fn ruffle_goto_frame(cast_lib: i32, cast_member: i32, frame: i32);
+    fn ruffle_goto_frame(sprite_num: i32, frame_or_label: &str);
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleStop")]
-    fn ruffle_stop(cast_lib: i32, cast_member: i32);
+    fn ruffle_stop(sprite_num: i32);
 
     #[wasm_bindgen(js_name = "dirplayer_rufflePlay")]
-    fn ruffle_play(cast_lib: i32, cast_member: i32);
+    fn ruffle_play(sprite_num: i32);
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleRewind")]
-    fn ruffle_rewind(cast_lib: i32, cast_member: i32);
+    fn ruffle_rewind(sprite_num: i32);
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleIsPlaying")]
-    fn ruffle_is_playing(cast_lib: i32, cast_member: i32) -> bool;
+    fn ruffle_is_playing(sprite_num: i32) -> bool;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetFrameCount")]
-    fn ruffle_get_frame_count(cast_lib: i32, cast_member: i32) -> i32;
+    fn ruffle_get_frame_count(sprite_num: i32) -> i32;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetCurrentFrame")]
-    fn ruffle_get_current_frame(cast_lib: i32, cast_member: i32) -> i32;
+    fn ruffle_get_current_frame(sprite_num: i32) -> i32;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFrame")]
-    fn ruffle_call_frame(cast_lib: i32, cast_member: i32, frame: i32);
+    fn ruffle_call_frame(sprite_num: i32, frame: i32);
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleHitTest")]
-    fn ruffle_hit_test(cast_lib: i32, cast_member: i32, x: f64, y: f64) -> bool;
+    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> bool;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetFlashProperty", catch)]
-    fn ruffle_get_flash_property(cast_lib: i32, cast_member: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
+    fn ruffle_get_flash_property(sprite_num: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetFlashProperty")]
-    fn ruffle_set_flash_property(cast_lib: i32, cast_member: i32, target: &str, prop_num: i32, value: &str);
+    fn ruffle_set_flash_property(sprite_num: i32, target: &str, prop_num: i32, value: &str);
 }
 
 pub struct BuiltInHandlerManager {}
 
 impl BuiltInHandlerManager {
-    /// Resolve a sprite datum to (cast_lib, cast_member) for Flash bridge calls.
-    fn resolve_flash_member(datum_ref: &DatumRef) -> Result<Option<(i32, i32)>, ScriptError> {
+    /// Resolve a sprite/integer datum to its sprite number for Flash bridge
+    /// calls. Per-sprite Ruffle instances mean sprite_num is the lookup
+    /// key; cast_lib/cast_member are returned alongside for callers that
+    /// still need them (e.g. building FlashObjectRefs).
+    fn resolve_flash_member(datum_ref: &DatumRef) -> Result<Option<(i32, i32, i32)>, ScriptError> {
         reserve_player_ref(|player| {
             let datum = player.get_datum(datum_ref);
             let sprite_num = match datum {
@@ -98,8 +103,47 @@ impl BuiltInHandlerManager {
                 None => return Ok(None),
             };
             match &sprite.member {
-                Some(member_ref) => Ok(Some((member_ref.cast_lib as i32, member_ref.cast_member as i32))),
+                Some(member_ref) => Ok(Some((
+                    sprite_num as i32,
+                    member_ref.cast_lib as i32,
+                    member_ref.cast_member as i32,
+                ))),
                 None => Ok(None),
+            }
+        })
+    }
+
+    /// Like `resolve_flash_member`, but only returns Some when the
+    /// sprite's member is actually a Flash cast member. Used by the
+    /// `stop` / `play` / `rewind` Lingo built-ins so we route those to
+    /// the Ruffle bridge only for Flash sprites — `stop sound 1`,
+    /// `stop(member …)` etc. continue to fall through to the existing
+    /// SWA no-op (which is correct for those operands in the web port).
+    fn resolve_flash_sprite_strict(datum_ref: &DatumRef) -> Result<Option<i32>, ScriptError> {
+        use crate::player::cast_member::CastMemberType;
+        reserve_player_ref(|player| {
+            let datum = player.get_datum(datum_ref);
+            let sprite_num = match datum {
+                Datum::SpriteRef(n) => *n,
+                Datum::Int(n) => *n as i16,
+                _ => return Ok(None),
+            };
+            let sprite = match player.movie.score.get_sprite(sprite_num) {
+                Some(s) => s,
+                None => return Ok(None),
+            };
+            let member_ref = match &sprite.member {
+                Some(m) => m,
+                None => return Ok(None),
+            };
+            let member = match player.movie.cast_manager.find_member_by_ref(member_ref) {
+                Some(m) => m,
+                None => return Ok(None),
+            };
+            if matches!(member.member_type, CastMemberType::Flash(_)) {
+                Ok(Some(sprite_num as i32))
+            } else {
+                Ok(None)
             }
         })
     }
@@ -900,8 +944,42 @@ impl BuiltInHandlerManager {
                     Ok(player.alloc_datum(Datum::Int(posn.max(top).min(bottom))))
                 })
             }
-            // stop/play/rewind/sound on a member or channel — no-op in web player
-            "stop" | "play" | "rewind" | "pause"  => Ok(DatumRef::Void),
+            // `stop` / `play` / `rewind` / `pause` are overloaded Lingo
+            // built-ins. Historically the web port stubbed them all to
+            // no-op because they targeted SWA sound channels (`stop sound 1`)
+            // which we don't implement. But Director also uses them on
+            // Flash sprites (`stop(sprite N)`, `play(sprite N)`,
+            // `rewind(sprite N)`) — storyscramble's BS38 calls
+            // `stop(sprite(me.spriteNum))` right after `gotoFrame(...,31)`
+            // to park the bubble. Route Flash-sprite operands to the
+            // Ruffle bridge; everything else (sound channels, members,
+            // bare integers that don't resolve to a Flash sprite) keeps
+            // the historical no-op behaviour.
+            "stop" => {
+                if args.len() >= 1 {
+                    if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                        ruffle_stop(sn);
+                    }
+                }
+                Ok(DatumRef::Void)
+            }
+            "play" => {
+                if args.len() >= 1 {
+                    if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                        ruffle_play(sn);
+                    }
+                }
+                Ok(DatumRef::Void)
+            }
+            "rewind" => {
+                if args.len() >= 1 {
+                    if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                        ruffle_rewind(sn);
+                    }
+                }
+                Ok(DatumRef::Void)
+            }
+            "pause"  => Ok(DatumRef::Void),
             "cursor" => TypeHandlers::cursor(args),
             "externalparamcount" => MovieHandlers::external_param_count(args),
             "externalparamname" => MovieHandlers::external_param_name(args),
@@ -998,8 +1076,8 @@ impl BuiltInHandlerManager {
                     let path = reserve_player_ref(|player| {
                         player.get_datum(&args[1]).string_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        match ruffle_get_variable(cast_lib, cast_member, &path) {
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        match ruffle_get_variable(sn, &path) {
                             Ok(val) => {
                                 if let Some(s) = val.as_string() {
                                     return reserve_player_mut(|player| {
@@ -1023,8 +1101,8 @@ impl BuiltInHandlerManager {
                     let value = reserve_player_ref(|player| {
                         player.get_datum(&args[2]).string_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        if let Err(e) = ruffle_set_variable(cast_lib, cast_member, &path, &value) {
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        if let Err(e) = ruffle_set_variable(sn, &path, &value) {
                             warn!("setVariable error: {:?}", e);
                         }
                     }
@@ -1032,14 +1110,14 @@ impl BuiltInHandlerManager {
                 Ok(DatumRef::Void)
             }
             "gotoframe" => {
-                // Flash (SWF) member interop — goToFrame(sprite, frame)
+                // Flash (SWF) member interop — goToFrame(sprite, frame_or_label)
                 if args.len() >= 2 {
                     let member_ref = Self::resolve_flash_member(&args[0])?;
-                    let frame = reserve_player_ref(|player| {
-                        player.get_datum(&args[1]).int_value()
+                    let frame_or_label = reserve_player_ref(|player| {
+                        player.get_datum(&args[1]).string_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        ruffle_goto_frame(cast_lib, cast_member, frame);
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        ruffle_goto_frame(sn, &frame_or_label);
                     }
                 }
                 Ok(DatumRef::Void)
@@ -1050,8 +1128,8 @@ impl BuiltInHandlerManager {
                     let frame = reserve_player_ref(|player| {
                         player.get_datum(&args[1]).int_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        ruffle_call_frame(cast_lib, cast_member, frame);
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        ruffle_call_frame(sn, frame);
                     }
                 }
                 Ok(DatumRef::Void)
@@ -1065,8 +1143,8 @@ impl BuiltInHandlerManager {
                     let prop_num = reserve_player_ref(|player| {
                         player.get_datum(&args[2]).int_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        match ruffle_get_flash_property(cast_lib, cast_member, &target, prop_num) {
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        match ruffle_get_flash_property(sn, &target, prop_num) {
                             Ok(val) => {
                                 if let Some(s) = val.as_string() {
                                     return reserve_player_mut(|player| {
@@ -1092,8 +1170,8 @@ impl BuiltInHandlerManager {
                     let value = reserve_player_ref(|player| {
                         player.get_datum(&args[3]).string_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        ruffle_set_flash_property(cast_lib, cast_member, &target, prop_num, &value);
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        ruffle_set_flash_property(sn, &target, prop_num, &value);
                     }
                 }
                 Ok(DatumRef::Void)
@@ -1107,8 +1185,8 @@ impl BuiltInHandlerManager {
                     let y = reserve_player_ref(|player| {
                         player.get_datum(&args[2]).int_value()
                     })?;
-                    if let Some((cast_lib, cast_member)) = member_ref {
-                        let result = ruffle_hit_test(cast_lib, cast_member, x as f64, y as f64);
+                    if let Some((sn, _cl, _cm)) = member_ref {
+                        let result = ruffle_hit_test(sn, x as f64, y as f64);
                         return reserve_player_mut(|player| {
                             Ok(player.alloc_datum(Datum::Int(if result { 1 } else { 0 })))
                         });

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -258,7 +258,10 @@ impl MovieHandlers {
                     }
 
                     player.advance_frame();
-                    player.movie.frame_script_instance = None;
+                    // begin_all_sprites manages frame_script_instance lifecycle —
+                    // it preserves the cached instance while the playhead stays within
+                    // the same frame script's span and recreates it only when the active
+                    // script changes or the span is exited.
                     player.begin_all_sprites();
 
                     // Apply tweening after sprites are initialized

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -284,8 +284,18 @@ pub struct DirPlayer {
     pub system_start_time: chrono::DateTime<chrono::Local>, // For ticks & milliSeconds (system uptime)
     pub handler_stack_depth: usize,
     pub in_frame_script: bool,
-    /// Flash frame buffers: maps (cast_lib, cast_member) to BitmapRef in bitmap_manager
-    pub flash_frame_buffers: HashMap<(i32, i32), bitmap::manager::BitmapRef>,
+    /// Per-sprite Flash frame buffers. One Ruffle instance per (sprite,
+    /// cast_member) gives each Flash sprite an independent playhead, which
+    /// is what Director semantics actually require (e.g. storyscramble's 3
+    /// story tiles share one Flash member but display different poster
+    /// frames simultaneously). Keyed by sprite number; the renderer reads
+    /// `flash_frame_buffers[channel_num]` when drawing a Flash sprite.
+    pub flash_frame_buffers: HashMap<i16, bitmap::manager::BitmapRef>,
+    /// Whether the lazy-load dispatch has fired for a given (sprite,
+    /// cast_lib, cast_member). Prevents the renderer from triggering
+    /// duplicate `createFlashInstance` calls every frame before the
+    /// instance's first pixels arrive.
+    pub flash_sprite_loaded: HashSet<(i16, i32, i32)>,
     /// Cached rendered 3D scene bitmaps (populated during sprite rendering, read by world.image)
     pub w3d_frame_buffers: HashMap<(i32, i32), bitmap::manager::BitmapRef>,
     pub in_enter_frame: bool,
@@ -480,6 +490,7 @@ impl DirPlayer {
             handler_stack_depth: 0,
             in_frame_script: false,
             flash_frame_buffers: HashMap::new(),
+            flash_sprite_loaded: HashSet::new(),
             w3d_frame_buffers: HashMap::new(),
             in_enter_frame: false,
             in_prepare_frame: false,
@@ -527,12 +538,14 @@ impl DirPlayer {
     }
 
     /// Pre-dispatch Flash members for all active sprites so they start loading
-    /// before Lingo scripts try to access them.
+    /// before Lingo scripts try to access them. Per-sprite: each sprite that
+    /// references a Flash member gets its own dedicated Ruffle instance.
     pub fn pre_dispatch_flash_members(&mut self) {
         for channel in &self.movie.score.channels {
+            let channel_num = channel.number as i16;
             if let Some(member_ref) = &channel.sprite.member {
-                let flash_key = (member_ref.cast_lib, member_ref.cast_member);
-                if self.flash_frame_buffers.contains_key(&flash_key) {
+                let dispatch_key = (channel_num, member_ref.cast_lib, member_ref.cast_member);
+                if self.flash_sprite_loaded.contains(&dispatch_key) {
                     continue;
                 }
                 if let Some(member) = self.movie.cast_manager.find_member_by_ref(member_ref) {
@@ -541,19 +554,26 @@ impl DirPlayer {
                             let data = flash_member.data.clone();
                             let w = channel.sprite.width.max(1) as u32;
                             let h = channel.sprite.height.max(1) as u32;
+                            let paused_at_start = flash_member
+                                .flash_info
+                                .as_ref()
+                                .map(|fi| fi.paused_at_start)
+                                .unwrap_or(false);
                             debug!(
-                                "[Flash] Pre-dispatching {}:{} ({}x{}, {} bytes)",
-                                member_ref.cast_lib, member_ref.cast_member,
-                                w, h, data.len()
+                                "[Flash] Pre-dispatching sprite#{} {}:{} ({}x{}, {} bytes, pausedAtStart={})",
+                                channel_num, member_ref.cast_lib, member_ref.cast_member,
+                                w, h, data.len(), paused_at_start,
                             );
                             JsApi::dispatch_flash_member_loaded(
+                                channel_num as i32,
                                 member_ref.cast_lib,
                                 member_ref.cast_member,
                                 &data,
                                 w,
                                 h,
+                                paused_at_start,
                             );
-                            self.flash_frame_buffers.insert(flash_key, 0);
+                            self.flash_sprite_loaded.insert(dispatch_key);
                         }
                     }
                 }
@@ -2308,7 +2328,7 @@ impl DirPlayer {
         member_ref: DatumRef,
     ) -> Result<(), ScriptError> {
         let sound_channel = self.get_sound_channel(channel_num)?;
-        
+
         // Get the loop setting from the cast member
         let loop_count = {
             let member_datum = self.get_datum(&member_ref);
@@ -3687,7 +3707,10 @@ pub async fn run_single_frame() -> (bool, bool) {
 
     reserve_player_mut(|player| {
         if !stayed_on_same_frame {
-            player.movie.frame_script_instance = None;
+            // begin_all_sprites manages frame_script_instance lifecycle: it preserves
+            // the cached instance while the playhead stays within the same script's
+            // span (so the script's properties survive across frames) and recreates
+            // it only when the active frame script changes or the span is exited.
             player.begin_all_sprites();
         }
 
@@ -3835,6 +3858,26 @@ pub async fn run_single_frame() -> (bool, bool) {
     (is_playing, is_script_paused)
 }
 
+/// Tick the global SoundManager by `delta` seconds — advances fades
+/// regardless of whether the frame loop is currently paused (e.g.
+/// blocked on a Flash/Ruffle load). Without this, a `sound fadeIn`
+/// started just before such a pause leaves the channel at gain=0 for
+/// the entire blocked period: the audio source plays silently into a
+/// zero-gain node and is gone by the time the frame loop resumes.
+fn tick_sound_manager(delta: f64) {
+    unsafe {
+        if let Some(player) = PLAYER_OPT.as_mut() {
+            // Aliasing the player via a raw pointer because
+            // SoundManager::update needs `&mut DirPlayer` for
+            // bookkeeping but lives inside the same player.
+            // SoundManager::update is `&self` and only touches the
+            // channels (Rc<RefCell<…>>), so this aliasing is sound.
+            let player_ptr = player as *mut DirPlayer;
+            let _ = player.sound_manager.update(delta, &mut *player_ptr);
+        }
+    }
+}
+
 pub async fn run_frame_loop() {
     unsafe {
         let player = PLAYER_OPT.as_ref().unwrap();
@@ -3882,6 +3925,12 @@ pub async fn run_frame_loop() {
             debug!("[Flash] Waiting for Ruffle instance to finish loading...");
             for _ in 0..150 {
                 timeout(Duration::from_millis(100), future::pending::<()>()).await.unwrap_err();
+                // Tick sound manager during the wait: a 1.6s applause
+                // with `sound fadeIn` started right before this pause
+                // would otherwise stay at gain=0 for its entire
+                // duration (frame loop is blocked, so the fade ramp
+                // never runs). 0.1s matches the wait granularity.
+                tick_sound_manager(0.1);
                 if !is_flash_loading().unwrap_or(false) {
                     break;
                 }
@@ -3898,12 +3947,27 @@ pub async fn run_frame_loop() {
             return;
         }
 
+        // Tick the sound manager so per-channel fade-in / fade-out
+        // progress. Without this, Lingo's `sound fadeIn` sets the
+        // channel volume to 0 to start the fade but the ramp never
+        // runs — the audio gets scheduled into a gain=0 node and plays
+        // silently (storyscramble's `playPayoff` applause uses fadeIn
+        // via the soundLoop script). Delta is the per-frame tempo
+        // interval in seconds; matches what the SoundChannel::update
+        // fade math expects.
+        {
+            let tempo = reserve_player_ref(|player| player.current_frame_tempo);
+            let delta = if tempo == 0 { 1.0 / 30.0 } else { 1.0 / tempo as f64 };
+            tick_sound_manager(delta);
+        }
+
         // Also check after frame execution: if scripts tried to access a Flash
         // instance that doesn't exist yet, wait for Ruffle to finish loading.
         if is_flash_loading().unwrap_or(false) {
             debug!("[Flash] Scripts accessed unready Flash instance, waiting...");
             for _ in 0..150 {
                 timeout(Duration::from_millis(100), future::pending::<()>()).await.unwrap_err();
+                tick_sound_manager(0.1);
                 if !is_flash_loading().unwrap_or(false) {
                     break;
                 }

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -175,6 +175,13 @@ impl Movie {
             "mouseDown" => {
                 Ok(datum_bool(self.mouse_down))
             },
+            // `the mouseUp` is the inverse of `the mouseDown` — true while
+            // the mouse button is in the up (released) state. Director uses
+            // this in per-frame polling like storyscramble's Draggable
+            // behavior (`if the mouseUp then …`) to detect button release.
+            "mouseUp" => {
+                Ok(datum_bool(!self.mouse_down))
+            },
             "traceScript" => Ok(datum_bool(self.trace_script)),
             "activeWindow" => Ok(Datum::Stage),
             "rollOver" => {
@@ -235,13 +242,21 @@ impl Movie {
                 })
             },
             "labelList" => {
-                let s = self
-                    .score
-                    .frame_labels
-                    .iter()
-                    .map(|fl| fl.label.as_str())
-                    .collect::<Vec<_>>()
-                    .join("\r");
+                // Director's `the labelList` ends each label (including the
+                // last) with a `\r`, so `the number of lines in the labelList`
+                // returns label_count + 1 — script idioms like
+                //   numMarkers = the number of lines in the labelList
+                //   repeat with i = 1 to numMarkers
+                //     L = (the labelList).line[i]
+                //     ...
+                // expect the trailing empty line to be present (the last
+                // iteration sees L = "") so downstream lists end with the
+                // same shape they would in Director.
+                let mut s = String::new();
+                for fl in &self.score.frame_labels {
+                    s.push_str(&fl.label);
+                    s.push('\r');
+                }
                 Ok(Datum::String(s))
             },
             "debugplaybackenabled" => Ok(datum_bool(self.debug_playback_enabled)),

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -50,12 +50,21 @@ use super::{
 // src/services/flashPlayerManager.ts::initFlashBridge.
 #[wasm_bindgen]
 extern "C" {
+    // All sprite-method Flash bridge calls now key by sprite_num — each
+    // Flash sprite has its own dedicated Ruffle instance.
     #[wasm_bindgen(js_name = "dirplayer_ruffleIsPlaying")]
-    fn ruffle_is_playing(cast_lib: i32, cast_member: i32) -> bool;
+    fn ruffle_is_playing(sprite_num: i32) -> bool;
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetFrameCount")]
-    fn ruffle_get_frame_count(cast_lib: i32, cast_member: i32) -> i32;
+    fn ruffle_get_frame_count(sprite_num: i32) -> i32;
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetCurrentFrame")]
-    fn ruffle_get_current_frame(cast_lib: i32, cast_member: i32) -> i32;
+    fn ruffle_get_current_frame(sprite_num: i32) -> i32;
+    /// `sprite.frame = N` semantic: seek + STOP (pin at the frame).
+    /// This is the gotoAndStop path used for poster-frame Flash sprites
+    /// like storyscramble's tiles. For `sprite(N).gotoFrame(...)` (seek +
+    /// keep playing — required by mello's Fire/Marshmello which play
+    /// looping animations under each label) use `dirplayer_ruffleGoToFrame`.
+    #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrameAndStop")]
+    fn ruffle_goto_frame_and_stop(sprite_num: i32, frame_or_label: &str);
 }
 
 #[derive(Clone, Debug)]
@@ -1821,12 +1830,32 @@ impl Score {
             }
         }
 
-        // Always ensure frame script instance exists for current frame
-        // This handles looping - frame scripts need to be recreated each time we enter the frame
+        // Frame script lifecycle: keep the instance alive across frames within the same
+        // span (so script properties like markList persist), discard it when the script
+        // changes or when we leave the span.
         // Frame scripts need instances so that `me` resolves to ScriptInstanceRef (not ScriptRef)
         // in their handlers — e.g., `me.spriteNum` in beginSprite/enterFrame handlers.
+        let new_script_member = self.get_script_in_frame(frame_num).map(|b| CastMemberRef {
+            cast_lib: b.cast_lib as i32,
+            cast_member: b.cast_member as i32,
+        });
+
+        // Discard the cached instance if the script has changed or no longer applies.
+        // Without this, the previous-span's instance would linger when entering a new
+        // span, and `the frame` inside a different script's beginSprite would see stale state.
+        let should_discard = reserve_player_ref(|player| {
+            player.movie.frame_script_instance.is_some()
+                && player.movie.frame_script_member != new_script_member
+        });
+        if should_discard {
+            reserve_player_mut(|player| {
+                player.movie.frame_script_instance = None;
+                player.movie.frame_script_member = None;
+            });
+        }
+
         if let Some(behavior_ref) = self.get_script_in_frame(frame_num) {
-            // Check if we need to create/recreate the frame script instance
+            // Only create when no instance is cached (covers initial entry and post-discard).
             let needs_creation = reserve_player_ref(|player| {
                 player.movie.frame_script_instance.is_none()
             });
@@ -3178,24 +3207,25 @@ pub fn sprite_get_prop(
         "castLibNum" => Ok(Datum::Int(sprite.map_or(0, |x| {
             x.member.as_ref().map_or(0, |y| y.cast_lib)
         }))),
-        // Flash (SWF) sprite properties
+        // Flash (SWF) sprite properties — keyed by sprite_num because
+        // each Flash sprite has its own dedicated Ruffle instance.
         "playing" => {
-            if let Some(member_ref) = sprite.and_then(|s| s.member.as_ref()) {
-                Ok(datum_bool(ruffle_is_playing(member_ref.cast_lib, member_ref.cast_member)))
+            if sprite.and_then(|s| s.member.as_ref()).is_some() {
+                Ok(datum_bool(ruffle_is_playing(sprite_id as i32)))
             } else {
                 Ok(datum_bool(false))
             }
         }
         "frameCount" => {
-            if let Some(member_ref) = sprite.and_then(|s| s.member.as_ref()) {
-                Ok(Datum::Int(ruffle_get_frame_count(member_ref.cast_lib, member_ref.cast_member)))
+            if sprite.and_then(|s| s.member.as_ref()).is_some() {
+                Ok(Datum::Int(ruffle_get_frame_count(sprite_id as i32)))
             } else {
                 Ok(Datum::Int(0))
             }
         }
         "currentFrame" | "frame" => {
-            if let Some(member_ref) = sprite.and_then(|s| s.member.as_ref()) {
-                Ok(Datum::Int(ruffle_get_current_frame(member_ref.cast_lib, member_ref.cast_member)))
+            if sprite.and_then(|s| s.member.as_ref()).is_some() {
+                Ok(Datum::Int(ruffle_get_current_frame(sprite_id as i32)))
             } else {
                 Ok(Datum::Int(0))
             }
@@ -3634,6 +3664,28 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
 
     reserve_player_mut(|player| { player.stage_dirty = true; });
     let result = match prop_name {
+        // Flash (SWF) sprite frame setter — `mySprite.frame = N` on a Flash
+        // member must navigate that sprite's embedded Ruffle player, not be
+        // treated as a behaviour-property assignment. Each Flash sprite has
+        // its own Ruffle instance keyed by sprite_num, so multiple sprites
+        // sharing a single Flash cast member can independently pin to
+        // different frames (storyscramble's 3 story tiles use cast 2:1 but
+        // display poster frames 2/4/6 simultaneously).
+        "frame" | "currentFrame" => {
+            let frame_or_label = value.string_value()?;
+            let has_member = reserve_player_ref(|player| {
+                player
+                    .movie
+                    .score
+                    .get_sprite(sprite_id)
+                    .and_then(|s| s.member.as_ref().map(|_| ()))
+                    .is_some()
+            });
+            if has_member {
+                ruffle_goto_frame_and_stop(sprite_id as i32, &frame_or_label);
+            }
+            Ok(())
+        }
         "visible" | "visibility" => borrow_sprite_mut(
             sprite_id,
             |_| {},

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -1478,9 +1478,11 @@ fn render_filmloop_from_channel_data(
                 }
             }
             CastMemberType::Flash(_) => {
+                // Filmloop child Flash: per-sprite, same model as the
+                // outer Flash branch.
                 let flash_bitmap_ref = player
                     .flash_frame_buffers
-                    .get(&(sprite_member_ref.cast_lib, sprite_member_ref.cast_member))
+                    .get(&(channel_num as i16))
                     .copied();
 
                 if let Some(&bitmap_ref) = flash_bitmap_ref.as_ref().filter(|&&r| r != 0) {
@@ -2890,10 +2892,12 @@ pub fn render_score_to_bitmap_with_offset(
                 );
             }
             CastMemberType::Flash(flash_member) => {
-                // Render Flash content from frame buffer provided by Ruffle via JS bridge
+                // Render Flash content from the per-sprite frame buffer.
+                // Each Flash sprite has its own Ruffle player so multiple
+                // sprites sharing one cast member can show different frames.
                 let flash_bitmap_ref = player
                     .flash_frame_buffers
-                    .get(&(member_ref.cast_lib, member_ref.cast_member))
+                    .get(&(channel_num as i16))
                     .copied();
 
                 if let Some(&bitmap_ref) = flash_bitmap_ref.as_ref().filter(|&&r| r != 0) {
@@ -2937,27 +2941,33 @@ pub fn render_score_to_bitmap_with_offset(
                         );
                     }
                 } else if flash_bitmap_ref.is_none() && has_swf_signature(&flash_member.data) {
-                    // First time seeing this Flash member - notify JS to create Ruffle instance
-                    let sprite = get_score_sprite(&player.movie, score_source, channel_num).unwrap();
-                    let w = sprite.width.max(1) as u32;
-                    let h = sprite.height.max(1) as u32;
-                    debug!(
-                        "  Flash channel {}: requesting Ruffle instance for member {}:{} ({}x{}, {} bytes SWF)",
-                        channel_num, member_ref.cast_lib, member_ref.cast_member, w, h, flash_member.data.len()
-                    );
-                    JsApi::dispatch_flash_member_loaded(
-                        member_ref.cast_lib,
-                        member_ref.cast_member,
-                        &flash_member.data,
-                        w,
-                        h,
-                    );
-                    // Insert a sentinel so we don't re-dispatch every frame
-                    // (The real BitmapRef will be set when update_flash_frame is called from JS)
-                    player.flash_frame_buffers.insert(
-                        (member_ref.cast_lib, member_ref.cast_member),
-                        0, // sentinel value - INVALID_BITMAP_REF
-                    );
+                    // First time this sprite renders a Flash member — ask
+                    // JS to spin up a dedicated Ruffle instance for it.
+                    let dispatch_key = (channel_num as i16, member_ref.cast_lib, member_ref.cast_member);
+                    if !player.flash_sprite_loaded.contains(&dispatch_key) {
+                        let sprite = get_score_sprite(&player.movie, score_source, channel_num).unwrap();
+                        let w = sprite.width.max(1) as u32;
+                        let h = sprite.height.max(1) as u32;
+                        debug!(
+                            "  Flash sprite#{}: requesting Ruffle instance for member {}:{} ({}x{}, {} bytes SWF)",
+                            channel_num, member_ref.cast_lib, member_ref.cast_member, w, h, flash_member.data.len()
+                        );
+                        let paused_at_start = flash_member
+                            .flash_info
+                            .as_ref()
+                            .map(|fi| fi.paused_at_start)
+                            .unwrap_or(false);
+                        JsApi::dispatch_flash_member_loaded(
+                            channel_num as i32,
+                            member_ref.cast_lib,
+                            member_ref.cast_member,
+                            &flash_member.data,
+                            w,
+                            h,
+                            paused_at_start,
+                        );
+                        player.flash_sprite_loaded.insert(dispatch_key);
+                    }
                 }
             }
             _ => {}

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -1091,7 +1091,7 @@ impl WebGL2Renderer {
     /// Render a single sprite
     fn render_sprite(&mut self, player: &mut DirPlayer, channel_num: i16) {
         // Get sprite and member info
-        let (member_ref, mut sprite_rect, ink, blend, flip_h, flip_v, rotation, skew, bg_color, fg_color, has_fore_color, has_back_color, is_puppet, raw_loc, sprite_width, sprite_height, w3d_camera, w3d_extra_cams) = {
+        let (member_ref, mut sprite_rect, ink, mut blend, flip_h, flip_v, rotation, skew, bg_color, fg_color, has_fore_color, has_back_color, is_puppet, raw_loc, sprite_width, sprite_height, w3d_camera, w3d_extra_cams) = {
             let score = &player.movie.score;
             let sprite = match score.get_sprite(channel_num) {
                 Some(s) => s,
@@ -1144,9 +1144,33 @@ impl WebGL2Renderer {
             }
         }
 
+        // Sprite-level `blend` on Flash members is ignored by Shockwave
+        // regardless of directToStage — Director's D8-era Flash sprite
+        // compositor doesn't apply the sprite blend value (verified
+        // against the storyscramble tile sprite: score had blend=50,
+        // Director rendered at full opacity, directToStage=false).
+        // Force blend=100 for any Flash member so we match Shockwave;
+        // without this the tile sprite shows up washed-out / gray.
+        if let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) {
+            if matches!(member.member_type, CastMemberType::Flash(_)) {
+                blend = 100;
+            }
+        }
+
         // Determine what kind of texture we need based on member type
         enum TextureSource {
-            Bitmap { image_ref: u32 },
+            /// `is_flash` distinguishes a captureFrame bitmap from Ruffle
+            /// (true) from a plain authored Director bitmap (false). Flash
+            /// bitmaps have their transparency already encoded in the alpha
+            /// channel via wmode='transparent', so ink modes that color-key
+            /// against sprite.bg_color must NOT also strip matching pixels
+            /// (that erases SWF artwork whose fill happens to equal the
+            /// sprite's bg). Plain bitmaps with use_alpha=true (e.g. PNGs
+            /// imported as 32-bit) still need the color-key path for ink 36
+            /// to actually do its "background transparent" job — Habbo v1's
+            /// 32-bit init bitmap with ink 36 + bg palette-index-0 relies
+            /// on it to strip black corners.
+            Bitmap { image_ref: u32, is_flash: bool },
             SolidColor { r: u8, g: u8, b: u8 },
             RenderedText {
                 cache_key: RenderedTextCacheKey,
@@ -1242,15 +1266,19 @@ impl WebGL2Renderer {
         // filmloop's sprite-dim rect, meaning the score dimensions are intentional.
         let mut filmloop_sprite_dims_match = false;
 
-        // Handle Flash member dispatch before the texture_source borrow block
+        // Handle Flash member dispatch before the texture_source borrow block.
+        // We dispatch per (sprite, cast_lib, cast_member) so multiple sprites
+        // sharing one Flash cast member each get their own Ruffle player
+        // instance — required so e.g. storyscramble's 3 story tiles can pin
+        // to different poster frames of the same SWF simultaneously.
         {
-            let flash_key = (member_ref.cast_lib, member_ref.cast_member);
-            if !player.flash_frame_buffers.contains_key(&flash_key) {
+            let dispatch_key = (channel_num, member_ref.cast_lib, member_ref.cast_member);
+            if !player.flash_sprite_loaded.contains(&dispatch_key) {
                 if let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) {
                     if let CastMemberType::Flash(flash_member) = &member.member_type {
                         debug!(
-                            "Flash dispatch check {}:{} data_len={} first_bytes={:?}",
-                            member_ref.cast_lib, member_ref.cast_member,
+                            "Flash dispatch check sprite#{} {}:{} data_len={} first_bytes={:?}",
+                            channel_num, member_ref.cast_lib, member_ref.cast_member,
                             flash_member.data.len(),
                             &flash_member.data[..3.min(flash_member.data.len())]
                         );
@@ -1258,14 +1286,21 @@ impl WebGL2Renderer {
                             let data = flash_member.data.clone();
                             let w = sprite_width.max(1) as u32;
                             let h = sprite_height.max(1) as u32;
+                            let paused_at_start = flash_member
+                                .flash_info
+                                .as_ref()
+                                .map(|fi| fi.paused_at_start)
+                                .unwrap_or(false);
                             JsApi::dispatch_flash_member_loaded(
+                                channel_num as i32,
                                 member_ref.cast_lib,
                                 member_ref.cast_member,
                                 &data,
                                 w,
                                 h,
+                                paused_at_start,
                             );
-                            player.flash_frame_buffers.insert(flash_key, 0);
+                            player.flash_sprite_loaded.insert(dispatch_key);
                         }
                     }
                 }
@@ -1430,7 +1465,7 @@ impl WebGL2Renderer {
 
             match &member.member_type {
                 CastMemberType::Bitmap(bitmap_member) => {
-                    TextureSource::Bitmap { image_ref: bitmap_member.image_ref }
+                    TextureSource::Bitmap { image_ref: bitmap_member.image_ref, is_flash: false }
                 }
                 CastMemberType::Shape(shape_member) => {
                     // Skip rendering shapes with tiny dimensions (blank placeholders or zero-size)
@@ -2292,12 +2327,15 @@ impl WebGL2Renderer {
                     }
                 }
                 CastMemberType::Flash(_) => {
-                    let key = (member_ref.cast_lib, member_ref.cast_member);
-                    match player.flash_frame_buffers.get(&key).copied() {
+                    // Each sprite has its own Ruffle player instance (lazy-
+                    // created above on first render), so the per-sprite
+                    // bitmap is the only source we read here.
+                    let bitmap_ref_opt = player.flash_frame_buffers.get(&channel_num).copied();
+                    match bitmap_ref_opt {
                         Some(bitmap_ref) if bitmap_ref != 0 => {
-                            TextureSource::Bitmap { image_ref: bitmap_ref }
+                            TextureSource::Bitmap { image_ref: bitmap_ref, is_flash: true }
                         }
-                        _ => return, // Not ready yet; dispatch handled below
+                        _ => return, // Instance not ready yet; first frame hasn't arrived.
                     }
                 }
                 CastMemberType::FilmLoop(film_loop) => {
@@ -2424,7 +2462,7 @@ impl WebGL2Renderer {
 
         // Get bitmap info for palette reference, bit depth, and use_alpha (only used for bitmap sprites)
         let (bitmap_palette_ref, bitmap_bit_depth, bitmap_use_alpha) = match &texture_source {
-            TextureSource::Bitmap { image_ref } => {
+            TextureSource::Bitmap { image_ref, .. } => {
                 match player.bitmap_manager.get_bitmap(*image_ref) {
                     Some(bitmap) => {
                         (bitmap.palette_ref.clone(), bitmap.original_bit_depth, bitmap.use_alpha)
@@ -2565,7 +2603,7 @@ impl WebGL2Renderer {
         let is_button_alpha_matte = matches!(texture_source, TextureSource::ButtonBitmap { ink: i, .. } if i == 2 || i == 36 || i == 8 || i == 7);
 
         let tex = match texture_source {
-            TextureSource::Bitmap { image_ref } => {
+            TextureSource::Bitmap { image_ref, is_flash } => {
                 // Pass sprite's bgColor for matte/transparency computation for inks that need it
                 let sprite_bg_for_matte = if ink == 7 || ink == 8 || ink == 9 || ink == 36 || ink == 37 || ink == 39 || ink == 40 || ink == 41 {
                     Some(bg_color_rgb)
@@ -2573,7 +2611,7 @@ impl WebGL2Renderer {
                     None
                 };
 
-                match self.get_or_create_texture(player, &member_ref, image_ref, ink, colorize_params, sprite_bg_for_matte) {
+                match self.get_or_create_texture(player, &member_ref, image_ref, ink, colorize_params, sprite_bg_for_matte, is_flash) {
                     Some((tex, _w, _h)) => tex,
                     None => return,
                 }
@@ -2708,6 +2746,11 @@ impl WebGL2Renderer {
 
                 let cache_key = TextureCacheKey {
                     member_ref: member_ref.clone(),
+                    // Filmloops don't share a per-sprite bitmap pool like
+                    // Flash members do — one filmloop member renders the
+                    // same offscreen for every sprite that draws it, so 0
+                    // works as a sentinel here.
+                    image_ref: 0,
                     ink: ink as i32,
                     colorize: None,
                     sprite_bg_color: None,
@@ -3440,6 +3483,13 @@ impl WebGL2Renderer {
     /// Colorize parameters: (has_fore, has_back, fg_r, fg_g, fg_b, bg_r, bg_g, bg_b)
     /// sprite_bg_color: The sprite's bgColor, used for ink 8 matte computation on indexed bitmaps
     /// mask_bitmap: For ink 9 (Mask), the next cast member's bitmap used as grayscale alpha mask
+    /// is_flash_bitmap: True when this bitmap is a Ruffle captureFrame buffer
+    /// (sourced from a Flash sprite via wmode='transparent'). Such bitmaps
+    /// have their transparency authoritatively encoded in the alpha channel;
+    /// secondary ink-36-style color-keying against sprite.bg_color would
+    /// destructively strip artwork whose fill happens to equal the bg.
+    /// Plain authored 32-bit bitmaps with embedded alpha (PNG imports) still
+    /// need the color-key to make ink 36 actually do its job.
     fn bitmap_to_rgba(
         bitmap: &Bitmap,
         palettes: &crate::player::bitmap::palette_map::PaletteMap,
@@ -3447,6 +3497,7 @@ impl WebGL2Renderer {
         colorize: Option<(bool, bool, u8, u8, u8, u8, u8, u8)>,
         sprite_bg_color: Option<(u8, u8, u8)>,
         mask_bitmap: Option<&Bitmap>,
+        is_flash_bitmap: bool,
     ) -> Vec<u8> {
         let width = bitmap.width as usize;
         let height = bitmap.height as usize;
@@ -3784,18 +3835,30 @@ impl WebGL2Renderer {
                     // For ink 0 (Copy) without matte: always fully opaque
                     255
                 } else if use_embedded_alpha {
-                    // 32-bit with use_alpha (non-ink-0): use embedded alpha directly, ignore any matte
+                    // 32-bit with use_alpha (non-ink-0): use embedded alpha
+                    // directly, ignore any matte.
                     let index = (y * width + x) * 4;
                     let embedded_a = if index + 3 < bitmap.data.len() {
                         bitmap.data[index + 3]
                     } else {
                         255
                     };
-                    // For ink 36 (BgTransparent): also color-key bgColor pixels
-                    if ink == 36 {
+                    // Ink 36 (Background Transparent) ALSO color-keys
+                    // against sprite.bg_color — BUT only for plain
+                    // authored bitmaps. Flash captureFrame bitmaps
+                    // (`is_flash_bitmap=true`) have their transparency
+                    // already encoded by Ruffle's wmode='transparent'
+                    // treatment, so layering a second key would
+                    // destructively strip SWF artwork whose fill happens
+                    // to equal sprite.bg_color (storyscramble's chat
+                    // bubble: white-filled bubble + sprite bg=white →
+                    // entire bubble erased). Plain 32-bit-with-alpha
+                    // members (Habbo v1's `init` member is one) still
+                    // need the key so ink 36 can actually do its job.
+                    if ink == 36 && !is_flash_bitmap {
                         if let Some(bg) = sprite_bg_color {
                             if (r, g, b) == bg {
-                                0 // bgColor pixel → transparent
+                                0
                             } else {
                                 embedded_a
                             }
@@ -4225,6 +4288,7 @@ impl WebGL2Renderer {
         ink: i32,
         colorize: Option<(bool, bool, u8, u8, u8, u8, u8, u8)>,
         sprite_bg_color: Option<(u8, u8, u8)>,
+        is_flash_bitmap: bool,
     ) -> Option<(web_sys::WebGlTexture, u32, u32)> {
         // For inks that need matte, ensure create_matte is called first
         // This matches Canvas2D behavior in rendering.rs
@@ -4281,6 +4345,7 @@ impl WebGL2Renderer {
         };
         let cache_key = TextureCacheKey {
             member_ref: member_ref.clone(),
+            image_ref,
             ink,
             colorize,
             sprite_bg_color: cache_key_bg_color,
@@ -4320,7 +4385,7 @@ impl WebGL2Renderer {
             None
         };
 
-        let rgba_data = Self::bitmap_to_rgba(bitmap, &palettes, ink, colorize, sprite_bg_color, mask_bitmap_ref.as_ref());
+        let rgba_data = Self::bitmap_to_rgba(bitmap, &palettes, ink, colorize, sprite_bg_color, mask_bitmap_ref.as_ref(), is_flash_bitmap);
 
         // Validate data size
         let expected_size = (width * height * 4) as usize;

--- a/vm-rust/src/rendering_gpu/webgl2/texture_cache.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/texture_cache.rs
@@ -23,6 +23,14 @@ use crate::player::sprite::ColorRef;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TextureCacheKey {
     pub member_ref: CastMemberRef,
+    /// Backing bitmap (BitmapRef.id, the slot in bitmap_manager). For most
+    /// members `member_ref` already pins one bitmap, but a single Flash
+    /// cast member can have N independent per-sprite bitmaps when several
+    /// sprites share it (storyscramble's 3 story tiles each get their own
+    /// `flash_frame_buffers[sprite]` even though they all reference cast
+    /// 2:1). Without this field the cache collapses them and renders the
+    /// first uploaded version for every sprite.
+    pub image_ref: u32,
     /// Ink mode - affects whether matte computation is applied (especially for 32-bit bitmaps)
     pub ink: i32,
     /// Colorize parameters (only used when has_fore_color or has_back_color is true)


### PR DESCRIPTION
7e218bd  Renderer: trust embedded alpha on ink 36 + Flash bitmap; force blend=100 for Flash
820d634  Flash member: centerRegPoint uses real SWF dimensions + OLE FlashInfo fallback
c339cba  Flash members: per-sprite Ruffle instance + label-aware gotoFrame + event:// + mouse forwarding
c6ab3e2  Sound channel: protect MP3 playback against stale callbacks, GC, lost pan
e1b955c  Lingo: add the paramCount, chunk-count, the mouseUp, labelList trailing CR  ← +if/then/pass/multi-line
a3eef91  Bump ruffle submodule: dirplayer fork hooks

fixes #47 

needs to rebuild ruffle from updated submodule