### PR TITLE
supporting "trick or treat - beat"

### DIFF
--- a/vm-rust/src/player/compare.rs
+++ b/vm-rust/src/player/compare.rs
@@ -327,6 +327,33 @@ pub fn datum_equals(
     }
 }
 
+/// List-membership equality (`getPos`, `getOne`, `findPos`).
+///
+/// Director's `=` operator is strict — `#foo = "foo"` returns FALSE — but the
+/// list-membership lookup family matches by text content across the
+/// Symbol/String boundary. Verified with `put getPos([#foo, #bar], "foo")`
+/// returning 1 in Director 11.5. Scripts in the wild (e.g. Trick or Treat
+/// Beat's `getPos(gSingleTileObjNames, member.name)`) rely on this looser
+/// rule even though general `=` would not match.
+pub fn datum_equals_member(
+    left: &Datum,
+    right: &Datum,
+    allocator: &DatumAllocator,
+) -> Result<bool, ScriptError> {
+    use Datum::*;
+    let symbol_string_match = match (left, right) {
+        (Symbol(sym), other @ (String(_) | StringChunk(..)))
+        | (other @ (String(_) | StringChunk(..)), Symbol(sym)) => {
+            Some(sym.eq_ignore_ascii_case(&other.string_value_cow()?))
+        }
+        _ => None,
+    };
+    if let Some(matched) = symbol_string_match {
+        return Ok(matched);
+    }
+    datum_equals(left, right, allocator)
+}
+
 #[allow(dead_code)]
 pub fn datum_greater_than(left: &Datum, right: &Datum, allocator: &DatumAllocator) -> Result<bool, ScriptError> {
     match (left, right) {

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -527,10 +527,19 @@ fn get_eval_top_level_prop(
     if let Some(global_ref) = player.globals.get(prop_name) {
         Ok(global_ref.clone())
     } else {
-        // Try to get as a top-level prop, but if it fails, return an error about undefined variable
         match GetSetUtils::get_top_level_prop(player, prop_name) {
             Ok(result) => Ok(player.alloc_datum(result)),
-            Err(_) => Err(ScriptError::new(format!("Undefined variable: {}", prop_name)))
+            Err(_) => {
+                // Classic Director resolves unknown identifiers to VOID, so
+                // patterns like `do("foo(" & #none & ")")` reach the handler as
+                // `foo(VOID)`. Preserve the diagnostic error only when the user
+                // is poking around in the debugger.
+                if player.current_breakpoint.is_some() {
+                    Err(ScriptError::new(format!("Undefined variable: {}", prop_name)))
+                } else {
+                    Ok(DatumRef::Void)
+                }
+            }
         }
     }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/bitmap.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/bitmap.rs
@@ -71,6 +71,7 @@ impl BitmapMemberHandlers {
             )),
             "useAlpha" => Ok(Datum::Int(if bitmap_member.info.use_alpha { 1 } else { 0 })),
             "trimWhiteSpace" => Ok(Datum::Int(if bitmap_member.info.trim_white_space { 1 } else { 0 })),
+            "centerRegPoint" => Ok(Datum::Int(if bitmap_member.info.center_reg_point { 1 } else { 0 })),
             _ => Err(ScriptError::new(format!(
                 "Cannot get castMember property {} for bitmap",
                 prop
@@ -306,6 +307,54 @@ impl BitmapMemberHandlers {
                     }
                     Ok(())
                 })
+            }
+            "centerRegPoint" => {
+                let center = value.to_bool()?;
+                borrow_member_mut(
+                    member_ref,
+                    |_| {},
+                    |cast_member, _| {
+                        let bitmap_member = cast_member.member_type.as_bitmap_mut().unwrap();
+                        bitmap_member.info.center_reg_point = center;
+                        // Director snaps regPoint to bitmap center when the
+                        // flag is turned on — the renderer also recomputes
+                        // when reading the flag, but external readers of
+                        // `regPoint` (Lingo getters, cached layout) expect
+                        // the centered value once the flag flips.
+                        if center {
+                            // Need bitmap dimensions: defer to next reserve_player_mut.
+                        }
+                        Ok(())
+                    },
+                )?;
+                if center {
+                    reserve_player_mut(|player| {
+                        let member = player
+                            .movie
+                            .cast_manager
+                            .find_member_by_ref(member_ref)
+                            .unwrap();
+                        let bitmap_member = member.member_type.as_bitmap().unwrap();
+                        let bitmap_ref = bitmap_member.image_ref;
+                        let (w, h) = if let Some(bm) = player.bitmap_manager.get_bitmap(bitmap_ref) {
+                            (bm.width as i32, bm.height as i32)
+                        } else {
+                            (0, 0)
+                        };
+                        let reg_x = w / 2;
+                        let reg_y = h / 2;
+                        let member = player
+                            .movie
+                            .cast_manager
+                            .find_mut_member_by_ref(member_ref)
+                            .unwrap();
+                        let bm = member.member_type.as_bitmap_mut().unwrap();
+                        bm.reg_point = (reg_x as i16, reg_y as i16);
+                        member.reg_point = (reg_x, reg_y);
+                        Ok(())
+                    })?;
+                }
+                Ok(())
             }
             _ => Err(ScriptError::new(format!(
                 "Cannot set castMember prop {} for bitmap",

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -18,6 +18,7 @@ use crate::{
     },
     js_api::JsApi,
     player::{
+        bitmap::bitmap::{resolve_color_ref, Bitmap},
         cast_lib::CastMemberRef,
         cast_member::{BitmapMember, CastMember, CastMemberType, CastMemberTypeId, TextMember},
         handlers::types::TypeUtils,
@@ -437,7 +438,21 @@ impl CastMemberRefHandlers {
     ) -> Result<Datum, ScriptError> {
         match prop {
             "name" => Ok(Datum::String("".to_string())),
-            "number" => Ok(Datum::Int(-1)),
+            // Director: `.number` returns 0 for the empty/NULL member ref
+            // (i.e. `sprite(N).member.number` when sprite N has no member),
+            // and the negative slot for `member(-1)`-style invalid refs.
+            // Scripts use `sprite(chan).member.number = 0` as the
+            // empty-channel exit test in tile-composition loops; returning
+            // -1 unconditionally made that test never fire and dragged the
+            // loop through unrelated UI sprites further down the score
+            // (verified in Trick or Treat Beat's `buildTileAnims`).
+            "number" => Ok(Datum::Int(
+                if member_ref.cast_lib == 0 && member_ref.cast_member == 0 {
+                    0
+                } else {
+                    member_ref.cast_member.min(-1)
+                },
+            )),
             "type" => Ok(Datum::String("empty".to_string())),
             "castLibNum" => Ok(Datum::Int(-1)),
             "memberNum" => Ok(Datum::Int(-1)),
@@ -598,6 +613,127 @@ impl CastMemberRefHandlers {
                         "pattern" => Ok(Datum::Int(info.pattern as i32)),
                         "foreColor" => Ok(Datum::Int(info.fore_color as i32)),
                         "backColor" => Ok(Datum::Int(info.back_color as i32)),
+                        "image" => {
+                            // Director rasterizes shape members on demand for
+                            // `the image of member`. Snapshot the small
+                            // ShapeInfo so we can release the cast_manager
+                            // borrow before mutating bitmap_manager below.
+                            let info_owned = info.clone();
+                            let width = info_owned.width().max(1) as u16;
+                            let height = info_owned.height().max(1) as u16;
+                            let palettes_rc = player.movie.cast_manager.palettes();
+                            let palettes: &_ = &*palettes_rc;
+                            let frame_palette = player
+                                .movie
+                                .score
+                                .get_frame_palette(player.movie.current_frame);
+                            let fg_rgb = resolve_color_ref(
+                                palettes,
+                                &ColorRef::PaletteIndex(info_owned.fore_color),
+                                &frame_palette,
+                                8,
+                            );
+                            let bg_rgb = resolve_color_ref(
+                                palettes,
+                                &ColorRef::PaletteIndex(info_owned.back_color),
+                                &frame_palette,
+                                8,
+                            );
+
+                            let mut bitmap =
+                                Bitmap::new(width, height, 32, 32, 8, frame_palette.clone());
+                            let w = width as i32;
+                            let h = height as i32;
+                            bitmap.fill_rect(0, 0, w, h, bg_rgb, palettes, 1.0);
+
+                            let filled = info_owned.fill_type != 0;
+                            // Same 1-based thickness convention as the on-stage
+                            // renderer: filled shapes draw their outline at the
+                            // raw thickness; outlined shapes subtract 1 so 1 ==
+                            // hairline/invisible.
+                            let thickness = if filled {
+                                info_owned.line_thickness as i32
+                            } else {
+                                (info_owned.line_thickness as i32) - 1
+                            };
+
+                            match info_owned.shape_type {
+                                ShapeType::Rect => {
+                                    if filled {
+                                        bitmap.fill_rect(0, 0, w, h, fg_rgb, palettes, 1.0);
+                                    }
+                                    if thickness > 0 {
+                                        for t in 0..thickness {
+                                            bitmap.stroke_rect(
+                                                t,
+                                                t,
+                                                w - t,
+                                                h - t,
+                                                fg_rgb,
+                                                palettes,
+                                                1.0,
+                                            );
+                                        }
+                                    }
+                                }
+                                ShapeType::OvalRect => {
+                                    let radius = 12;
+                                    if filled {
+                                        bitmap.fill_round_rect(
+                                            0, 0, w, h, radius, fg_rgb, palettes, 1.0,
+                                        );
+                                    }
+                                    if thickness > 0 {
+                                        bitmap.stroke_round_rect(
+                                            0, 0, w, h, radius, fg_rgb, palettes, 1.0, thickness,
+                                        );
+                                    }
+                                }
+                                ShapeType::Oval => {
+                                    if filled {
+                                        bitmap.fill_ellipse(0, 0, w, h, fg_rgb, palettes, 1.0);
+                                    }
+                                    if thickness > 0 {
+                                        bitmap.stroke_ellipse(
+                                            0, 0, w, h, fg_rgb, palettes, 1.0, thickness,
+                                        );
+                                    }
+                                }
+                                ShapeType::Line => {
+                                    let t = (info_owned.line_thickness as i32).max(1);
+                                    if info_owned.line_direction == 6 {
+                                        bitmap.draw_line_thick(
+                                            0,
+                                            h - 1,
+                                            w - 1,
+                                            0,
+                                            fg_rgb,
+                                            palettes,
+                                            1.0,
+                                            t,
+                                        );
+                                    } else {
+                                        bitmap.draw_line_thick(
+                                            0,
+                                            0,
+                                            w - 1,
+                                            h - 1,
+                                            fg_rgb,
+                                            palettes,
+                                            1.0,
+                                            t,
+                                        );
+                                    }
+                                }
+                                ShapeType::Unknown => {
+                                    bitmap.fill_rect(0, 0, w, h, fg_rgb, palettes, 1.0);
+                                }
+                            }
+
+                            let bitmap_ref =
+                                player.bitmap_manager.add_ephemeral_bitmap(bitmap);
+                            Ok(Datum::BitmapRef(bitmap_ref))
+                        }
                         _ => Err(ScriptError::new(format!(
                             "Shape members don't support property {}", prop
                         ))),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -145,8 +145,11 @@ impl BuiltInHandlerManager {
     }
 
     fn get_pos_global(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
-        // getPos(list, value) - find position of value in list
-        use crate::player::compare::datum_equals;
+        // getPos(list, value) - find position of value in list.
+        // Uses the looser membership equality so Symbol/String pairs with
+        // matching text match each other, mirroring Director — verified with
+        // `put getPos([#foo, #bar], "foo")` returning 1 in Director 11.5.
+        use crate::player::compare::datum_equals_member;
         reserve_player_mut(|player| {
             let list_datum = player.get_datum(&args[0]);
             let search_ref = &args[1];
@@ -156,7 +159,7 @@ impl BuiltInHandlerManager {
                     for (i, item_ref) in items.iter().enumerate() {
                         let item = player.get_datum(item_ref);
                         let search = player.get_datum(search_ref);
-                        if datum_equals(item, search, &player.allocator)? {
+                        if datum_equals_member(item, search, &player.allocator)? {
                             return Ok(player.alloc_datum(Datum::Int((i + 1) as i32)));
                         }
                     }
@@ -167,7 +170,7 @@ impl BuiltInHandlerManager {
                     for (i, (_, val_ref)) in pairs.iter().enumerate() {
                         let val = player.get_datum(val_ref);
                         let search = player.get_datum(search_ref);
-                        if datum_equals(val, search, &player.allocator)? {
+                        if datum_equals_member(val, search, &player.allocator)? {
                             return Ok(player.alloc_datum(Datum::Int((i + 1) as i32)));
                         }
                     }
@@ -1242,6 +1245,20 @@ impl BuiltInHandlerManager {
                     Datum::Vector(v) => Ok(player.alloc_datum(Datum::Vector(*v))),
                     Datum::Transform3d(t) => Ok(player.alloc_datum(Datum::Transform3d(*t))),
                     Datum::CastMember(r) => Ok(player.alloc_datum(Datum::CastMember(r.clone()))),
+                    Datum::BitmapRef(bitmap_ref) => {
+                        // `duplicate(image)` returns an independent copy of the
+                        // bitmap; the result is an ephemeral so it's freed when
+                        // the caller's DatumRef drops.
+                        let new_bitmap = player
+                            .bitmap_manager
+                            .get_bitmap(*bitmap_ref)
+                            .ok_or_else(|| ScriptError::new(
+                                "duplicate(): source bitmap not found".to_string(),
+                            ))?
+                            .clone();
+                        let new_ref = player.bitmap_manager.add_ephemeral_bitmap(new_bitmap);
+                        Ok(player.alloc_datum(Datum::BitmapRef(new_ref)))
+                    }
                     _ => Err(ScriptError::new(format!("duplicate() not implemented for type {}", player.get_datum(item).type_str()))),
                 })
             }

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -2473,7 +2473,26 @@ impl Score {
     }
 
     pub fn get_sprite_mut(&mut self, number: i16) -> &mut Sprite {
-        let channel = &mut self.channels[number as usize];
+        // Out-of-range writes silently land on channel 0 instead of panicking
+        // on a negative-i16-cast-to-usize index. The cleaner fix is to make
+        // every call-site bounds-check explicitly, but there are 30+ callers
+        // and a panic at this level was bringing the whole VM down on
+        // legitimate Lingo patterns like `sprite(N).prop = X` where N came
+        // from a list-lookup that can return -1/0. Lingo entry points
+        // (`sprite_set_prop` / `sprite_get_prop`) guard separately and
+        // short-circuit before reaching here, so this branch is just a
+        // last-line safety net.
+        let idx = if number < 0 || number as usize >= self.channels.len() {
+            log::warn!(
+                "get_sprite_mut: out-of-range sprite number {} (channels.len()={}), clamping to 0",
+                number,
+                self.channels.len()
+            );
+            0
+        } else {
+            number as usize
+        };
+        let channel = &mut self.channels[idx];
         return &mut channel.sprite;
     }
 
@@ -3009,8 +3028,24 @@ pub fn sprite_get_prop(
             let (x, y) = sprite.map_or((0, 0), |sprite| (sprite.loc_h, sprite.loc_v));
             Ok(Datum::Point([x as f64, y as f64], 0))
         },
-        "width" => Ok(Datum::Int(sprite.map_or(0, |sprite| sprite.width) as i32)),
-        "height" => Ok(Datum::Int(sprite.map_or(0, |sprite| sprite.height) as i32)),
+        // Director: `sprite.width` / `sprite.height` return the *displayed*
+        // dimensions (= sprite.rect width/height), not the raw score-channel
+        // values. For an unscaled bitmap sprite they match bitmap-native dims;
+        // for a stretched sprite they match the score-authored width. The
+        // heuristics live in `get_concrete_sprite_rect`, which the rect-based
+        // getters (left/top/right/bottom/rect) already use. Without this,
+        // scripts that compute layer offsets via
+        // `destRect = rect(L, T, L + sprite(chan).width, ...)` read the
+        // cell-size 48 instead of the overlay's 29×29 and stretch the
+        // composite — verified in Trick or Treat Beat's `buildTileAnims`.
+        "width" => {
+            let rect = get_sprite_rect_in_context(player, sprite_id);
+            Ok(Datum::Int((rect.2 - rect.0) as i32))
+        }
+        "height" => {
+            let rect = get_sprite_rect_in_context(player, sprite_id);
+            Ok(Datum::Int((rect.3 - rect.1) as i32))
+        }
         "blend" => Ok(Datum::Int(sprite.map_or(0, |sprite| sprite.blend) as i32)),
         "ink" => Ok(Datum::Int(sprite.map_or(0, |sprite| sprite.ink) as i32)),
         "left" => {
@@ -3628,6 +3663,21 @@ fn sprite_set_prop_is_noop(
 }
 
 pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<(), ScriptError> {
+    // Director silently ignores property writes to invalid sprite refs. A
+    // script doing `sprite(N).prop = X` where N came from a list-lookup
+    // returning -1 (not-found sentinel) is legitimate Lingo — verified in
+    // Trick or Treat Beat where the panic surfaced via a behavior script.
+    // Also bounds-check the upper end against `channels.len()` to keep the
+    // unsigned-cast indexing in `get_sprite_mut` safe.
+    if sprite_id < 0 {
+        return Ok(());
+    }
+    let in_range = reserve_player_ref(|player| {
+        (sprite_id as usize) < player.movie.score.channels.len()
+    });
+    if !in_range {
+        return Ok(());
+    }
     if sprite_set_prop_is_noop(sprite_id, prop_name, &value)? {
         return Ok(());
     }


### PR DESCRIPTION
fixes #118 

2e00769 — Resolve unknown identifiers to VOID in do() runtime eval
5e6dfe8 — Add datum_equals_member helper for loose list-membership equality
82b34e4 — Use loose equality for getPos; support duplicate(BitmapRef)
b00776c — Rasterize Shape.image; return 0 for empty sprite member.number
857fb30 — Expose centerRegPoint getter/setter for bitmap members
da7489a — Derive sprite.width/height from rect; guard sprite_set_prop bounds


The movie has still some bitmap rect issues, which needs some deeper investigation without regressing other movies.

The game is playable up to level 5 (didn't played more)