### PR TITLE
improve playback of the Bach movie

### DIFF
--- a/vm-rust/src/director/chunks/cue_points.rs
+++ b/vm-rust/src/director/chunks/cue_points.rs
@@ -1,0 +1,84 @@
+use binary_reader::{BinaryReader, Endian};
+
+/// Director `cupt` chunk — list of cue points attached to a Sound cast member.
+///
+/// Layout (big-endian):
+///   u32        count
+///   N records, each `record_size = (chunk_size - 4) / count`:
+///     u32      time_ms
+///     u8       name_len
+///     [u8]     name (length-prefixed)
+///     ...      zero padding to `record_size`
+///
+/// `record_size` is encoded implicitly. For the inspected sample
+/// (Fugue No. 4 / i04.dir, member "Track  2") it's 36 — wide enough for
+/// "Untitled Marker NNN " (20 chars) plus trailing extras whose meaning is
+/// not yet known but appears to be all zero. We tolerate any per-record
+/// width that's at least the time + name-length byte.
+#[derive(Clone, Debug)]
+pub struct CuePointsChunk {
+    pub times_ms: Vec<u32>,
+    pub names: Vec<String>,
+}
+
+impl CuePointsChunk {
+    pub fn from_reader(reader: &mut BinaryReader) -> Result<CuePointsChunk, String> {
+        let original = reader.endian;
+        reader.endian = Endian::Big;
+
+        let mut body = Vec::new();
+        while let Ok(b) = reader.read_u8() {
+            body.push(b);
+        }
+
+        reader.endian = original;
+
+        if body.len() < 4 {
+            return Err(format!("cupt chunk too small: {} bytes", body.len()));
+        }
+        let count = u32::from_be_bytes([body[0], body[1], body[2], body[3]]) as usize;
+        if count == 0 {
+            return Ok(CuePointsChunk { times_ms: Vec::new(), names: Vec::new() });
+        }
+        let payload = body.len() - 4;
+        if payload < count {
+            return Err(format!(
+                "cupt chunk truncated: count={} but only {} payload bytes",
+                count, payload
+            ));
+        }
+        let per_record = payload / count;
+        if per_record < 5 {
+            return Err(format!(
+                "cupt record too small: per_record={} count={} payload={}",
+                per_record, count, payload
+            ));
+        }
+
+        let mut times_ms = Vec::with_capacity(count);
+        let mut names = Vec::with_capacity(count);
+        for i in 0..count {
+            let ofs = 4 + i * per_record;
+            if ofs + per_record > body.len() {
+                break;
+            }
+            let time = u32::from_be_bytes([
+                body[ofs],
+                body[ofs + 1],
+                body[ofs + 2],
+                body[ofs + 3],
+            ]);
+            let name_len = body[ofs + 4] as usize;
+            let name_end = (ofs + 5 + name_len).min(ofs + per_record);
+            let raw = &body[ofs + 5..name_end];
+            // Trim Director's trailing space/null padding from the stored name.
+            let name = String::from_utf8_lossy(raw)
+                .trim_end_matches(|c: char| c == '\0' || c == ' ')
+                .to_string();
+            times_ms.push(time);
+            names.push(name);
+        }
+
+        Ok(CuePointsChunk { times_ms, names })
+    }
+}

--- a/vm-rust/src/director/chunks/mod.rs
+++ b/vm-rust/src/director/chunks/mod.rs
@@ -26,6 +26,7 @@ pub mod xmedia;
 pub mod xtra_list;
 pub mod w3d;
 pub mod xmedia_styled_text;
+pub mod cue_points;
 
 use std::collections::HashMap;
 
@@ -44,6 +45,7 @@ use self::{
     script_names::ScriptNamesChunk, text::TextChunk,
 };
 use self::{cast_info::CastInfoChunk, effect::EffectChunk, thum::ThumChunk, xmedia::XMediaChunk, xtra_list::XtraListChunk};
+use self::cue_points::CuePointsChunk;
 use super::{
     guid::MoaID,
     rifx::RIFXReaderContext,
@@ -82,6 +84,7 @@ pub enum Chunk {
     Effect(EffectChunk),
     Thum(ThumChunk),
     XtraList(XtraListChunk),
+    CuePoints(CuePointsChunk),
     Raw(Vec<u8>),
 }
 
@@ -270,6 +273,7 @@ pub fn make_chunk(
         "FXmp" => return Ok(Chunk::Effect(EffectChunk::from_reader(&mut chunk_reader)?)),
         "Thum" => return Ok(Chunk::Thum(ThumChunk::from_reader(&mut chunk_reader)?)),
         "XTRl" => return Ok(Chunk::XtraList(XtraListChunk::from_reader(&mut chunk_reader)?)),
+        "cupt" => return Ok(Chunk::CuePoints(CuePointsChunk::from_reader(&mut chunk_reader)?)),
         "CLUT" => Ok(Chunk::Palette(palette::PaletteChunk::from_reader(
             &mut chunk_reader,
             version,

--- a/vm-rust/src/director/chunks/pfr1/rasterizer.rs
+++ b/vm-rust/src/director/chunks/pfr1/rasterizer.rs
@@ -5,6 +5,17 @@ use super::types::*;
 use super::glyph::fixed_point_multiply16;
 use super::log;
 
+/// Master switch for the "make text bolder" post-processing applied to
+/// glyph coverage. When `true`, edge alpha is darkened via a sqrt() gamma
+/// boost in the software-scanline path and via `steepen_alpha_ramp(48, 208)`
+/// for non-pixel fonts. This was added originally for readability at small
+/// sizes but produces a visibly heavier weight than Shockwave's native
+/// rasterizer (most noticeable on long-form body text such as the Fugue
+/// No. 4 Narrative field). Flip to `false` to get the thinner Shockwave-like
+/// rendering; flip back to `true` to restore the legacy weight without any
+/// other code change.
+pub const PFR_EDGE_BOOST: bool = false;
+
 /// Rasterize a single glyph using the browser's Canvas2D path fill.
 /// This leverages the browser's native rasterizer which handles edge cases
 /// (self-intersecting contours, sub-pixel alignment) more accurately than
@@ -237,9 +248,11 @@ fn rasterize_glyph_to_alpha_mask(
                 }
             }
             let raw_coverage = (count * 255 / block) as u8;
-            // Apply gamma boost (gamma=0.5) to make anti-aliased edges more prominent.
-            // This makes text bolder and more readable at small sizes.
-            let coverage = if raw_coverage == 0 || raw_coverage == 255 {
+            // Optional gamma boost (gamma=0.5) to make anti-aliased edges
+            // more prominent. Gated by `PFR_EDGE_BOOST` so the weight can
+            // be flipped back to Shockwave-like thin rendering without
+            // touching call sites.
+            let coverage = if !PFR_EDGE_BOOST || raw_coverage == 0 || raw_coverage == 255 {
                 raw_coverage
             } else {
                 let norm = raw_coverage as f32 / 255.0;
@@ -462,6 +475,25 @@ pub fn rasterize_pfr1_font(
     target_height: usize,
     design_size: usize,
 ) -> RasterizedFont {
+    rasterize_pfr1_font_with_options(parsed_font, target_height, design_size, false)
+}
+
+/// Variant of `rasterize_pfr1_font` that exposes additional knobs.
+///
+/// `thin_stem_boost = true` applies a `sqrt(α/255)` gamma curve to AA pixel
+/// coverage values, lifting faint partial-coverage thin-stem pixels into a
+/// visible range. Intended for italic-variant atlases where lowercase `l`,
+/// `i` and uppercase `I` are 1-orus-wide stems whose AA coverage at small
+/// render sizes (12 px) lands at α≈30–80 — without the boost they read as
+/// barely-there gray; with it they read as a clear thin stroke. Don't use
+/// it for regular-weight atlases: the same curve thickens the AA edges of
+/// solid stems and makes the whole atlas look bold.
+pub fn rasterize_pfr1_font_with_options(
+    parsed_font: &Pfr1ParsedFont,
+    target_height: usize,
+    design_size: usize,
+    thin_stem_boost: bool,
+) -> RasterizedFont {
     let phys = &parsed_font.physical_font;
 
     let outline_res = phys.outline_resolution as f32;
@@ -469,8 +501,18 @@ pub fn rasterize_pfr1_font(
     let coords_scaled = target_em_px > 0.0 && outline_res > 0.0;
 
     let scale = if coords_scaled {
-        // Coordinates are already in target pixel space (parsed at actual target size).
-        1.0
+        // Coordinates were parsed at `target_em_px` pixel space (typically
+        // = outline_resolution, à la Fontinator). Downscale to the actual
+        // render height. When target_em_px equals the requested
+        // target_height this is 1.0 (legacy behaviour); when parse was at
+        // outline_res and we render at e.g. 12 px, this is 12/2048 ≈ 0.006
+        // — the same downscale Fontinator does at paint time. Avoids the
+        // broken "parse-with-target=12 → fragmented zone hints" path.
+        if target_em_px > 0.0 {
+            target_height as f32 / target_em_px
+        } else {
+            1.0
+        }
     } else if outline_res > 0.0 {
         // Scale from ORU space to target pixel size.
         // Must use outline_res (not metric_height = ascender - descender) to match the
@@ -780,17 +822,27 @@ pub fn rasterize_pfr1_font(
             (-min_y * glyph_scale_y).round()
         };
 
-        // Use Canvas2D (Skia-backed) for all font rendering. For coords_scaled
-        // pixel fonts, threshold the anti-aliased output to binary. This matches
-        // Skia's pixel boundary rules exactly, producing output identical to
-        // SkiaSharp. Our custom scanline rasterizer had
-        // subtly different boundary pixel rules causing ~1px extra width on
-        // some characters (98 pixel differences across 34 chars).
+        // Use Canvas2D (Skia-backed) for all font rendering.
         //
-        // For non-pixel fonts, keep the anti-aliased Canvas2D output as-is
-        // for higher quality rendering with oversampled fallback.
-        let alpha_mask = if coords_scaled {
-            // Canvas2D with even-odd fill → binary threshold
+        // For PIXEL fonts (PFR1 cast members that ship pre-rendered bitmap
+        // glyphs alongside outlines — fff_reaction, volter, prima_mono,
+        // v/vb, etc.): threshold the Canvas2D AA output to binary at 128.
+        // The bitmap glyphs are designed for integer-coordinate cells, and
+        // any sub-pixel AA would blur their crisp pixel edges. The earlier
+        // gate `coords_scaled` was too coarse — with our parse-at-
+        // outline_resolution change it became `true` for *all* outline
+        // fonts too, which then killed thin italic stems (lowercase l, i,
+        // uppercase I in fugue_arial_italic) whose AA coverage falls
+        // below 128 at small render sizes. Fontinator's SkiaSharp path
+        // does NOT threshold and renders these correctly at 12px.
+        //
+        // For OUTLINE fonts (Arial / Verdana / fugue_arial etc.): keep
+        // the Canvas2D AA coverage as-is. Matches Skia's analytic AA and
+        // Font Xtra's 4-bit-per-pixel coverage + SRCPAINT composite.
+        let is_pixel_font = phys.has_bitmap_section
+            && !parsed_font.bitmap_glyphs.is_empty();
+        let alpha_mask = if coords_scaled && is_pixel_font {
+            // Canvas2D with even-odd fill → binary threshold (pixel-font path)
             let canvas_result = {
                 #[cfg(target_arch = "wasm32")]
                 {
@@ -800,10 +852,6 @@ pub fn rasterize_pfr1_font(
                             glyph_scale_x, glyph_scale_y,
                             glyph_offset_x, glyph_offset_y,
                         )?;
-                        // Threshold to binary: Canvas2D anti-aliases at edges,
-                        // but for integer-coordinate pixel fonts the coverage
-                        // at boundaries is deterministic. Threshold at 128
-                        // matches Skia's non-anti-aliased behavior.
                         for a in alpha.iter_mut() {
                             *a = if *a >= 128 { 255 } else { 0 };
                         }
@@ -827,6 +875,29 @@ pub fn rasterize_pfr1_font(
                 )
             })
         } else {
+            // Optional thin-stem alpha boost: a sqrt(α/255) gamma curve
+            // that lifts faint partial-coverage pixels (α≈30–80) into a
+            // visible range while leaving solid centers (255) untouched.
+            // Used for italic atlases where lowercase l, i, uppercase I
+            // are 1-orus-wide stems whose AA coverage at 12 px is too
+            // faint to read. Caller decides per-font via the `thin_stem_
+            // boost` parameter — applying it to regular-weight atlases
+            // thickens AA edges of solid stems and makes the body look
+            // bold, so don't.
+            let apply_thin_stem_boost = |alpha: &mut [u8]| {
+                if thin_stem_boost {
+                    for a in alpha.iter_mut() {
+                        if *a == 0 || *a == 255 {
+                            continue;
+                        }
+                        let norm = (*a as f32) / 255.0;
+                        *a = (norm.sqrt() * 255.0).round().min(255.0) as u8;
+                    }
+                }
+                if PFR_EDGE_BOOST {
+                    steepen_alpha_ramp(alpha, 48, 208);
+                }
+            };
             let canvas_result = {
                 #[cfg(target_arch = "wasm32")]
                 {
@@ -836,9 +907,7 @@ pub fn rasterize_pfr1_font(
                             glyph_scale_x, glyph_scale_y,
                             glyph_offset_x, glyph_offset_y,
                         )?;
-                        // Steepen alpha ramp for crisper edges at small sizes.
-                        // lo=48 removes faint fringe, hi=208 saturates near-solid.
-                        steepen_alpha_ramp(&mut alpha, 48, 208);
+                        apply_thin_stem_boost(&mut alpha);
                         Some(alpha)
                     })
                 }
@@ -856,7 +925,7 @@ pub fn rasterize_pfr1_font(
                     glyph_offset_y,
                     4, // 4x oversampling for anti-aliased output
                 );
-                steepen_alpha_ramp(&mut alpha, 48, 208);
+                apply_thin_stem_boost(&mut alpha);
                 alpha
             })
         };

--- a/vm-rust/src/director/chunks/score.rs
+++ b/vm-rust/src/director/chunks/score.rs
@@ -1619,16 +1619,32 @@ impl ScoreChunk {
             // Primary entries: 40 bytes base (5 x u32 fields + 20-byte
             // TweenInfo) plus zero or more trailing u32s of authored
             // keyframe indices. v8.0 movies only ever produce 40/44/48
-            // byte primaries (0-2 trailing keyframes); v8.5+ adds a
-            // 52-byte size for spans with 3 trailing keyframes (where
-            // path tweens with authored interior keyframes live —
-            // sprite 2 / sprites 41-42 of 15love_hs). Accepting 52+
-            // unconditionally previously over-matched non-primary
-            // chunks in Junkbot (v8.0), so we gate the wider sizes
-            // strictly on movie version.
+            // byte primaries (0-2 trailing keyframes); v8.5+ extends to
+            // 52 (3 trailing keyframes) and beyond — Fugue No.4 / i04.dir
+            // has primary entries of 72, 116, 188, 232, 336+ bytes for
+            // sprites with many authored keyframes along an animated
+            // path. Accepting 52+ unconditionally previously
+            // over-matched non-primary chunks in Junkbot (v8.0), so we
+            // still gate the wider sizes by movie version AND validate
+            // the first 8 bytes look like (start_frame, end_frame) of
+            // a real primary (small, ascending) to avoid false matches.
             let accept_extended = dir_version >= 850;
-            let size_accepted = matches!(entry_bytes.len(), 40 | 44 | 48)
+            let size_accepted_basic = matches!(entry_bytes.len(), 40 | 44 | 48)
                 || (accept_extended && entry_bytes.len() == 52);
+            // Allow any 4-byte-aligned entry >= 40 bytes on D8.5+ if the
+            // header looks plausible — that's the path-keyframe-bearing
+            // case that was getting rejected.
+            let size_accepted_extended = accept_extended
+                && entry_bytes.len() > 52
+                && entry_bytes.len() % 4 == 0
+                && entry_bytes.len() >= 8
+                && {
+                    let b = entry_bytes;
+                    let sf = u32::from_be_bytes([b[0], b[1], b[2], b[3]]);
+                    let ef = u32::from_be_bytes([b[4], b[5], b[6], b[7]]);
+                    sf >= 1 && sf <= 10000 && ef >= sf && ef <= 100000
+                };
+            let size_accepted = size_accepted_basic || size_accepted_extended;
             match entry_bytes.len() {
                 _ if size_accepted => {
                     // Primary entry

--- a/vm-rust/src/director/chunks/xmedia_styled_text.rs
+++ b/vm-rust/src/director/chunks/xmedia_styled_text.rs
@@ -1,5 +1,4 @@
 use log::debug;
-use crate::io::encoding::win1252_byte_to_char;
 use crate::player::handlers::datum_handlers::cast_member::font::{StyledSpan, HtmlStyle, TextAlignment};
 
 impl XmedStyledText {
@@ -809,18 +808,21 @@ fn parse_section_3(data: &[u8]) -> Result<Section3Data, String> {
     }
 
     // Extract text, preserving all characters including \r, \n, \t.
-    // Director text members store bytes as Windows-1252. The earlier
-    // Mac-Roman decoder mapped 0xE4 to U+2021 (‡) instead of U+00E4 (ä),
-    // breaking umlauts, ß, ø, ñ, and Spanish accents in Windows-authored
-    // movies (i.e. virtually all live test corpora).
-    let mut text = String::new();
-    for i in text_start..text_end {
-        let ch = win1252_byte_to_char(data[i]);
-        if ch == '\0' {
-            break; // Stop at first null byte (padding)
-        }
-        text.push(ch);
-    }
+    //
+    // Encoding: D6-D9 movies store text bytes as Windows-1252; D10+
+    // (Unicode-aware authoring) stores them as UTF-8. Fugue No.4 (D11.5)
+    // has e.g. "Tradução" as `m c3 a7 c3 a3 o` and "©" as `c2 a9`.
+    // Decoding either as plain Win-1252 mangles UTF-8 sequences into
+    // "Â©" / "TraduÃ§Ã£o" mojibake.
+    //
+    // Strategy: trim at the first 0x00 padding byte, then run
+    // `decode_text_auto` — strict UTF-8 first, falling back to Win-1252
+    // only when the bytes don't form a valid UTF-8 sequence. Win-1252
+    // input almost never coincidentally satisfies UTF-8's continuation-
+    // byte constraints, so older movies keep decoding correctly.
+    let raw = &data[text_start..text_end];
+    let body_end = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+    let text = crate::io::encoding::decode_text_auto(&raw[..body_end]);
 
     debug!("    Section 3: {} chars", text.len());
 

--- a/vm-rust/src/io/reader.rs
+++ b/vm-rust/src/io/reader.rs
@@ -2,7 +2,7 @@ use std::io::Read;
 
 use binary_reader::BinaryReader;
 
-use crate::io::encoding::decode_win1252;
+use crate::io::encoding::decode_text_auto;
 
 pub trait DirectorExt {
     fn read_var_int(&mut self) -> Result<i32, std::io::Error>;
@@ -50,13 +50,22 @@ impl DirectorExt for BinaryReader {
     }
 
     fn read_string(&mut self, len: usize) -> Result<String, std::io::Error> {
-        // Director text is Windows-1252 (CP1252), not UTF-8. The old
-        // from_utf8_lossy here silently replaced every non-ASCII byte with
-        // U+FFFD, killing umlauts (ä ö ü ß), Scandinavian (å ø æ), and
-        // Spanish (á é í ó ú ñ) characters in fields, text members, Lingo
-        // string literals, score labels, etc.
+        // Director's on-disk text encoding is movie-version-dependent.
+        // D6-D9 movies stored field/text member content as Windows-1252.
+        // D10+ (Unicode-aware) authoring tools store the same content as
+        // UTF-8 — e.g. Fugue No.4 (D11.5) has "música" encoded as
+        // `m c3 ba sica`. Decoding such bytes as plain Win-1252 would
+        // yield "mÃºsica" mojibake.
+        //
+        // `decode_text_auto` tries strict UTF-8 first, falling back to
+        // Win-1252 only when the bytes don't form a valid UTF-8 sequence.
+        // The check is cheap and the false-positive rate is negligible:
+        // arbitrary Win-1252 byte streams almost never coincidentally
+        // satisfy UTF-8's continuation-byte constraints, so legitimate
+        // Win-1252 text always falls through to the existing Win-1252
+        // path. Older movies keep working; D11 Unicode authoring works.
         let bytes = self.read_bytes(len).unwrap();
-        return Ok(decode_win1252(&bytes));
+        return Ok(decode_text_auto(&bytes));
     }
 
     fn read_apple_float_80(&mut self) -> Result<f64, String> {

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -928,12 +928,18 @@ impl JsApi {
                 return;
             }
 
-            let cast = player
-                .movie
-                .cast_manager
-                .get_cast(member_ref.cast_lib as u32)
-                .unwrap();
-            let member = cast.members.get(&(member_ref.cast_member as u32)).unwrap();
+            // The cast or slot can vanish between the change firing and this
+            // async task running (e.g. mouseUp on the timeline triggers
+            // sprite reslotting in mid-handler, then the snapshot dispatch
+            // lands after the member is gone). Bail silently instead of
+            // panicking — the next change event will repaint the inspector
+            // correctly.
+            let Ok(cast) = player.movie.cast_manager.get_cast(member_ref.cast_lib as u32) else {
+                return;
+            };
+            let Some(member) = cast.members.get(&(member_ref.cast_member as u32)) else {
+                return;
+            };
             let member_map = Self::get_member_snapshot(member, member_ref.cast_lib as u32, cast.lctx.as_ref(), player);
 
             onCastMemberChanged(member_ref.to_js().to_js_value(), member_map.to_js_object());

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -959,7 +959,13 @@ impl GetSetBytecodeHandler {
                     }
                 }
             } else if prop_type == 0x0a {
-                // Cast member property with chunk expression (e.g. the foreColor of char X of member Y)
+                // Cast member property with chunk expression (e.g. the
+                // textStyle of char X of member Y). The previous version
+                // discarded all 8 chunk refs and read the MEMBER-wide
+                // property, which made `the textStyle of char N of member`
+                // collapse to the member's overall font_style — Fugue No.4
+                // Narrative's underline-detection loop saw "plain" for
+                // every char and never routed clicks to underlined words.
                 let cast_lib_datum = if player.movie.dir_version >= 500 {
                     let r = {
                         let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
@@ -974,14 +980,25 @@ impl GetSetBytecodeHandler {
                     scope.stack.pop().unwrap()
                 };
                 let member_id_datum = player.get_datum(&member_id_ref).clone();
-                // Pop 8 chunk ref values (first_char, last_char, first_word, last_word,
-                // first_item, last_item, first_line, last_line)
-                {
+                // Pop the 8 chunk-range values. Top of stack is last_line, then
+                // first_line, last_item, first_item, last_word, first_word,
+                // last_char, first_char (bottom).
+                let chunk_refs = {
                     let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
+                    let mut v = Vec::with_capacity(8);
                     for _ in 0..8 {
-                        scope.stack.pop().unwrap();
+                        v.push(scope.stack.pop().unwrap());
                     }
-                }
+                    v
+                };
+                let last_line = player.get_datum(&chunk_refs[0]).int_value().unwrap_or(0);
+                let first_line = player.get_datum(&chunk_refs[1]).int_value().unwrap_or(0);
+                let last_item = player.get_datum(&chunk_refs[2]).int_value().unwrap_or(0);
+                let first_item = player.get_datum(&chunk_refs[3]).int_value().unwrap_or(0);
+                let last_word = player.get_datum(&chunk_refs[4]).int_value().unwrap_or(0);
+                let first_word = player.get_datum(&chunk_refs[5]).int_value().unwrap_or(0);
+                let last_char = player.get_datum(&chunk_refs[6]).int_value().unwrap_or(0);
+                let first_char = player.get_datum(&chunk_refs[7]).int_value().unwrap_or(0);
                 let prop_name = get_cast_member_prop_name(prop_id as u16).to_string();
                 let member_ref = player.movie.cast_manager.find_member_ref_by_identifiers(
                     &member_id_datum,
@@ -990,8 +1007,119 @@ impl GetSetBytecodeHandler {
                 )?;
                 match member_ref {
                     Some(member_ref) => {
-                        let result = CastMemberRefHandlers::get_prop(player, &member_ref, &prop_name)?;
-                        Ok(player.alloc_datum(result))
+                        // Determine which chunk type is active (only one
+                        // pair is non-zero in Director's bytecode for
+                        // chunked prop reads).
+                        use crate::director::lingo::datum::{StringChunkExpr, StringChunkType};
+                        let chunk_expr: Option<StringChunkExpr> = if first_char != 0 || last_char != 0 {
+                            Some(StringChunkExpr { chunk_type: StringChunkType::Char, start: first_char, end: last_char, item_delimiter: player.movie.item_delimiter })
+                        } else if first_word != 0 || last_word != 0 {
+                            Some(StringChunkExpr { chunk_type: StringChunkType::Word, start: first_word, end: last_word, item_delimiter: player.movie.item_delimiter })
+                        } else if first_item != 0 || last_item != 0 {
+                            Some(StringChunkExpr { chunk_type: StringChunkType::Item, start: first_item, end: last_item, item_delimiter: player.movie.item_delimiter })
+                        } else if first_line != 0 || last_line != 0 {
+                            Some(StringChunkExpr { chunk_type: StringChunkType::Line, start: first_line, end: last_line, item_delimiter: player.movie.item_delimiter })
+                        } else {
+                            None
+                        };
+
+                        // For per-char style props (textStyle / fontStyle),
+                        // read the active STXT formatting run directly.
+                        // Director 11.5 Scripting Dictionary p.949: returns
+                        // the style of the character at position N.
+                        let chunk_result: Option<Datum> = if let Some(ref ce) = chunk_expr {
+                            let lc = prop_name.to_ascii_lowercase();
+                            use crate::player::cast_member::CastMemberType;
+                            use crate::player::handlers::datum_handlers::string_chunk::{StringChunkHandlers, StringChunkUtils};
+                            if lc == "textstyle" || lc == "fontstyle" {
+                                if let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) {
+                                    let text = match &member.member_type {
+                                        CastMemberType::Field(f) => f.text.clone(),
+                                        CastMemberType::Text(t) => t.text.clone(),
+                                        _ => String::new(),
+                                    };
+                                    let (char_start, _char_end) = StringChunkHandlers::resolve_chunk_char_range(&text, ce);
+                                    // STXT formatting_runs use BYTE positions
+                                    // in Director's text data, not char
+                                    // positions. For text with multi-byte
+                                    // UTF-8 chars (ñ, é, ç in Fugue No.4's
+                                    // Spanish/Portuguese headers and body),
+                                    // converting char_start to its byte
+                                    // offset is required so the run boundary
+                                    // lookup picks the run that contains the
+                                    // visible character — without this,
+                                    // chars after the first multi-byte char
+                                    // get the wrong style and `chunk =
+                                    // "Español"` ends up comparing the
+                                    // 8-char slice "Español " against
+                                    // the 7-char literal.
+                                    let byte_start: usize = text
+                                        .char_indices()
+                                        .nth(char_start)
+                                        .map(|(b, _)| b)
+                                        .unwrap_or_else(|| text.len());
+                                    let (bold, italic, underline) = match &member.member_type {
+                                        CastMemberType::Field(f) => {
+                                            let style = f.formatting_runs.iter().rev()
+                                                .find(|r| (r.start_position as usize) <= byte_start)
+                                                .map(|r| r.style).unwrap_or(0);
+                                            ((style & 0x01) != 0, (style & 0x02) != 0, (style & 0x04) != 0)
+                                        }
+                                        CastMemberType::Text(t) => {
+                                            let mut pos = 0usize;
+                                            let mut found = (false, false, false);
+                                            for span in &t.html_styled_spans {
+                                                let len = span.text.chars().count();
+                                                if char_start < pos + len {
+                                                    found = (span.style.bold, span.style.italic, span.style.underline);
+                                                    break;
+                                                }
+                                                pos += len;
+                                            }
+                                            found
+                                        }
+                                        _ => (false, false, false),
+                                    };
+                                    // For CHUNKED access (`the textStyle of
+                                    // char N` or `the fontStyle of char N`)
+                                    // Director returns a STRING form.
+                                    let mut parts: Vec<&str> = Vec::new();
+                                    if bold { parts.push("bold"); }
+                                    if italic { parts.push("italic"); }
+                                    if underline { parts.push("underline"); }
+                                    let s = if parts.is_empty() { "plain".to_string() } else { parts.join(",") };
+                                    let _ = lc;
+                                    Some(Datum::String(s))
+                                } else {
+                                    None
+                                }
+                            } else if lc == "text" {
+                                if let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) {
+                                    let text = match &member.member_type {
+                                        CastMemberType::Field(f) => f.text.clone(),
+                                        CastMemberType::Text(t) => t.text.clone(),
+                                        _ => String::new(),
+                                    };
+                                    let s = StringChunkUtils::resolve_chunk_expr_string(&text, ce)?;
+                                    Some(Datum::String(s))
+                                } else {
+                                    None
+                                }
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+
+                        if let Some(d) = chunk_result {
+                            Ok(player.alloc_datum(d))
+                        } else {
+                            // Other props (foreColor, name, etc.) keep
+                            // current member-wide behaviour.
+                            let result = CastMemberRefHandlers::get_prop(player, &member_ref, &prop_name)?;
+                            Ok(player.alloc_datum(result))
+                        }
                     }
                     None => {
                         warn!("get cast member chunk prop '{}': member not found", prop_name);

--- a/vm-rust/src/player/bytecode/string.rs
+++ b/vm-rust/src/player/bytecode/string.rs
@@ -370,18 +370,52 @@ impl StringBytecodeHandler {
                 let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
                 scope.stack.pop().unwrap()
             };
-            
+
             // Read all chunk parameters
             let chunks = Self::read_all_chunks(player, ctx)?;
-            
-            // Apply chunks sequentially
-            let mut result = player.get_datum(&string_ref).string_value()?;
-            for chunk_expr in chunks {
-                result = StringChunkUtils::resolve_chunk_expr_string(&result, &chunk_expr)?;
-            }
-            
-            let result_datum = Datum::String(result);
-            let result_ref = player.alloc_datum(result_datum);
+
+            // For chunked access on a CastMember (`member.line[5].word[1]`)
+            // or on another StringChunk (already nested), build a StringChunk
+            // chain rather than flattening to a String. The chain lets
+            // downstream property reads — `.fontStyle`, `.font`, `.color`,
+            // `.charSpacing` — walk back to the source member and look up
+            // STXT formatting_runs / styled spans for the resolved char
+            // range. Without this, `member.line[5].word[1].fontStyle`
+            // errored with "Invalid string built-in property fontStyle"
+            // because the chunk had already lost its member back-reference.
+            //
+            // Plain `String` inputs (`"hello".word[2]`) have no member to
+            // chain to, so the original flatten-to-String behaviour is
+            // preserved for them.
+            let source_datum = player.get_datum(&string_ref).clone();
+            let initial_chain_source: Option<StringChunkSource> = match &source_datum {
+                Datum::CastMember(member_ref) => Some(StringChunkSource::Member(member_ref.clone())),
+                Datum::StringChunk(..) => Some(StringChunkSource::Datum(string_ref.clone())),
+                _ => None,
+            };
+
+            let result_ref = if let Some(initial_source) = initial_chain_source {
+                let mut current_source = initial_source;
+                let mut current_str = source_datum.string_value()?;
+                let mut current_ref = string_ref.clone();
+                for expr in chunks.iter() {
+                    current_str = StringChunkUtils::resolve_chunk_expr_string(&current_str, expr)?;
+                    current_ref = player.alloc_datum(Datum::StringChunk(
+                        current_source.clone(),
+                        expr.clone(),
+                        current_str.clone(),
+                    ));
+                    current_source = StringChunkSource::Datum(current_ref.clone());
+                }
+                current_ref
+            } else {
+                let mut result = source_datum.string_value()?;
+                for chunk_expr in chunks {
+                    result = StringChunkUtils::resolve_chunk_expr_string(&result, &chunk_expr)?;
+                }
+                player.alloc_datum(Datum::String(result))
+            };
+
             let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
             scope.stack.push(result_ref);
             Ok(HandlerExecutionResult::Advance)

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -56,6 +56,15 @@ pub struct CastLib {
     pub dir_version: u16,
     /// Offset to adjust bitmap clutId from Config-based to MCsL-based member numbering.
     pub palette_id_offset: i16,
+    /// Director Fmap/VWFM font-table snapshot: font_id → font name (e.g.
+    /// "Arial", "Arial Bold", "Arial Italic"). Kept on the cast lib so
+    /// per-run `font_id`s from STXT can be resolved to actual names at
+    /// runtime — `.font` and `.fontStyle` chunk getters need this to
+    /// distinguish bold variants from italic variants. Bit-flag heuristics
+    /// (e.g. `font_id & 0x8000 = bold`) don't generalise — different movies
+    /// pack the table differently and the only authoritative mapping is
+    /// the file's own font table.
+    pub font_table: HashMap<u16, String>,
 }
 
 impl CastLib {
@@ -309,6 +318,7 @@ impl CastLib {
         self.capital_x = cast_def.capital_x;
         self.dir_version = cast_def.dir_version;
         self.palette_id_offset = cast_def.palette_id_offset;
+        self.font_table = font_table.clone();
         self.state = CastLibState::Loaded;
         for (id, member_def) in &cast_def.members {
             self.insert_member(
@@ -437,7 +447,28 @@ impl CastLib {
     }
 
     pub fn get_script_for_member(&self, number: u32) -> Option<&Rc<Script>> {
-        self.scripts.get(&number)
+        // Direct path: `number` is a cast-member slot that holds a Script
+        // member — this is how scripts authored as standalone behaviors are
+        // registered (see `insert_member`, which inserts `scripts[number]`).
+        if let Some(script) = self.scripts.get(&number) {
+            return Some(script);
+        }
+
+        // Fallback: `number` is an lctx-script-id (the value stored in
+        // `member_info.header.script_id` for non-Script members like Field
+        // and Text). In D11+ movies this id may NOT equal the cast-member
+        // slot — e.g. a field with `header.script_id=10` may have its
+        // actual script cast member elsewhere. Walk the cast looking for
+        // a Script-type member whose own `script_id` matches, then return
+        // its registered script.
+        for (slot, member) in &self.members {
+            if let CastMemberType::Script(script_member) = &member.member_type {
+                if script_member.script_id == number {
+                    return self.scripts.get(slot);
+                }
+            }
+        }
+        None
     }
 
     pub fn get_behavior_script_from_lctx(&mut self, script_id: u32) -> Option<Rc<Script>> {

--- a/vm-rust/src/player/cast_manager.rs
+++ b/vm-rust/src/player/cast_manager.rs
@@ -119,6 +119,7 @@ impl CastManager {
                 capital_x: false,
                 dir_version: 0,
                 palette_id_offset: cast_def.map_or(0, |x| x.palette_id_offset),
+                font_table: HashMap::new(),
             };
             if let Some(cast_def) = cast_def {
                 cast.apply_cast_def(dir, cast_def, bitmap_manager, &dir.font_table);

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -51,6 +51,12 @@ pub struct FieldMember {
     pub font_style: String,
     pub font_size: u16,
     pub font_id: Option<u16>, // STXT font ID for lookup by ID
+    /// All STXT formatting runs parsed for this field. Each run has a
+    /// `start_position` (char index) and applies until the next run begins
+    /// (or end of text). Director's `the textStyle of char N of member`
+    /// and `member.char[N].fontStyle` resolve by walking these runs.
+    /// Empty when the field has uniform styling (older parser behaviour).
+    pub formatting_runs: Vec<crate::director::chunks::text::StxtFormattingRun>,
     pub text_height: u16,  // Text area height from FieldInfo (for dimension calculations)
     pub fixed_line_space: u16,  // Line spacing for text rendering
     pub top_spacing: i16,
@@ -215,6 +221,7 @@ impl FieldMember {
             font_style: "plain".to_string(),
             font_size: 12,
             font_id: None,
+            formatting_runs: Vec::new(),
             text_height: 100,
             fixed_line_space: 0,
             top_spacing: 0,
@@ -287,6 +294,7 @@ impl FieldMember {
             font_style: "plain".to_string(),
             font_size: 12,
             font_id: None,
+            formatting_runs: Vec::new(),
             text_height: field_info.text_height,  // Text area height for dimension calculations
             fixed_line_space: 0,  // Use default line spacing for text rendering
             top_spacing: field_info.scroll as i16,
@@ -4099,7 +4107,90 @@ impl CastMember {
 
                 // Parse STXT formatting data to extract actual fontId, fontSize, and style
                 let formatting_runs = text_chunk.parse_formatting_runs();
-                if let Some(first_run) = formatting_runs.first() {
+                // Keep the FULL run list on the field so per-char prop access
+                // (`the textStyle of char N of member`, `member.char[N].fontStyle`)
+                // and per-run rendering (underline links, mixed bold spans)
+                // can read it. Without this, fields with rich STXT formatting
+                // (Fugue No.4's "Narrative" text-link field, etc.) would
+                // collapse to a single uniform style and the script's
+                // link-detection logic never fires.
+                field_member.formatting_runs = formatting_runs.clone();
+                // Pick the DOMINANT font_size — the size used by the most
+                // characters — as the member-wide default. Director's
+                // rendering effectively uses this size for the bulk of
+                // the field; the first run's size (e.g. David's Notes
+                // header at 18) is correct for that range but the body
+                // (12) is what dominates the rendered area. Picking
+                // dominant matches Shockwave's visual output for
+                // Spanish/Portuguese/David's Notes alike.
+                //
+                // Algorithm:
+                //   1. For each run, compute its char coverage as
+                //      (next_run.start_position - run.start_position),
+                //      or text_len - run.start_position for the last
+                //      run.
+                //   2. Sum coverage per font_size (skipping bogus sizes
+                //      <6 from marker runs).
+                //   3. Pick the size with the highest total coverage.
+                //
+                // Other member-wide defaults (font, fixed_line_space,
+                // fore_color) still come from the FIRST run with that
+                // dominant size, so any consistent per-run formatting
+                // tied to the body comes through correctly.
+                let text_byte_len = text_chunk.text.len() as u32;
+                let mut coverage_by_size: std::collections::HashMap<u16, u32> =
+                    std::collections::HashMap::new();
+                for (i, r) in formatting_runs.iter().enumerate() {
+                    if r.font_size < 6 { continue; }
+                    let next_pos = if i + 1 < formatting_runs.len() {
+                        formatting_runs[i + 1].start_position
+                    } else {
+                        text_byte_len
+                    };
+                    let coverage = next_pos.saturating_sub(r.start_position);
+                    *coverage_by_size.entry(r.font_size).or_insert(0) += coverage;
+                }
+                let dominant_size: Option<u16> = coverage_by_size
+                    .iter()
+                    .max_by_key(|&(_, c)| *c)
+                    .map(|(s, _)| *s);
+                // Among runs at the dominant size, prefer one whose
+                // font_id resolves to a NON-styled (no "Bold"/"Italic")
+                // variant. The renderer loads one atlas per field and
+                // applies bold via double-strike / italic via shear on
+                // that atlas — if the atlas itself is "Arial Bold" or
+                // "Arial Italic", stacking another transformation on
+                // top produces bold-italic or extra-bold glyphs that
+                // don't match Shockwave's render. Fugue No. 4
+                // Narrative's 12pt body has its dominant run pointed
+                // at "Arial Bold" in the Fmap; without this preference
+                // the whole body atlas comes out heavy.
+                let resolve_name = |fid: u16| -> Option<String> {
+                    font_table.get(&fid).cloned()
+                };
+                let is_neutral_name = |name: &str| -> bool {
+                    let lc = name.to_ascii_lowercase();
+                    !lc.contains("bold") && !lc.contains("italic")
+                };
+                let primary_run = dominant_size
+                    .and_then(|sz| {
+                        formatting_runs.iter()
+                            .find(|r| r.font_size == sz
+                                && resolve_name(r.font_id)
+                                    .as_deref()
+                                    .map(is_neutral_name)
+                                    .unwrap_or(false))
+                            .or_else(|| formatting_runs.iter().find(|r| r.font_size == sz))
+                    })
+                    .or_else(|| formatting_runs.iter()
+                        .find(|r| r.font_size >= 6
+                            && resolve_name(r.font_id)
+                                .as_deref()
+                                .map(is_neutral_name)
+                                .unwrap_or(false)))
+                    .or_else(|| formatting_runs.iter().find(|r| r.font_size >= 6))
+                    .or_else(|| formatting_runs.first());
+                if let Some(first_run) = primary_run {
                     // Extract foreground color from STXT formatting run
                     let fg_r = (first_run.color_r >> 8) as u8;
                     let fg_g = (first_run.color_g >> 8) as u8;

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -816,6 +816,14 @@ pub struct FilmLoopMember {
 pub struct SoundMember {
     pub info: SoundInfo,
     pub sound: SoundChunk,
+    /// Cue point times in milliseconds, parsed from the member's `cupt`
+    /// child chunk. Exposed to Lingo as `member.cuePointTimes`. The
+    /// SoundChannel reads these on `queue()` so playback can fire
+    /// `on cuePassed` as the playhead crosses each entry.
+    pub cue_point_times: Vec<u32>,
+    /// Names parallel to `cue_point_times`. Empty string when the
+    /// authoring tool didn't assign one.
+    pub cue_point_names: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -2408,6 +2416,7 @@ impl CastMember {
             Chunk::Effect(_) => "FXmp",
             Chunk::Thum(_) => "Thum",
             Chunk::XtraList(_) => "XTRl",
+            Chunk::CuePoints(_) => "cupt",
             Chunk::Raw(_) => "Raw",
         }
     }
@@ -4715,6 +4724,18 @@ impl CastMember {
                     }
                 }
 
+                // Pluck the cue-points child chunk (`cupt`), if present. Director
+                // stores these alongside the sound payload on the cast member; the
+                // movie's `on cuePassed` handler is driven by the playhead crossing
+                // these times.
+                let (cue_point_times, cue_point_names) = member_def.children.iter()
+                    .filter_map(|c| c.as_ref())
+                    .find_map(|c| match c {
+                        Chunk::CuePoints(cp) => Some((cp.times_ms.clone(), cp.names.clone())),
+                        _ => None,
+                    })
+                    .unwrap_or_else(|| (Vec::new(), Vec::new()));
+
                 // Try to find a sound chunk - check multiple formats:
                 // 1. "snd " chunk (Mac snd resource)
                 // 2. "ediM" chunk (MediaChunk)
@@ -4823,12 +4844,16 @@ impl CastMember {
                     CastMemberType::Sound(SoundMember {
                         info,
                         sound: sound_chunk,
+                        cue_point_times,
+                        cue_point_names,
                     })
                 } else {
                     warn!("No sound chunk found for member {}", number);
                     CastMemberType::Sound(SoundMember {
                         info: SoundInfo::default(),
                         sound: SoundChunk::default(),
+                        cue_point_times,
+                        cue_point_names,
                     })
                 }
             }

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -1473,18 +1473,79 @@ pub async fn eval_lingo_expr_ast_runtime(expr: &LingoExpr) -> Result<DatumRef, S
             // "Invalid string built-in property line".
             if let LingoExpr::ObjProp(obj_expr, prop_name) = list_expr.as_ref() {
                 let prop_lower = prop_name.to_ascii_lowercase();
-                if prop_lower == "line" || prop_lower == "item" || prop_lower == "word" {
+                if prop_lower == "line" || prop_lower == "item" || prop_lower == "word"
+                    || prop_lower == "char"
+                {
                     let obj_ref = Box::pin(eval_lingo_expr_ast_runtime(obj_expr.as_ref())).await?;
                     let index_ref = Box::pin(eval_lingo_expr_ast_runtime(index_expr.as_ref())).await?;
                     let chunk_datum = reserve_player_mut(|player| {
-                        if !matches!(player.get_datum(&obj_ref), Datum::String(_)) {
-                            return Ok(None);
-                        }
+                        use crate::director::lingo::datum::{
+                            StringChunkExpr, StringChunkSource, StringChunkType,
+                        };
                         let index = player.get_datum(&index_ref).int_value()?;
-                        let d = crate::player::handlers::datum_handlers::string::StringDatumUtils::get_prop_ref(
-                            player, &obj_ref, &prop_lower, index, index,
-                        )?;
-                        Ok(Some(d))
+                        let source_datum = player.get_datum(&obj_ref).clone();
+                        match source_datum {
+                            // `string.line[N]` etc. — build a StringChunk
+                            // whose source is the originating string datum.
+                            Datum::String(_) => {
+                                let d = crate::player::handlers::datum_handlers::string::StringDatumUtils::get_prop_ref(
+                                    player, &obj_ref, &prop_lower, index, index,
+                                )?;
+                                Ok(Some(d))
+                            }
+                            // `member.line[N]` — build a StringChunk whose
+                            // source is the underlying member, so downstream
+                            // `.fontStyle` / `.font` / `.color` can walk back
+                            // to STXT formatting_runs. Without this the AST
+                            // path returned a plain String (via the field
+                            // `.line` getter returning a List<String>) and
+                            // every per-chunk style read errored with
+                            // "Invalid string built-in property fontStyle".
+                            Datum::CastMember(member_ref) => {
+                                let member = player.movie.cast_manager
+                                    .find_member_by_ref(&member_ref);
+                                let text = match member {
+                                    Some(m) => match &m.member_type {
+                                        crate::player::cast_member::CastMemberType::Field(f) => f.text.clone(),
+                                        crate::player::cast_member::CastMemberType::Text(t) => t.text.clone(),
+                                        _ => return Ok(None),
+                                    },
+                                    None => return Ok(None),
+                                };
+                                let chunk_expr = StringChunkExpr {
+                                    chunk_type: StringChunkType::from(prop_lower.as_str()),
+                                    start: index,
+                                    end: index,
+                                    item_delimiter: player.movie.item_delimiter,
+                                };
+                                let resolved =
+                                    StringChunkUtils::resolve_chunk_expr_string(&text, &chunk_expr)?;
+                                Ok(Some(Datum::StringChunk(
+                                    StringChunkSource::Member(member_ref),
+                                    chunk_expr,
+                                    resolved,
+                                )))
+                            }
+                            // Nested chunk: chain via Datum source so the
+                            // walk back to the member preserves both ranges.
+                            Datum::StringChunk(..) => {
+                                let parent_str = player.get_datum(&obj_ref).string_value()?;
+                                let chunk_expr = StringChunkExpr {
+                                    chunk_type: StringChunkType::from(prop_lower.as_str()),
+                                    start: index,
+                                    end: index,
+                                    item_delimiter: player.movie.item_delimiter,
+                                };
+                                let resolved =
+                                    StringChunkUtils::resolve_chunk_expr_string(&parent_str, &chunk_expr)?;
+                                Ok(Some(Datum::StringChunk(
+                                    StringChunkSource::Datum(obj_ref.clone()),
+                                    chunk_expr,
+                                    resolved,
+                                )))
+                            }
+                            _ => Ok(None),
+                        }
                     })?;
                     if let Some(d) = chunk_datum {
                         return reserve_player_mut(|player| Ok(player.alloc_datum(d)));
@@ -2065,12 +2126,38 @@ pub async fn eval_lingo_expr_ast_runtime(expr: &LingoExpr) -> Result<DatumRef, S
                     item_delimiter: player.movie.item_delimiter,
                 })
             })?;
-            
-            // Extract the chunk
-            let result_string = StringChunkUtils::resolve_chunk_expr_string(&source_string, &chunk_expr)?;
-            
+
+            // Extract the chunk. When the source is a `CastMember` or another
+            // `StringChunk`, return a chained `StringChunk` so subsequent
+            // `.fontStyle` / `.font` / `.color` reads can walk back to the
+            // member's STXT runs (parallel to the bytecode `get_chunk`
+            // handler in bytecode/string.rs). Plain `String` sources have
+            // no member to chain to, so they keep the original flatten
+            // behaviour. This is the path the interactive message-window
+            // evaluator uses; without it `put member.line[5].word[1].fontStyle`
+            // would error with "Invalid string built-in property fontStyle"
+            // because `word[1]` would have already collapsed to a String.
+            let result_string =
+                StringChunkUtils::resolve_chunk_expr_string(&source_string, &chunk_expr)?;
+
             reserve_player_mut(|player| {
-                Ok(player.alloc_datum(Datum::String(result_string)))
+                use crate::director::lingo::datum::StringChunkSource;
+                let source_datum = player.get_datum(&source_ref).clone();
+                let chunk_source = match source_datum {
+                    Datum::CastMember(member_ref) => {
+                        Some(StringChunkSource::Member(member_ref))
+                    }
+                    Datum::StringChunk(..) => Some(StringChunkSource::Datum(source_ref.clone())),
+                    _ => None,
+                };
+                Ok(match chunk_source {
+                    Some(src) => player.alloc_datum(Datum::StringChunk(
+                        src,
+                        chunk_expr,
+                        result_string,
+                    )),
+                    None => player.alloc_datum(Datum::String(result_string)),
+                })
             })
         }
         LingoExpr::Eq(left, right) => {

--- a/vm-rust/src/player/font/mod.rs
+++ b/vm-rust/src/player/font/mod.rs
@@ -108,6 +108,26 @@ pub struct DrawTextParams<'a> {
     pub top_spacing: i16,
     pub char_spacing: i16,
     pub member_width: Option<i16>,
+    /// Minimum advance for the space character. When > 0, any stored
+    /// space advance below this is clamped up to this value during both
+    /// wrap measurement AND char-index calculation. Mirrors the renderer's
+    /// `space_min_advance` clamp so hit-testing and drawing agree on
+    /// which char is at a given pixel position. Without this, fields
+    /// drawn with widened spaces but measured with raw narrow spaces
+    /// would have `the mouseChar` return positions in the wrong run
+    /// (clicks on "Christ's passion" hitting "the sign of the cross").
+    pub min_space_advance: Option<i16>,
+    /// Pre-computed per-character advances (one entry per char of the
+    /// text, including newlines — those entries are ignored). When
+    /// `Some`, these are used instead of `font.get_char_advance(c)` —
+    /// callers can plug in run-aware advances (e.g. Arial Bold widths
+    /// for an underlined run on top of an otherwise-Arial field) so
+    /// the hit-test wraps with the same per-run metrics the renderer
+    /// draws with. Length must equal `text.chars().count()`; out-of-range
+    /// lookups fall back to the font's advance. The space-min clamp and
+    /// `char_spacing` are NOT re-applied on top of these — the caller
+    /// must bake them in if needed.
+    pub per_char_advances: Option<&'a [i32]>,
 }
 
 impl FontManager {
@@ -176,26 +196,80 @@ impl FontManager {
 
         let font_name_lc = font_name.to_lowercase();
         let font_name_canon = Self::canonical_font_name(font_name);
+        // Match priority — needed because PFR1 internal `font_info.name`
+        // uses the convention `<FamilyName>_<Weight>_<Other>` (e.g.
+        // "Arial_700_000" for Bold, "Arial_400_000" for Regular). Our
+        // canonical_font_name strips trailing digit-only tokens, so
+        // ALL Arial variants canonicalize via info_name to plain
+        // "arial" — meaning a request for "Arial *" used to match
+        // whichever variant iterated first (often Bold), and the body
+        // of every field rendered bold. Member names ("Arial *",
+        // "Arial Bold *", "Arial Italic *") DO preserve the variant
+        // distinction after canonicalization, so we match on those
+        // first and only fall back to info_name canonical when no
+        // member-name match exists.
+        //   tier 0: exact lowercase match on member.name or info_name
+        //   tier 1: canonical member.name match
+        //   tier 2: canonical info_name match (fallback)
+        let mut best_tier: Option<u8> = None;
+        let mut best: Option<(u32, u32, u32)> = None; // (cast_lib_num, member_id, tier)
         for cast_lib in &cast_manager.casts {
-            for member in cast_lib.members.values() {
+            for (&member_id, member) in cast_lib.members.iter() {
                 if let CastMemberType::Font(font_data) = &member.member_type {
                     let info_name_canon = Self::canonical_font_name(&font_data.font_info.name);
                     let member_name_canon = Self::canonical_font_name(&member.name);
-                    let name_matches =
-                        font_data.font_info.name.to_lowercase() == font_name_lc
-                            || member.name.to_lowercase() == font_name_lc
-                            || (!font_name_canon.is_empty()
-                                && (info_name_canon == font_name_canon
-                                    || member_name_canon == font_name_canon));
-                    if !name_matches {
-                        continue;
+                    let exact_match = font_data.font_info.name.to_lowercase() == font_name_lc
+                        || member.name.to_lowercase() == font_name_lc;
+                    let member_canon_match = !font_name_canon.is_empty()
+                        && member_name_canon == font_name_canon;
+                    let info_canon_match = !font_name_canon.is_empty()
+                        && info_name_canon == font_name_canon;
+                    let tier: Option<u8> = if exact_match {
+                        Some(0)
+                    } else if member_canon_match {
+                        Some(1)
+                    } else if info_canon_match {
+                        Some(2)
+                    } else {
+                        None
+                    };
+                    if let Some(t) = tier {
+                        if best_tier.map_or(true, |bt| t < bt) {
+                            best_tier = Some(t);
+                            best = Some((cast_lib.number, member_id, t as u32));
+                        }
                     }
-
+                }
+            }
+        }
+        // Walk the loop again only when we have a winner, to actually
+        // rasterize and cache it. (Re-borrows are fine; the priority
+        // pass above is read-only.)
+        let winner = best;
+        for cast_lib in &cast_manager.casts {
+            for (&member_id, member) in cast_lib.members.iter() {
+                if winner.map_or(true, |(cl, mid, _)| cl != cast_lib.number || mid != member_id) {
+                    continue;
+                }
+                if let CastMemberType::Font(font_data) = &member.member_type {
                     if let Some(ref parsed) = font_data.pfr_parsed {
                         use crate::director::chunks::pfr1::{rasterizer, parse_pfr1_font_with_target};
 
+                        // Match FontinatorFINAL's working approach: parse with
+                        // target_em_px = outline_resolution rather than 0 or
+                        // the small render size. Hinting still fires, but at
+                        // ~unity scale (the multiplier `target/outline_res` is
+                        // 1), so it doesn't try to snap stems into a 12-pixel
+                        // box and fragment glyphs. The rasterizer then handles
+                        // the actual downscale to the displayed size via
+                        // `scale = target_height / target_em_px` in the
+                        // coords_scaled branch. Fontinator's 9px atlas output
+                        // for fugue_arial / fugue_arial_italic verifies this
+                        // produces complete, thin glyphs.
+                        let outline_res = parsed.physical_font.outline_resolution as i32;
+                        let parse_target = if outline_res > 0 { outline_res } else { 0 };
                         let parsed_for_size = if let Some(ref raw) = font_data.pfr_data {
-                            match parse_pfr1_font_with_target(raw, 0) {
+                            match parse_pfr1_font_with_target(raw, parse_target) {
                                 Ok(p) => p,
                                 Err(_) => parsed.clone(),
                             }
@@ -203,7 +277,24 @@ impl FontManager {
                             parsed.clone()
                         };
 
-                        let rasterized = rasterizer::rasterize_pfr1_font(&parsed_for_size, requested_size as usize, font_data.font_info.size as usize);
+                        // Enable the thin-stem alpha boost only for italic
+                        // variants. Italic glyphs concentrate the 1-orus-
+                        // wide vertical stems (lowercase l, i, uppercase I)
+                        // whose AA coverage at small sizes is too faint
+                        // without the sqrt() gamma lift. Regular and bold
+                        // atlases have wider strokes — the boost would
+                        // thicken their AA edges and make the whole atlas
+                        // look bolder than Shockwave's reference render.
+                        let font_info_lc = font_data.font_info.name.to_ascii_lowercase();
+                        let member_name_lc = member.name.to_ascii_lowercase();
+                        let thin_stem_boost = font_info_lc.contains("italic")
+                            || member_name_lc.contains("italic");
+                        let rasterized = rasterizer::rasterize_pfr1_font_with_options(
+                            &parsed_for_size,
+                            requested_size as usize,
+                            font_data.font_info.size as usize,
+                            thin_stem_boost,
+                        );
 
                         let bitmap_width = rasterized.bitmap_width as u16;
                         let bitmap_height = rasterized.bitmap_height as u16;
@@ -287,7 +378,20 @@ impl FontManager {
                 if let Some(pfr_bytes) = self.default_pfr_data.get(&key) {
                     use crate::director::chunks::pfr1::{rasterizer, parse_pfr1_font_with_target};
 
-                    match parse_pfr1_font_with_target(pfr_bytes, 0) {
+                    // Match the cast-member PFR re-parse path above:
+                    // parse with target_em_px = outline_resolution so hinting
+                    // fires at unity scale, then let the rasterizer downscale.
+                    // First parse with target=0 to learn outline_res, then
+                    // re-parse with that as target.
+                    let parsed_for_res = match parse_pfr1_font_with_target(pfr_bytes, 0) {
+                        Ok(p) => Some(p),
+                        Err(_) => None,
+                    };
+                    let parse_target = parsed_for_res.as_ref()
+                        .map(|p| p.physical_font.outline_resolution as i32)
+                        .filter(|&v| v > 0)
+                        .unwrap_or(0);
+                    match parse_pfr1_font_with_target(pfr_bytes, parse_target) {
                         Ok(parsed) => {
                             let rasterized = rasterizer::rasterize_pfr1_font(&parsed, requested_size as usize, 0);
 
@@ -1356,8 +1460,17 @@ pub fn measure_text(
     } else {
         (line_height as i16).max(effective_lh)
     };
-    let mut height = (top_spacing + first_line_h) as u16;
-    let line_step = (effective_lh + bottom_spacing + top_spacing) as u16;
+    // Guard against negative top_spacing (set by the field renderer to
+    // implement scrollTop via a negative offset). The original formulas
+    // `(top_spacing + first_line_h) as u16` and
+    // `(effective_lh + bottom_spacing + top_spacing) as u16` underflow
+    // when top_spacing is negative, producing huge line_step values that
+    // cause `(num_lines-1) * line_step` to balloon to ~50M for paged
+    // fields — and the resulting bitmap allocation either fails or hangs,
+    // leaving the field stuck at whatever the last successful scroll
+    // position was. Clamp via i32 arithmetic and saturate at the bottom.
+    let mut height = ((top_spacing as i32) + (first_line_h as i32)).max(0) as u16;
+    let line_step = ((effective_lh as i32) + (bottom_spacing as i32) + (top_spacing.max(0) as i32)).max(1) as u16;
     let mut index = 0;
     let mut last_was_newline = false;
     for c in text.chars() {
@@ -1440,7 +1553,10 @@ pub fn measure_text_wrapped(
         line_spacing
     };
     let effective_lh = if line_spacing > 0 { line_spacing as i16 } else { effective_line_h as i16 };
-    let line_step = (effective_lh + bottom_spacing + top_spacing) as u16;
+    // Mirror the i32-clamped formula in measure_text — negative top_spacing
+    // (used by the field renderer for scrollTop) would otherwise underflow
+    // here and break paged-field rendering past ~font_size px.
+    let line_step = ((effective_lh as i32) + (bottom_spacing as i32) + (top_spacing.max(0) as i32)).max(1) as u16;
 
     // Per-character advance including char_spacing — matches the renderer at
     // text.rs's flush_line loop which does `x += adv + char_spacing` for every char.
@@ -1516,8 +1632,10 @@ pub fn measure_text_wrapped(
     let num_lines = visual_lines.len().max(1);
     let max_width_found = visual_lines.iter().copied().max().unwrap_or(0).max(0) as u16;
     let first_line_h = (effective_line_h as i16).max(effective_lh);
-    let height = (top_spacing + first_line_h) as u16
-        + (num_lines as u16 - 1) * line_step;
+    // Same i32-clamp as measure_text — protects against scrollTop's
+    // negative top_spacing pushing bitmap height into the u16 wrap.
+    let height_first = ((top_spacing as i32) + (first_line_h as i32)).max(0) as u16;
+    let height = height_first + (num_lines as u16 - 1) * line_step;
 
     (max_width_found, height)
 }
@@ -1528,34 +1646,138 @@ pub fn get_text_char_pos(text: &str, params: &DrawTextParams, char_index: usize)
     let mut line_width: i16 = 0;
     let mut line_index = 0;
     let eff_lh = if params.font.font_size > 0 { params.font.font_size } else { params.font.char_height };
+    // Match the renderer's line_step (no +1) — see comment in
+    // get_text_index_at_pos for the line-by-line drift it causes.
     let line_step = params.line_height.unwrap_or(eff_lh) as i16
-        + params.line_spacing as i16
-        + 1;
+        + params.line_spacing as i16;
+    let wrap_w = params.member_width.unwrap_or(0) as i32;
+    let wrap_enabled = wrap_w > 0;
 
+    // Pre-scan wrap-break positions so the y returned reflects the
+    // VISUAL line layout (matches the renderer + locToCharPos), not
+    // source-line indices. Critical for AdvanceScroll's
+    // `charPosToLoc(member, selStart+1)` — without wrap awareness the
+    // returned y misses the visible target line by the number of
+    // wrapped visual lines preceding it in long paragraphs.
+    // No +1 — matches measure_text_wrapped / get_text_index_at_pos so
+    // wrap points line up with the renderer's layout.
+    let char_adv_i32 = |c: char, char_idx: usize| -> i32 {
+        if let Some(v) = params.per_char_advances {
+            if let Some(adv) = v.get(char_idx) {
+                return *adv;
+            }
+        }
+        let raw = params.font.get_char_advance(c as u8) as i32;
+        let clamped = if c == ' ' {
+            raw.max(params.min_space_advance.unwrap_or(0) as i32)
+        } else {
+            raw
+        };
+        clamped + params.char_spacing as i32
+    };
+    let mut wrap_starts: Vec<usize> = Vec::new();
+    if wrap_enabled {
+        let mut line_w: i32 = 0;
+        let mut line_start_byte: usize = 0;
+        let mut last_space_after_byte: Option<usize> = None;
+        let mut last_space_w: i32 = 0;
+        let mut char_idx_pre: usize = 0;
+        for (byte_pos, c) in text.char_indices() {
+            if c == '\r' || c == '\n' {
+                wrap_starts.push(byte_pos + c.len_utf8());
+                line_start_byte = byte_pos + c.len_utf8();
+                last_space_after_byte = None;
+                last_space_w = 0;
+                line_w = 0;
+                char_idx_pre += 1;
+                continue;
+            }
+            let cw = char_adv_i32(c, char_idx_pre);
+            char_idx_pre += 1;
+            if line_w + cw > wrap_w && byte_pos > line_start_byte {
+                if let Some(sp_after) = last_space_after_byte
+                    .filter(|&sp| sp > line_start_byte)
+                {
+                    wrap_starts.push(sp_after);
+                    line_start_byte = sp_after;
+                    last_space_after_byte = None;
+                    line_w -= last_space_w;
+                    last_space_w = 0;
+                }
+            }
+            line_w += cw;
+            if c == ' ' {
+                last_space_after_byte = Some(byte_pos + 1);
+                last_space_w = line_w;
+            }
+        }
+    }
+
+    let mut visual_line_idx = 0usize;
+    let mut next_wrap = wrap_starts.first().copied();
+    let mut byte_pos = 0usize;
     let mut prev_was_cr = false;
     for c in text.chars() {
+        let c_bytes = c.len_utf8();
+        // Apply pending wrap-break BEFORE checking char_index for this char
+        // so visual line advances when the next char actually crosses a wrap.
+        while let Some(wp) = next_wrap {
+            if wp == byte_pos && byte_pos != 0 {
+                line_width = 0;
+                y += line_step;
+                visual_line_idx += 1;
+                next_wrap = wrap_starts.get(visual_line_idx).copied();
+            } else {
+                break;
+            }
+        }
         if c == '\r' || c == '\n' {
             if line_index == char_index {
                 return (line_width, y);
             }
-            // Treat \r\n as a single line break
             if c == '\n' && prev_was_cr {
                 prev_was_cr = false;
                 line_index += 1;
+                byte_pos += c_bytes;
                 continue;
             }
             prev_was_cr = c == '\r';
             line_width = 0;
             y += line_step;
+            // Source \r/\n advances a visual line; skip a matching
+            // wrap_starts entry if it points to the next byte.
+            if let Some(wp) = next_wrap {
+                if wp == byte_pos + c_bytes {
+                    visual_line_idx += 1;
+                    next_wrap = wrap_starts.get(visual_line_idx).copied();
+                }
+            }
         } else {
             prev_was_cr = false;
-            let char_advance = params.font.get_char_advance(c as u8) as i16 + 1 + params.char_spacing;
+            // Honor per_char_advances if provided (caller pre-computed
+            // run-aware widths), otherwise fall back to font lookup
+            // with the same space-min clamp the renderer uses.
+            let char_advance: i16 = if let Some(v) = params
+                .per_char_advances
+                .and_then(|v| v.get(line_index))
+            {
+                (*v as i16).max(0)
+            } else {
+                let raw_adv = params.font.get_char_advance(c as u8) as i16;
+                let clamped_adv = if c == ' ' {
+                    raw_adv.max(params.min_space_advance.unwrap_or(0))
+                } else {
+                    raw_adv
+                };
+                clamped_adv + params.char_spacing
+            };
             if line_index == char_index {
                 return (line_width, y);
             }
             line_width += char_advance;
         }
         line_index += 1;
+        byte_pos += c_bytes;
     }
     if line_width > x {
         x = line_width;
@@ -1566,29 +1788,162 @@ pub fn get_text_char_pos(text: &str, params: &DrawTextParams, char_index: usize)
 pub fn get_text_index_at_pos(text: &str, params: &DrawTextParams, x: i32, y: i32) -> usize {
     let eff_lh = if params.font.font_size > 0 { params.font.font_size } else { params.font.char_height };
     let line_h = params.line_height.unwrap_or(eff_lh) as i32;
-    let mut index = 0;
-    let mut line_width = 0;
-    let mut line_y = params.top_spacing as i32;
-    for c in text.chars() {
-        if c == '\r' || c == '\n' {
-            if y >= line_y && y < line_y + line_h {
-                if x < line_width {
-                    return index;
-                }
+    // line_step must match the renderer's per-line vertical advance
+    // (measure_text_wrapped uses `effective_lh + line_spacing` with no
+    // extra +1). Diverging by 1px per line accumulates over wrapped text
+    // and shifts hit-test results by an entire line by the time the user
+    // clicks on the body of a paragraph — visible as clicks on "Christ's
+    // passion" landing on "three motives" or "a crown" instead.
+    let line_step = line_h + params.line_spacing as i32;
+    let wrap_w = params.member_width.unwrap_or(0) as i32;
+    let wrap_enabled = wrap_w > 0;
+    // Pre-scan word-wrap break positions so the y-mapping reflects the
+    // VISUAL line layout, not the source `\r\n` layout. Without this,
+    // a Narrative-style field whose 26k-char body has only a handful of
+    // paragraph breaks renders into dozens of wrapped lines, but the
+    // hit-test would treat them as one giant single line and clamp y
+    // past the bottom — producing `text.length` and breaking the
+    // PageNext animation precondition (`locToCharPos(point(1, pageHeight))
+    // < text.length`).
+    //
+    // Each entry is the byte-position of the FIRST char of a visual
+    // line. Index 0 is implicit (start of text).
+    //
+    // Char advance matches measure_text_wrapped (no +1) so wrap points
+    // line up with the renderer's actual layout — diverging would cause
+    // charPosToLoc and locToCharPos to disagree on which line a char is
+    // on, throwing AdvanceScroll off-target by several visual lines.
+    let char_adv = |c: char, char_idx: usize| -> i32 {
+        if let Some(v) = params.per_char_advances {
+            if let Some(adv) = v.get(char_idx) {
+                return *adv;
             }
-            if line_width > x {
-                line_width = 0;
-            }
-            line_y += line_h + params.line_spacing as i32 + 1;
+        }
+        let raw = params.font.get_char_advance(c as u8) as i32;
+        let clamped = if c == ' ' {
+            raw.max(params.min_space_advance.unwrap_or(0) as i32)
         } else {
-            if y >= line_y && y < line_y + line_h {
-                if x < line_width {
-                    return index;
+            raw
+        };
+        clamped + params.char_spacing as i32
+    };
+    let mut wrap_starts: Vec<usize> = Vec::new();
+    if wrap_enabled {
+        // Iterate CHARS not bytes — multi-byte chars (ñ, á, ç in
+        // Narrative's Spanish/Portuguese top header) would otherwise be
+        // counted twice with garbage char_adv per UTF-8 byte, miscounting
+        // line widths and producing wrap_starts at wrong byte positions.
+        // The main loop matches by byte_pos, so wrong positions cause
+        // visual-line jumps in scattered y ranges (the symptom: 271 OK,
+        // 272..285 broken, 286 OK).
+        let mut line_w: i32 = 0;
+        let mut line_start_byte: usize = 0;
+        let mut last_space_after_byte: Option<usize> = None; // byte index AFTER the space
+        let mut last_space_w: i32 = 0; // line_w at the space (so we can split cleanly)
+        let mut char_idx_pre: usize = 0;
+        for (byte_pos, c) in text.char_indices() {
+            if c == '\r' || c == '\n' {
+                wrap_starts.push(byte_pos + c.len_utf8());
+                line_start_byte = byte_pos + c.len_utf8();
+                last_space_after_byte = None;
+                last_space_w = 0;
+                line_w = 0;
+                char_idx_pre += 1;
+                continue;
+            }
+            let cw = char_adv(c, char_idx_pre);
+            char_idx_pre += 1;
+            if line_w + cw > wrap_w && byte_pos > line_start_byte {
+                if let Some(sp_after) = last_space_after_byte
+                    .filter(|&sp| sp > line_start_byte)
+                {
+                    wrap_starts.push(sp_after);
+                    line_start_byte = sp_after;
+                    last_space_after_byte = None;
+                    // Remaining width = line_w (current) - last_space_w
+                    line_w = line_w - last_space_w;
+                    last_space_w = 0;
                 }
             }
-            line_width += params.font.get_char_advance(c as u8) as i32 + 1;
+            line_w += cw;
+            if c == ' ' {
+                last_space_after_byte = Some(byte_pos + 1);
+                last_space_w = line_w;
+            }
+        }
+    }
+
+    let mut index = 0usize;
+    let mut line_width = 0i32;
+    let mut line_y = params.top_spacing as i32;
+    let mut visual_line_idx = 0usize;
+    let mut next_wrap = wrap_starts.first().copied();
+    let mut byte_pos = 0usize;
+
+    for c in text.chars() {
+        let c_bytes = c.len_utf8();
+
+        // Visual-line break triggered by word-wrap (byte_pos matches a
+        // wrap-start). Behaves like a soft \r/\n: check y range first,
+        // then advance line_y and reset line_width.
+        while let Some(wp) = next_wrap {
+            if wp == byte_pos && byte_pos != 0 {
+                if y >= line_y && y < line_y + line_h && x < line_width {
+                    return index;
+                }
+                line_width = 0;
+                line_y += line_step;
+                visual_line_idx += 1;
+                next_wrap = wrap_starts.get(visual_line_idx).copied();
+            } else {
+                break;
+            }
+        }
+
+        if c == '\r' || c == '\n' {
+            // Match against the full line_step so y values that fall in
+            // the 1-px gap between consecutive lines (line_h+1 .. line_step)
+            // still resolve to a valid char index. Without this, y exactly
+            // at a line boundary (e.g. y=259 with line_step=13) falls
+            // through the whole loop and the function returns total-1 =
+            // text.length-1, which becomes text.length after 1-based
+            // conversion — making `locToCharPos < text.length` FALSE and
+            // breaking PageNext's "is there more content below?" probe at
+            // scrollTop=0.
+            if y >= line_y && y < line_y + line_step && x < line_width {
+                return index;
+            }
+            line_width = 0;
+            line_y += line_step;
+            // Source \r/\n always advances visual lines; skip the
+            // matching wrap_starts entry (already pre-recorded).
+            if let Some(wp) = next_wrap {
+                if wp == byte_pos + 1 {
+                    visual_line_idx += 1;
+                    next_wrap = wrap_starts.get(visual_line_idx).copied();
+                }
+            }
+        } else {
+            // Match against the full line_step so y values that fall in
+            // the 1-px gap between consecutive lines (line_h+1 .. line_step)
+            // still resolve to a valid char index. Without this, y exactly
+            // at a line boundary (e.g. y=259 with line_step=13) falls
+            // through the whole loop and the function returns total-1 =
+            // text.length-1, which becomes text.length after 1-based
+            // conversion — making `locToCharPos < text.length` FALSE and
+            // breaking PageNext's "is there more content below?" probe at
+            // scrollTop=0.
+            if y >= line_y && y < line_y + line_step && x < line_width {
+                return index;
+            }
+            line_width += char_adv(c, index);
         }
         index += 1;
+        byte_pos += c_bytes;
     }
-    return index;
+    // Past the last visual line: report the last valid char index
+    // (text.chars().count() - 1, clamped to 0) so the caller can read
+    // `member.char[y..y+8]` without overflowing past text.length.
+    let total = text.chars().count();
+    if total == 0 { 0 } else { total - 1 }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
@@ -4,7 +4,7 @@ use itertools::Itertools;
 use crate::{
     director::lingo::datum::{Datum, DatumType, StringChunkExpr, StringChunkSource, StringChunkType, datum_bool},
     player::{
-        ColorRef, DatumRef, DirPlayer, ScriptError, bitmap::{bitmap::{Bitmap, BuiltInPalette, PaletteRef}, drawing::CopyPixelsParams}, cast_lib::CastMemberRef, cast_member::Media, font::{measure_text, measure_text_wrapped}, handlers::datum_handlers::{
+        ColorRef, DatumRef, DirPlayer, ScriptError, bitmap::{bitmap::{Bitmap, BuiltInPalette, PaletteRef}, drawing::CopyPixelsParams}, cast_lib::CastMemberRef, cast_member::Media, font::{get_text_index_at_pos, measure_text, measure_text_wrapped, DrawTextParams}, handlers::datum_handlers::{
             cast_member_ref::borrow_member_mut, string::{string_get_lines, string_get_words}, string_chunk::StringChunkUtils
         }
     },
@@ -89,6 +89,115 @@ impl FieldMemberHandlers {
                 member.set_text_preserving_caret(new_contents.trim_end_matches('\0').to_string());
                 Ok(DatumRef::Void)
             }
+            "locToCharPos" => {
+                // `member(N).locToCharPos(point(x, y))` — returns the 1-based
+                // char index under the local (member-relative) coordinate.
+                // Mirrors the text-member implementation in cast_member/text.rs.
+                //
+                // Must honor scroll_top + word_wrap: Narrative_Buttons#upCount
+                // / downCount rely on the index returned by
+                // `locToCharPos(point(1, 1))` *changing* as scrollTop is bumped
+                // each iteration. If the index stays constant the inner
+                // `repeat while (x = z) and (scrollTop > 0)` loop never
+                // terminates and the movie hard-stucks. Without word-wrap,
+                // a paged narrative member only has \r\n line breaks so the
+                // visible page boundary is determined purely by wrapping.
+                let (pt_vals, _flags) = player.get_datum(&args[0]).to_point_inline()?;
+                let x = pt_vals[0] as i32;
+                let y = pt_vals[1] as i32;
+                let member_ref = player.get_datum(datum).to_member_ref()?;
+                let member = player
+                    .movie
+                    .cast_manager
+                    .find_member_by_ref(&member_ref)
+                    .unwrap();
+                let field = member.member_type.as_field().unwrap();
+                let text_clone = field.text.clone();
+                let line_spacing = field.fixed_line_space;
+                let top_spacing = field.top_spacing;
+                let scroll_top = field.scroll_top as i32;
+                let wrap_width = field.width as i16;
+                let word_wrap = field.word_wrap;
+                let field_font_name = field.font.clone();
+                let field_font_size = field.font_size;
+                // Drop the immutable borrow on `member` (held implicitly
+                // via `field`) before we mutably borrow font_manager.
+                drop(field);
+                drop(member);
+                // Use the field's actual font (matching the renderer's
+                // atlas) instead of the system font. Hit-testing against
+                // system Arial widths while the renderer drew with PFR
+                // Arial widths caused clicks to map to the wrong
+                // underlined run (Fugue No.4: clicking visual "Christ's
+                // passion" returned a char position in "the sign of the
+                // cross").
+                let field_font = player.font_manager.get_font_with_cast_and_bitmap(
+                    &field_font_name,
+                    &player.movie.cast_manager,
+                    &mut player.bitmap_manager,
+                    if field_font_size > 0 { Some(field_font_size) } else { None },
+                    None,
+                );
+                let font_arc = field_font.or_else(|| player.font_manager.get_system_font());
+                let font_rc = match font_arc {
+                    Some(f) => f,
+                    None => return Ok(player.alloc_datum(Datum::Int(0))),
+                };
+                let min_space_adv = {
+                    let sz = font_rc.font_size.max(font_rc.char_height) as i32;
+                    let v = ((sz as f32) * 0.30).round() as i16;
+                    if v > 0 { Some(v) } else { None }
+                };
+                let params = DrawTextParams {
+                    font: &font_rc,
+                    line_height: None,
+                    line_spacing,
+                    top_spacing,
+                    char_spacing: 0,
+                    member_width: if word_wrap && wrap_width > 0 { Some(wrap_width) } else { None },
+                    // Match the renderer's space clamp so locToCharPos
+                    // returns positions consistent with the drawn layout.
+                    min_space_advance: min_space_adv,
+                    // TODO: build run-aware per-char advances here too
+                    // (mirror compute_mouse_char). Without it, scripts
+                    // calling `member.locToCharPos(point(x,y))` on a
+                    // mixed-font field get the same wrap-drift bug that
+                    // `the mouseChar` had before its per-run fix.
+                    per_char_advances: None,
+                };
+                let index = get_text_index_at_pos(&text_clone, &params, x, y + scroll_top);
+                Ok(player.alloc_datum(Datum::Int((index + 1) as i32)))
+            }
+            // `member.scrollByLine(amount)` — Director 11.5 Scripting
+            // Dictionary p.618: "scrolls the specified field or text cast
+            // member up or down by a specified number of lines. When amount
+            // is positive, the field scrolls down. When amount is negative,
+            // the field scrolls up." Fugue No.4's `fixSplitLines` passes
+            // fractional amounts (±0.1) for sub-line nudges to align the
+            // scroll position to a clean line boundary.
+            "scrollByLine" => {
+                let amount = player.get_datum(&args[0]).to_float()?;
+                let member_ref = player.get_datum(datum).to_member_ref()?;
+                let line_h = {
+                    let member = player.movie.cast_manager.find_member_by_ref(&member_ref).unwrap();
+                    let field = member.member_type.as_field().unwrap();
+                    if field.fixed_line_space > 0 {
+                        field.fixed_line_space as f64
+                    } else if field.font_size > 0 {
+                        field.font_size as f64
+                    } else {
+                        12.0
+                    }
+                };
+                let delta_px = (amount * line_h).round() as i32;
+                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                    if let Some(field) = member.member_type.as_field_mut() {
+                        let new_st = (field.scroll_top as i32 + delta_px).max(0) as u16;
+                        field.scroll_top = new_st;
+                    }
+                }
+                Ok(DatumRef::Void)
+            }
             _ => Err(ScriptError::new(format!(
                 "No handler {handler_name} for field member type"
             ))),
@@ -144,36 +253,67 @@ impl FieldMemberHandlers {
                 let word_datums: VecDeque<_> = words.into_iter().map(Datum::String).map(|d| player.alloc_datum(d)).collect();
                 Ok(Datum::List(DatumType::List, word_datums, false))
             }
+            // `member.char` / `member.item` — sibling of `member.line` /
+            // `member.word`: returns the full list of chunks so the script
+            // can index it. Narrative_Buttons#upCount uses
+            // `member(nar).char[y..y+8]` to extract a sliding 8-char window;
+            // without this, the get_prop call errors out and the button
+            // scroll logic never runs. (Director 11.5 Scripting Dictionary
+            // chunk-of-member entry.)
+            "char" => {
+                let chars: Vec<String> = field.text.chars().map(|c| c.to_string()).collect();
+                let char_datums: VecDeque<_> = chars.into_iter()
+                    .map(Datum::String)
+                    .map(|d| player.alloc_datum(d))
+                    .collect();
+                Ok(Datum::List(DatumType::List, char_datums, false))
+            }
+            "item" => {
+                let delim = player.movie.item_delimiter;
+                let items: Vec<String> = field.text.split(delim).map(|s| s.to_string()).collect();
+                let item_datums: VecDeque<_> = items.into_iter()
+                    .map(Datum::String)
+                    .map(|d| player.alloc_datum(d))
+                    .collect();
+                Ok(Datum::List(DatumType::List, item_datums, false))
+            }
             "pageHeight" => {
-                // pageHeight = total height of the text content (including word wrap)
-                let text_clone = field.text.clone();
-                let font_name = field.font.clone();
-                let font_size = Some(field.font_size);
-                let fixed_line_space = field.fixed_line_space;
-                let top_spacing = field.top_spacing;
-                let word_wrap = field.word_wrap;
-                let field_width = field.width;
-
-                let font = if !font_name.is_empty() {
-                    player.font_manager.get_font_with_cast_and_bitmap(
-                        &font_name,
-                        &player.movie.cast_manager,
-                        &mut player.bitmap_manager,
-                        font_size,
-                        None,
-                    )
-                } else {
-                    None
-                };
-                let font = font.or_else(|| player.font_manager.get_system_font())
-                    .ok_or_else(|| ScriptError::new("System font not available".to_string()))?;
-
-                let (_, measured_h) = if word_wrap && field_width > 0 {
-                    measure_text_wrapped(&text_clone, &font, field_width, true, fixed_line_space, top_spacing, 0, 0)
-                } else {
-                    measure_text(&text_clone, &font, None, fixed_line_space, top_spacing, 0)
-                };
-                Ok(Datum::Int(measured_h as i32))
+                // Director 11.5 Scripting Dictionary p.1077: "returns the
+                // height, in pixels, of the area of the field cast member
+                // that is visible on the Stage." For paged/scrollable
+                // field members (like Fugue No.4's Narrative — authored as
+                // a 250×9442 scroll container so the entire 26k-char body
+                // lives inside one member), the visible viewport is set
+                // by the SPRITE that hosts the member, not by the
+                // member's own rect or text_height. Look up the first
+                // sprite on the current frame whose member matches and
+                // use its height. Fall back to field.height / rect-derived
+                // height if no sprite is using the member.
+                let field_height = field.height as i32;
+                let rect_h = (field.rect_bottom as i32 - field.rect_top as i32).max(0);
+                let cm_ref = cast_member_ref.clone();
+                let frame = player.movie.current_frame;
+                let sprite_h: Option<i32> = player.movie.score
+                    .get_sorted_channels(frame)
+                    .iter()
+                    .find_map(|ch| {
+                        if ch.sprite.member.as_ref() == Some(&cm_ref) {
+                            Some((ch.sprite.height as i32).max(0))
+                        } else {
+                            None
+                        }
+                    });
+                // The text area inside the sprite excludes the field's
+                // border and margin (Director's box chrome). For Fugue
+                // No.4 Narrative (border=1, margin=5) that's 12px of
+                // chrome — without subtracting it, each PageNext
+                // over-scrolls by ~1 line. Match Director's reported
+                // pageHeight which is the *text* area, not the sprite rect.
+                let chrome = 2 * (field.border as i32) + 2 * (field.margin as i32);
+                let raw = sprite_h
+                    .filter(|h| *h > 0)
+                    .unwrap_or(field_height.max(rect_h));
+                Ok(Datum::Int((raw - chrome).max(1)))
             }
             "foreColor" => {
                 match &field.fore_color {
@@ -360,6 +500,22 @@ impl FieldMemberHandlers {
                 let lo = field.sel_start.min(field.sel_end).clamp(0, len);
                 let hi = field.sel_start.max(field.sel_end).clamp(0, len);
                 Ok(Datum::String(field.text[lo as usize..hi as usize].to_string()))
+            }
+            // `the selection of member` — Director 11.5 Scripting
+            // Dictionary p.1187: "returns the offsets of the start and
+            // end of the selection ... a linear list with two integers
+            // (selectionStart, selectionEnd)." Fugue No.4's
+            // Cues#AdvanceScroll reads `member(nar).selection`
+            // immediately after `hilite member(nar).line[o].char[1..x]`
+            // to get the char offsets of the hilited range, then uses
+            // `charPosToLoc` to translate to screen y for scrolling.
+            "selection" => {
+                let lo = field.sel_start.min(field.sel_end);
+                let hi = field.sel_start.max(field.sel_end);
+                let mut items = std::collections::VecDeque::new();
+                items.push_back(player.alloc_datum(Datum::Int(lo)));
+                items.push_back(player.alloc_datum(Datum::Int(hi)));
+                Ok(Datum::List(DatumType::List, items, false))
             }
             // Text rendering config
             "kerning" => Ok(datum_bool(field.kerning)),
@@ -590,7 +746,16 @@ impl FieldMemberHandlers {
                 member_ref,
                 |player| value.int_value(),
                 |cast_member, value| {
-                    cast_member.member_type.as_field_mut().unwrap().scroll_top = value? as u16;
+                    // Clamp negative values to 0 — `scrollTop` is a non-
+                    // negative pixel offset (Director 11.5 Scripting
+                    // Dictionary p.1158). Without the clamp, the bounceUp
+                    // animation in Narrative_Buttons (which decrements
+                    // scrollTop by 1 each step from the top of the field)
+                    // wraps -1 into u16::MAX, producing a single-frame
+                    // white-flash as the text scrolls off-bitmap.
+                    let new_val = value?.max(0) as u16;
+                    let field = cast_member.member_type.as_field_mut().unwrap();
+                    field.scroll_top = new_val;
                     Ok(())
                 },
             ),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -396,6 +396,8 @@ impl FontMemberHandlers {
                     top_spacing: text.top_spacing,
                     char_spacing: 0,
                     member_width: None,
+                    min_space_advance: None,
+                    per_char_advances: None,
                 };
 
                 let index = get_text_index_at_pos(&text.text, &params, x, y);

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/sound.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/sound.rs
@@ -1,5 +1,7 @@
+use std::collections::VecDeque;
+
 use crate::{
-    director::lingo::datum::Datum,
+    director::lingo::datum::{Datum, DatumType},
     player::{cast_lib::CastMemberRef, reserve_player_mut, DirPlayer, ScriptError},
 };
 
@@ -25,6 +27,27 @@ impl SoundMemberHandlers {
             "channelCount" => Ok(Datum::Int(sound.info.channels as i32)),
             "sampleCount" => Ok(Datum::Int(sound.info.sample_count as i32)),
             "loop" => Ok(Datum::Int(if sound.info.loop_enabled { 1 } else { 0 })),
+            // Cue-point properties — list of ms times and parallel names.
+            // Director uses 1-based indices into these lists when firing
+            // `on cuePassed`. Returned as Lingo lists so scripts can do
+            // `member(N).cuePointTimes[i]`.
+            "cuePointTimes" => {
+                // Snapshot the times to drop the borrow on `sound` (which
+                // holds `player` immutably) before re-borrowing `player`
+                // mutably via alloc_datum.
+                let times: Vec<u32> = sound.cue_point_times.clone();
+                let items: VecDeque<_> = times.into_iter()
+                    .map(|t| player.alloc_datum(Datum::Int(t as i32)))
+                    .collect();
+                Ok(Datum::List(DatumType::List, items, false))
+            }
+            "cuePointNames" => {
+                let names: Vec<String> = sound.cue_point_names.clone();
+                let items: VecDeque<_> = names.into_iter()
+                    .map(|n| player.alloc_datum(Datum::String(n)))
+                    .collect();
+                Ok(Datum::List(DatumType::List, items, false))
+            }
             _ => Err(ScriptError::new(format!(
                 "Cannot get castMember property {} for sound",
                 prop

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -108,6 +108,8 @@ impl TextMemberHandlers {
                     top_spacing: text.top_spacing,
                     char_spacing: 0,
                     member_width: None,
+                    min_space_advance: None,
+                    per_char_advances: None,
                 };
 
                 let index = get_text_index_at_pos(&text.text, &params, x, y);

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -183,6 +183,29 @@ impl CastMemberRefHandlers {
                 )
             }
             "getProp" => {
+                // Chunk-typed property + range args (e.g.
+                // `member.char[y..y+8]`, `member.line[3..5]`) compiles to
+                // `getProp(member, #char, y, y+8)`. Route those to the
+                // chunk-aware getPropRef path so the slice is taken as a
+                // StringChunk (with vm_range_to_host clamping) instead of
+                // being passed through a list getter that indexes a single
+                // element and ignores the end arg. Without this branch,
+                // Narrative_Buttons#upCount reads `member(nar).char[y..y+8]`
+                // and OOBs when locToCharPos returns a position past
+                // text.length.
+                let prop_name = reserve_player_mut(|player| {
+                    Ok::<String, ScriptError>(player.get_datum(&args[0]).string_value().unwrap_or_default())
+                })?;
+                let is_chunk_typed = matches!(
+                    prop_name.to_ascii_lowercase().as_str(),
+                    "char" | "chars" | "word" | "words" | "line" | "lines" | "item" | "items"
+                );
+                if is_chunk_typed && args.len() >= 2 {
+                    // Delegate to the member-type getPropRef which builds a
+                    // StringChunk via field.rs / text.rs.
+                    return Self::call_member_type(datum, &"getPropRef".to_string(), args);
+                }
+
                 let result_ref = reserve_player_mut(|player| {
                     let cast_member_ref = match player.get_datum(datum) {
                         Datum::CastMember(cast_member_ref) => cast_member_ref.to_owned(),

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -488,7 +488,13 @@ impl SoundChannelDatumHandlers {
 
     pub fn handle_stop(player: &mut DirPlayer, datum: &DatumRef) -> Result<(), ScriptError> {
         let channel = Self::get_sound_channel_mut(player, datum)?;
+        let channel_num = channel.borrow().channel_num;
         channel.borrow_mut().stop();
+        // Release the audio-time sync anchor when sound 1 stops — the score
+        // frame loop returns to its normal tempo'd advance.
+        if channel_num == 0 {
+            player.audio_sync_anchor = None;
+        }
         Ok(())
     }
 
@@ -1139,6 +1145,12 @@ pub struct SoundChannel {
     pub decode_generation: Rc<RefCell<u32>>, // Incremented each time a new decode starts
     pub playback_start_context_time: f64, // AudioContext.currentTime when playback started
 
+    /// Index of the next cue point in `sound_member.cue_point_times` that
+    /// hasn't yet fired this segment. Advanced as the playhead crosses each
+    /// entry. Reset on `start_segment_playback` (and skips entries that
+    /// fall before `start_time`, so a `[#startTime: N]` seek doesn't
+    /// re-fire cues already behind the playhead).
+    pub next_cue_index: usize,
 }
 
 impl SoundChannel {
@@ -1357,6 +1369,7 @@ impl SoundChannel {
             is_decoding: Rc::new(RefCell::new(false)),
             decode_generation: Rc::new(RefCell::new(0)),
             playback_start_context_time: 0.0,
+            next_cue_index: 0,
         }
     }
 
@@ -1773,6 +1786,14 @@ impl SoundChannel {
                 this.sample_count = sound_member.info.sample_count;
                 this.channel_count = sound_member.info.channels;
             }
+            // Stash sound_member + cue cursor are set further below, inside
+            // the async resampling completion block — at the exact moment we
+            // also reset `playback_start_context_time` so the cue-detection
+            // math in `update()` lines up with the real audio source clock.
+            // Setting them here in the sync prelude instead would mean
+            // `update()` starts comparing the cue list against a playhead
+            // that's been running for the entire decode/resample window
+            // (24MB ADPCM resample takes ~20s) and fires every cue at once.
 
             // Load audio data
             let audio_data = match Self::load_director_audio_data(
@@ -1799,6 +1820,12 @@ impl SoundChannel {
 
                 let self_rc_clone = self_rc.clone();
                 let mp3_data = mp3_bytes.clone();
+                // Pass the resolved sound member through to the MP3 decode
+                // task so the channel can stash it next to
+                // `playback_start_context_time` once the source actually
+                // starts — that's the moment the cue-detection clock
+                // resets, so cue list + clock have to land together.
+                let mp3_sound_member = sound_member.clone();
 
                 debug!("🚀 About to spawn MP3 decode task (start_sound)");
                 wasm_bindgen_futures::spawn_local(async move {
@@ -1807,9 +1834,9 @@ impl SoundChannel {
                         ch.status = SoundStatus::Loading;
                     }
 
-                    if let Err(e) = Self::start_sound_mp3_async(self_rc_clone.clone(), mp3_data.clone()).await {
+                    if let Err(e) = Self::start_sound_mp3_async(self_rc_clone.clone(), mp3_data.clone(), mp3_sound_member).await {
                         error!("❌ MP3 playback failed: {:?}", e);
-                        debug!("📊 MP3 data size: {} bytes, first bytes: {:02X?}", 
+                        debug!("📊 MP3 data size: {} bytes, first bytes: {:02X?}",
                             mp3_data.len(), &mp3_data[0..32.min(mp3_data.len())]);
                         {
                             let mut ch = self_rc_clone.borrow_mut();
@@ -1886,7 +1913,12 @@ impl SoundChannel {
                 let gen_ = *ch.decode_generation.borrow();
                 gen_  // Return the copied value
             };
-            
+
+            // Clone the resolved sound member so the async closure can stash
+            // it on the channel at the exact moment the source node starts —
+            // see the matching site further down.
+            let sound_member_for_cues = sound_member.clone();
+
             wasm_bindgen_futures::spawn_local(async move {
 
                 {
@@ -1968,7 +2000,37 @@ impl SoundChannel {
                 ch.elapsed_time = 0.0;
                 *ch.is_decoding.borrow_mut() = false;
 
+                // Cue-point state: must be set NOW, alongside
+                // `playback_start_context_time`. Setting it earlier (during
+                // the sync prelude of start_sound) would let `update()`
+                // compare the cue list against a wall-clock that's been
+                // accruing the entire ADPCM/MP3 decode + resample window
+                // (often 15-25s for a 24MB ADPCM track), and the first
+                // tick after sound_member became visible would dump every
+                // cue before the (fake) playhead in one shot. With this
+                // moved here, both clocks reset together at true start.
+                let seek_ms = ch.start_time as i64;
+                ch.next_cue_index = sound_member_for_cues
+                    .cue_point_times
+                    .iter()
+                    .position(|t| (*t as i64) >= seek_ms)
+                    .unwrap_or(sound_member_for_cues.cue_point_times.len());
+                ch.sound_member = Some(sound_member_for_cues);
+
+                let pcm_channel_num = ch.channel_num;
+                let pcm_anchor_ctx_time = ch.playback_start_context_time;
                 drop(ch);
+
+                // Mirror of the MP3-path audio-sync anchor — see comment there.
+                if pcm_channel_num == 0 {
+                    let player_opt = unsafe { crate::PLAYER_OPT.as_mut() };
+                    if let Some(player) = player_opt {
+                        player.audio_sync_anchor = Some((
+                            player.movie.current_frame,
+                            pcm_anchor_ctx_time,
+                        ));
+                    }
+                }
 
                 // Set up ended callback. Generation guard: when a previous
                 // source was explicitly stopped via `stop_with_when(0.0)`
@@ -2100,6 +2162,7 @@ impl SoundChannel {
     async fn start_sound_mp3_async(
         self_rc: Rc<RefCell<SoundChannel>>,
         mp3_bytes: Vec<u8>,
+        sound_member: SoundMember,
     ) -> Result<(), JsValue> {
         use web_sys::console;
 
@@ -2360,7 +2423,7 @@ impl SoundChannel {
         debug!("▶️ MP3 source.start() called");
 
         // Store nodes in channel state AFTER starting (only once!)
-        {
+        let (anchor_channel_num, anchor_ctx_time) = {
             let mut ch = self_rc.borrow_mut();
             ch.source_node = Some(Rc::new(source));
             ch.gain_node = Some(Rc::new(gain));
@@ -2368,6 +2431,34 @@ impl SoundChannel {
             ch.playback_start_context_time = ch.context_time();
             ch.elapsed_time = 0.0;
             *ch.is_decoding.borrow_mut() = false;
+
+            // Cue-point state must reset alongside `playback_start_context_time`,
+            // not in the synchronous prelude of start_sound — see the matching
+            // comment on the PCM resampling completion path.
+            let seek_ms = ch.start_time as i64;
+            ch.next_cue_index = sound_member
+                .cue_point_times
+                .iter()
+                .position(|t| (*t as i64) >= seek_ms)
+                .unwrap_or(sound_member.cue_point_times.len());
+            ch.sound_member = Some(sound_member);
+
+            (ch.channel_num, ch.playback_start_context_time)
+        };
+
+        // Anchor the score-frame ↔ audio-time sync on channel 1 (Lingo
+        // `sound(1)`, internal channel_num=0). The frame loop uses this
+        // anchor to keep score-driven sprites (Fugue No.4's Cross 1-4 path
+        // tweens) locked to audio playback instead of drifting on wall-clock.
+        // See run_frame_loop. Cleared when sound stops.
+        if anchor_channel_num == 0 {
+            let player_opt = unsafe { crate::PLAYER_OPT.as_mut() };
+            if let Some(player) = player_opt {
+                player.audio_sync_anchor = Some((
+                    player.movie.current_frame,
+                    anchor_ctx_time,
+                ));
+            }
         }
 
         debug!("✅ Channel {} MP3 playback started", channel_num);
@@ -3567,6 +3658,19 @@ impl SoundChannel {
             1
         };
 
+        // `#startTime` seeks into the queued audio in milliseconds.
+        // Director's Fugue No.4 movie uses it heavily — every Commence call
+        // queues [#member: m, #startTime: line[4][cm]] so the audio starts
+        // exactly at the time of cue #cm. Without honouring this, playback
+        // restarts at 0ms after every user click, re-firing the whole cue
+        // list from the top. Accept Int or Float (Director is lax here).
+        let start_time_ms = match SoundChannel::get_proplist_prop(player, &datum, "startTime") {
+            Some(Datum::Int(v)) => v as f64,
+            Some(Datum::Float(v)) => v,
+            _ => 0.0,
+        };
+        self.start_time = start_time_ms.max(0.0);
+
         if loop_count <= 0 {
             console::log_1(
                 &format!(
@@ -3727,6 +3831,36 @@ impl SoundChannel {
 
         self.elapsed_time += delta_time;
 
+        // Fire any cue points the playhead has just crossed. Playhead is
+        // measured against the audio-context clock for accuracy (matches
+        // the `currentTime` getter math at line 282-284); falls back to
+        // accumulated `elapsed_time` if the context handle isn't set up.
+        // `next_cue_index` is initialised on segment start, so this loop
+        // is a no-op for sounds without cue points.
+        if let Some(member) = self.sound_member.as_ref() {
+            if self.next_cue_index < member.cue_point_times.len() {
+                let playhead_ms = if let Some(ctx) = self.audio_context.as_ref() {
+                    self.start_time + (ctx.current_time() - self.playback_start_context_time) * 1000.0
+                } else {
+                    self.start_time + self.elapsed_time * 1000.0
+                };
+                while self.next_cue_index < member.cue_point_times.len()
+                    && (member.cue_point_times[self.next_cue_index] as f64) <= playhead_ms
+                {
+                    let number = (self.next_cue_index + 1) as i32;
+                    let name = member
+                        .cue_point_names
+                        .get(self.next_cue_index)
+                        .cloned()
+                        .unwrap_or_default();
+                    // Channels are 1-based in Director's Lingo surface; our
+                    // internal `channel_num` starts at 0 (channel 1 is index 0).
+                    player.pending_cue_events.push((self.channel_num + 1, number, name));
+                    self.next_cue_index += 1;
+                }
+            }
+        }
+
         // Note: previously had a "safety net" here that forced status to
         // Idle when `elapsed_time > sample_count/sample_rate + 0.1s`.
         // That heuristic used Director's authored duration (from the cast
@@ -3788,6 +3922,21 @@ impl SoundChannel {
         self.sample_rate = sound_member.info.sample_rate;
         self.sample_count = sound_member.info.sample_count;
         self.channel_count = sound_member.info.channels;
+
+        // Reset the cue cursor for this segment. Cues strictly before
+        // `start_time` (Lingo `[#startTime: ms]` seek) are already behind
+        // the playhead — skip them so a seek-into-audio doesn't spam
+        // cuePassed for every cue prior to the seek point. A cue whose
+        // time exactly equals the seek point still fires (Director's
+        // observed behaviour and what the Fugue movie relies on:
+        // `[#startTime: line[4][cm]]` seeks to the time of cue#cm so that
+        // cue fires almost immediately after play() starts).
+        let seek_ms = self.start_time as i64;
+        self.next_cue_index = sound_member
+            .cue_point_times
+            .iter()
+            .position(|t| (*t as i64) >= seek_ms)
+            .unwrap_or(sound_member.cue_point_times.len());
 
         self.expected_sample_rate = Some(sound_member.info.sample_rate);
 

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -119,6 +119,8 @@ impl SpriteDatumUtils {
             top_spacing,
             char_spacing: 0,
             member_width: None,
+            min_space_advance: None,
+            per_char_advances: None,
         };
 
         let char_index = get_text_index_at_pos(&text, &params, local_x, local_y);

--- a/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
@@ -97,7 +97,7 @@ impl StringChunkUtils {
                     .text
                     .clone(),
             };
-            Self::string_by_setting_chunk(&original_str, &chunk_expr, &new_string)
+            Self::string_by_putting_into_chunk(&original_str, &chunk_expr, &new_string)
         }?;
         Self::set_value(player, original_str_src, chunk_expr, new_string)?;
         Ok(())
@@ -204,26 +204,6 @@ impl StringChunkUtils {
                 new_chunks.drain(start..end);
                 Ok(new_chunks.join("\r\n"))
             },
-        }
-    }
-
-    pub fn string_by_setting_chunk(
-        string: &str,
-        chunk_expr: &StringChunkExpr,
-        replace_with: &str,
-    ) -> Result<String, ScriptError> {
-        match chunk_expr.chunk_type {
-            StringChunkType::Char => {
-                let mut new_string = string.to_owned();
-                let (start, end) =
-                    Self::vm_range_to_host((chunk_expr.start, chunk_expr.end), string.chars().count());
-                let (byte_start, byte_end) = char_range_to_byte_range(string, start, end);
-                new_string.replace_range(byte_start..byte_end, replace_with);
-                Ok(new_string)
-            }
-            _ => Err(ScriptError::new(
-                "Only char chunk type is supported for string by setting chunk".to_string(),
-            )),
         }
     }
 
@@ -402,7 +382,6 @@ impl StringChunkUtils {
         chunk_expr: &StringChunkExpr,
         replace_with: &str,
     ) -> Result<String, ScriptError> {
-        // Similar to string_by_setting_chunk but supports all chunk types
         match chunk_expr.chunk_type {
             StringChunkType::Char => {
                 let mut new_string = string.to_owned();
@@ -1031,6 +1010,35 @@ impl StringChunkHandlers {
         })
     }
 
+    /// `hilite fieldChunkExpression` / `chunk.hilite()` — Director command
+    /// that selects (highlights) the chunk's character range inside the
+    /// originating field/text member. Maps to setting the member's
+    /// sel_start / sel_end so the renderer can paint the selection band.
+    /// Director 11.5 Scripting Dictionary p.411: "highlights (selects) in
+    /// the field sprite the specified chunk".
+    fn hilite(datum: &DatumRef, _args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            if let Some((member_ref, start, end)) =
+                StringChunkHandlers::walk_chunk_to_member_range(player, datum)
+            {
+                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                    match &mut member.member_type {
+                        CastMemberType::Field(f) => {
+                            f.sel_start = start as i32;
+                            f.sel_end = end as i32;
+                        }
+                        CastMemberType::Text(t) => {
+                            t.sel_start = start as i32;
+                            t.sel_end = end as i32;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            Ok(DatumRef::Void)
+        })
+    }
+
     pub fn call(
         datum: &DatumRef,
         handler_name: &str,
@@ -1038,10 +1046,56 @@ impl StringChunkHandlers {
     ) -> Result<DatumRef, ScriptError> {
         match handler_name {
             "count" => Self::count(datum, args),
-            "getProp" => Self::get_prop(datum, args),
+            // Chunk-typed nested access (`member.line[o].char[1..x]`) is
+            // ALWAYS routed through get_prop_ref so the returned datum is
+            // a StringChunk — chained property reads like
+            // `member.line[o].char[1..x].font` can then walk the chunk
+            // chain back to the source member's styled spans. If we used
+            // get_prop here it would resolve to a plain String, and the
+            // `.font` access then errors with "Invalid string built-in
+            // property font" (Fugue No.4 Cues#AdvanceScroll trips this).
+            "getProp" => {
+                let prop_name = reserve_player_mut(|player| {
+                    Ok::<String, ScriptError>(
+                        player.get_datum(&args[0]).string_value().unwrap_or_default()
+                    )
+                })?;
+                let is_chunk_typed = matches!(
+                    prop_name.to_ascii_lowercase().as_str(),
+                    "char" | "chars" | "word" | "words" | "line" | "lines" | "item" | "items"
+                );
+                if is_chunk_typed {
+                    Self::get_prop_ref(datum, args)
+                } else {
+                    Self::get_prop(datum, args)
+                }
+            }
             "getPropRef" => Self::get_prop_ref(datum, args),
             "delete" => Self::delete(datum, args),
             "setContents" => Self::set_contents(datum, args),
+            "hilite" => Self::hilite(datum, args),
+            // `chunk[N]` — index access. Director treats this as the Nth
+            // character of the chunk's text (1-based). Movies that wrap a
+            // field lookup in `value(...)` and then `[1]` to grab the
+            // first element fall through here when our chain-preserving
+            // chunk machinery returns a StringChunk where the script
+            // expected a String.
+            "getAt" => {
+                if args.is_empty() {
+                    return Err(ScriptError::new("getAt requires 1 argument".to_string()));
+                }
+                let idx_ref = args[0].clone();
+                let datum = datum.clone();
+                reserve_player_mut(|player| {
+                    let s = player.get_datum(&datum).string_value()?;
+                    let idx = player.get_datum(&idx_ref).int_value()?;
+                    if idx < 1 {
+                        return Ok(player.alloc_datum(Datum::String(String::new())));
+                    }
+                    let ch = s.chars().nth((idx - 1) as usize).map(|c| c.to_string());
+                    Ok(player.alloc_datum(Datum::String(ch.unwrap_or_default())))
+                })
+            }
             _ => Err(ScriptError::new(format!(
                 "No handler {handler_name} for string chunk datum"
             ))),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1401,6 +1401,21 @@ impl BuiltInHandlerManager {
             "alert" => Self::alert(args),
             "objectp" => Self::object_p(args),
             "soundbusy" => TypeHandlers::sound_busy(args),
+            // `stopSound` (Director 11.5 Scripting Dictionary p.872) —
+            // legacy command that stops the sound currently playing on
+            // sound channel 1 (the implicit puppetSound channel). Fugue
+            // No.4 Narrative mouseUp calls it inside `if soundBusy(1)
+            // then stopSound()` to interrupt playback before checking
+            // for clicked underline targets — without it, soundBusy(1)
+            // stays true forever and the underline branch never runs.
+            "stopsound" => {
+                reserve_player_mut(|player| {
+                    if let Some(ch) = player.sound_manager.get_channel(0) {
+                        ch.borrow_mut().stop_sound();
+                    }
+                });
+                Ok(DatumRef::Void)
+            }
             "delay" => MovieHandlers::delay(args),
             "halt" => MovieHandlers::halt(args),
             "starttimer" => Self::start_timer(args),
@@ -1474,15 +1489,15 @@ impl BuiltInHandlerManager {
                         .find_member_by_ref(&member_ref)
                         .ok_or_else(|| ScriptError::new("Member not found".to_string()))?;
 
-                    let (text, fixed_line_space, top_spacing, char_spacing, member_width, font_name, font_size, alignment, tab_stops) = match &member.member_type {
+                    let (text, fixed_line_space, top_spacing, char_spacing, member_width, font_name, font_size, alignment, tab_stops, word_wrap) = match &member.member_type {
                         crate::player::cast_member::CastMemberType::Text(t) => {
-                            (t.text.clone(), t.fixed_line_space, t.top_spacing, t.char_spacing as i16, t.width as i16, t.font.clone(), t.font_size, t.alignment.clone(), t.tab_stops.clone())
+                            (t.text.clone(), t.fixed_line_space, t.top_spacing, t.char_spacing as i16, t.width as i16, t.font.clone(), t.font_size, t.alignment.clone(), t.tab_stops.clone(), t.word_wrap)
                         }
                         crate::player::cast_member::CastMemberType::Field(f) => {
-                            (f.text.clone(), f.fixed_line_space, f.top_spacing, 0, f.width as i16, f.font.clone(), f.font_size, f.alignment.clone(), Vec::new())
+                            (f.text.clone(), f.fixed_line_space, f.top_spacing, 0, f.width as i16, f.font.clone(), f.font_size, f.alignment.clone(), Vec::new(), f.word_wrap)
                         }
                         crate::player::cast_member::CastMemberType::Button(b) => {
-                            (b.field.text.clone(), b.field.fixed_line_space, b.field.top_spacing, 0, b.field.width as i16, b.field.font.clone(), b.field.font_size, b.field.alignment.clone(), Vec::new())
+                            (b.field.text.clone(), b.field.fixed_line_space, b.field.top_spacing, 0, b.field.width as i16, b.field.font.clone(), b.field.font_size, b.field.alignment.clone(), Vec::new(), b.field.word_wrap)
                         }
                         _ => {
                             return Err(ScriptError::new(
@@ -1490,6 +1505,17 @@ impl BuiltInHandlerManager {
                             ))
                         }
                     };
+                    // Effective wrap width: only honour the member's authored
+                    // width when the member ACTUALLY wraps (word_wrap = true).
+                    // For non-wrapping members (Habbo's Text Wrapper Class
+                    // composer creates `new(#text)` members whose word_wrap
+                    // defaults differ from field defaults), charPosToLoc must
+                    // return single-line absolute positions even when the
+                    // text would visually overflow `member.width` — the
+                    // composer's `pTextMem.charPosToLoc(char.count).locH + 16`
+                    // formula depends on this to compute the final bitmap
+                    // width BEFORE growing the rect.
+                    let effective_wrap_width: i16 = if word_wrap { member_width } else { 0 };
 
                     let align_lower = alignment.to_lowercase();
                     let align_kind: u8 = if align_lower == "center" || align_lower == "#center" {
@@ -1586,12 +1612,49 @@ impl BuiltInHandlerManager {
                         };
                         let width = (start_x + prefix_w).round() as i32;
 
+                        // Use the renderer's actual wrap function
+                        // `wrap_lines_with_spans` to count the visual line
+                        // that contains the target char. Anything else
+                        // (per-char measureText, bitmap-font advance sums)
+                        // diverges from the rendered layout by a few px
+                        // per line — drift of 30-40 lines accumulates over
+                        // a 26k-char field and lands AdvanceScroll several
+                        // sections away from the intended header.
                         let line_step = if fixed_line_space > 0 {
                             fixed_line_space as i32
                         } else {
                             display_font_size as i32
                         };
-                        let y = top_spacing as i32 + line_idx as i32 * line_step;
+                        // Convert char_pos (1-based) to byte position.
+                        let target_byte: usize = text
+                            .char_indices()
+                            .nth(index)
+                            .map(|(b, _)| b)
+                            .unwrap_or_else(|| text.len());
+                        // Look up the actual loaded font (PFR1 if available).
+                        let render_font = player.font_manager.get_font_with_cast_and_bitmap(
+                            &display_font_name,
+                            &player.movie.cast_manager,
+                            &mut player.bitmap_manager,
+                            Some(display_font_size),
+                            None,
+                        ).or_else(|| player.font_manager.get_system_font());
+                        let visual_line = if let Some(font) = render_font {
+                            let lines = crate::player::bitmap::bitmap::Bitmap
+                                ::wrap_lines_with_spans(&text, &font, if effective_wrap_width > 0 { effective_wrap_width as i32 } else { i32::MAX });
+                            let mut idx = 0usize;
+                            for (i, ls) in lines.iter().enumerate() {
+                                if target_byte >= ls.start && target_byte <= ls.end {
+                                    idx = i;
+                                    break;
+                                }
+                                if i == lines.len() - 1 { idx = i; }
+                            }
+                            idx as i32
+                        } else {
+                            line_idx as i32
+                        };
+                        let y = top_spacing as i32 + visual_line * line_step;
 
                         Ok(player.alloc_datum(Datum::Point([width as f64, y as f64], 0)))
                     } else {
@@ -1604,7 +1667,27 @@ impl BuiltInHandlerManager {
                             line_spacing: fixed_line_space,
                             top_spacing,
                             char_spacing,
-                            member_width: if member_width > 0 { Some(member_width) } else { None },
+                            // Honour word_wrap: only constrain measurement
+                            // by the authored width when the member actually
+                            // wraps. Non-wrapping members (Habbo composer's
+                            // `new(#text)` titles) need single-line absolute
+                            // positions.
+                            member_width: if effective_wrap_width > 0 { Some(effective_wrap_width) } else { None },
+                            // Match the renderer's per-field space-min clamp
+                            // (0.30 * font_size) so charPosToLoc and the
+                            // hit-test stay aligned with the drawn layout.
+                            // Without this, `the locToCharPos` returns a
+                            // char position from a hit-test layout with
+                            // narrower spaces than the rendered one — so
+                            // a click on visual "Christ's passion" maps
+                            // into the following "the sign of the cross"
+                            // chunk.
+                            min_space_advance: {
+                                let sz = font.font_size.max(font.char_height) as i32;
+                                let v = ((sz as f32) * 0.30).round() as i16;
+                                if v > 0 { Some(v) } else { None }
+                            },
+                            per_char_advances: None,
                         };
                         // Tab-aware char position. Coke Studios' userlist computes
                         // the dotted-separator bounds via two charPosToLoc calls,
@@ -1687,7 +1770,43 @@ impl BuiltInHandlerManager {
                             }
                             result.unwrap_or((x, y))
                         } else {
-                            crate::player::font::get_text_char_pos(&text, &params, index)
+                            // Use the renderer's own wrap_lines_with_spans
+                            // to find the visual line containing the target
+                            // char. Any other algorithm (my chars-based pre-
+                            // scan in get_text_char_pos, Canvas2D per-char
+                            // measureText) diverges by a few px per line
+                            // and lands the AdvanceScroll target several
+                            // sections away from the intended header.
+                            let target_byte: usize = text
+                                .char_indices()
+                                .nth(index)
+                                .map(|(b, _)| b)
+                                .unwrap_or_else(|| text.len());
+                            let line_step = if fixed_line_space > 0 {
+                                fixed_line_space as i16
+                            } else if font.font_size > 0 {
+                                font.font_size as i16
+                            } else {
+                                font.char_height as i16
+                            };
+                            let lines = crate::player::bitmap::bitmap::Bitmap
+                                ::wrap_lines_with_spans(&text, &font, if effective_wrap_width > 0 { effective_wrap_width as i32 } else { i32::MAX });
+                            let mut visual_idx: usize = 0;
+                            for (i, ls) in lines.iter().enumerate() {
+                                if target_byte >= ls.start && target_byte <= ls.end {
+                                    visual_idx = i;
+                                    break;
+                                }
+                                if i + 1 == lines.len() {
+                                    visual_idx = i;
+                                }
+                            }
+                            // x: position within the line, computed by
+                            // get_text_char_pos (which handles char-level
+                            // x correctly). y: from visual_idx * line_step.
+                            let (x_pos, _y_unused) = crate::player::font::get_text_char_pos(&text, &params, index);
+                            let y_pos = top_spacing.saturating_add(visual_idx as i16 * line_step);
+                            (x_pos, y_pos)
                         };
 
                         // Apply alignment offset so the returned x matches the pixel position
@@ -2185,6 +2304,135 @@ impl BuiltInHandlerManager {
             }
         })
     }
+}
+
+
+/// Count word-wrap visual line breaks (NOT source `\r\n` breaks) that
+/// occur strictly before `target_char_idx` in `text`, given a wrap
+/// width and font. Used by `charPosToLoc` for native-rendered fields
+/// so the returned y matches the wrapped visual layout. Width is
+/// measured via Canvas2D `measureText` so it agrees with the
+/// rasterizer.
+fn count_wraps_before_index(
+    text: &str,
+    font_name: &str,
+    font_size: u16,
+    wrap_w: i16,
+    target_char_idx: usize,
+) -> usize {
+    use wasm_bindgen::JsCast;
+    let ctx_opt = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.create_element("canvas").ok())
+        .and_then(|el| el.dyn_into::<web_sys::HtmlCanvasElement>().ok())
+        .and_then(|c| c.get_context("2d").ok().flatten())
+        .and_then(|c| c.dyn_into::<web_sys::CanvasRenderingContext2d>().ok());
+    let Some(ctx) = ctx_opt else { return 0; };
+    ctx.set_font(&format!("{}px {}", font_size, font_name));
+    // Walk source lines; for each line, simulate word-wrap and count
+    // breaks that occur at char positions < target_char_idx.
+    let normalised: String = text.replace("\r\n", "\n").replace('\r', "\n");
+    let mut consumed_chars = 0usize;
+    let mut extra_wraps = 0usize;
+    for source_line in normalised.split('\n') {
+        let line_chars: Vec<char> = source_line.chars().collect();
+        let line_len = line_chars.len();
+        if consumed_chars + line_len + 1 < target_char_idx {
+            // Need full wrap count of this line, target is past it.
+            extra_wraps += wraps_in_line(&ctx, source_line, wrap_w);
+            consumed_chars += line_len + 1; // +1 for the \n
+            continue;
+        }
+        // Target is somewhere on this source line. Count wraps that
+        // happen before (target_char_idx - consumed_chars) chars in.
+        let offset_in_line = target_char_idx.saturating_sub(consumed_chars).min(line_len);
+        extra_wraps += wraps_in_line_up_to(&ctx, source_line, wrap_w, offset_in_line);
+        break;
+    }
+    extra_wraps
+}
+
+/// Total visual-line breaks (excluding the implicit final line) when
+/// `line` is word-wrapped at `wrap_w` pixels. Uses Canvas2D for width.
+fn wraps_in_line(
+    ctx: &web_sys::CanvasRenderingContext2d,
+    line: &str,
+    wrap_w: i16,
+) -> usize {
+    wraps_in_line_up_to(ctx, line, wrap_w, line.chars().count())
+}
+
+/// Visual-line breaks that occur in `line` before reaching
+/// `target_char_offset` chars into it. Mirrors EXACTLY the renderer's
+/// word-level wrap algorithm in `measure_text_native_styled` —
+/// candidates are built by joining the next whitespace-separated word
+/// and measured as a whole string (so Canvas2D's natural kerning is
+/// preserved). Per-char measurement, by contrast, over-estimates
+/// because kerning isn't applied between independent calls.
+fn wraps_in_line_up_to(
+    ctx: &web_sys::CanvasRenderingContext2d,
+    line: &str,
+    wrap_w: i16,
+    target_char_offset: usize,
+) -> usize {
+    if line.is_empty() || wrap_w <= 0 { return 0; }
+    let wrap_width = wrap_w as f64;
+    // Tokenize the line: each token is either a word (run of non-
+    // whitespace) or a whitespace gap. We need to know the cumulative
+    // char count up to and including each token so we can stop counting
+    // wraps once we've passed `target_char_offset`.
+    #[derive(Clone)]
+    struct Token<'a> { text: &'a str, char_count: usize, is_ws: bool }
+    let mut tokens: Vec<Token> = Vec::new();
+    let mut iter = line.char_indices().peekable();
+    while let Some(&(start, c)) = iter.peek() {
+        let is_ws = c.is_whitespace();
+        let mut end = start;
+        let mut count = 0;
+        while let Some(&(p, ch)) = iter.peek() {
+            if ch.is_whitespace() != is_ws { break; }
+            end = p + ch.len_utf8();
+            count += 1;
+            iter.next();
+        }
+        tokens.push(Token { text: &line[start..end], char_count: count, is_ws });
+    }
+    // Now run the renderer's algorithm: `current` accumulates the
+    // running line; for each non-whitespace word, build a candidate
+    // `current + word` and check if it overflows wrap_width.
+    let mut current = String::new();
+    let mut wraps = 0usize;
+    let mut consumed_chars = 0usize;
+    for tok in &tokens {
+        if tok.is_ws {
+            // Whitespace between words. Renderer's split_whitespace
+            // discards these but joins with a single ' '. We mirror
+            // that by appending ' ' to current if current is non-empty.
+            // Match renderer's `format!("{} {}", current, word)` join.
+            consumed_chars += tok.char_count;
+            continue;
+        }
+        // Non-whitespace word.
+        let candidate = if current.is_empty() {
+            tok.text.to_string()
+        } else {
+            format!("{} {}", current, tok.text)
+        };
+        let w = ctx.measure_text(&candidate).map(|m| m.width()).unwrap_or(0.0);
+        if w > wrap_width && !current.is_empty() {
+            // Wrap before this word. The wrap-point sits at the start
+            // of THIS word in the original line.
+            if consumed_chars <= target_char_offset {
+                wraps += 1;
+            }
+            current = tok.text.to_string();
+        } else {
+            current = candidate;
+        }
+        consumed_chars += tok.char_count;
+        if consumed_chars > target_char_offset { break; }
+    }
+    wraps
 }
 
 fn get_datum_script_instance_ids(

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -419,6 +419,16 @@ impl TypeHandlers {
             let datum = player.get_datum(&args[0]);
             match datum {
                 Datum::String(s) => Some(s.clone()),
+                // StringChunk: produce the chunk's resolved text and
+                // parse that as Lingo, same as a plain string. Habbo
+                // / Sulake movies wrap field lookups in `value(...)`:
+                // `value(convertToPropList(field(...))["object.manager.class"])[1]`
+                // — without this branch, value() returned the chunk
+                // unchanged and `[1]` then errored with
+                // "No handler getAt for string chunk datum".
+                Datum::StringChunk(..) => {
+                    datum.string_value().ok()
+                },
                 _ => None,
             }
         });
@@ -562,6 +572,21 @@ impl TypeHandlers {
                 Datum::SpriteRef(sprite_num) => Datum::Int(*sprite_num as i32),
                 Datum::String(s) => {
                     let result = Self::integer_impl(&s);
+                    if let Some(int_value) = result {
+                        Datum::Int(int_value)
+                    } else {
+                        return Ok(DatumRef::Void);
+                    }
+                }
+                // StringChunk is what `member.line[N].item[M]` and friends
+                // now resolve to (since chunk-typed getProp returns refs so
+                // chained property reads like `.font` work). For
+                // `integer(...)` and other numeric coercions, fall through
+                // to the StringChunk's resolved string value and parse.
+                // Fugue No.4 Cues#startMovie: `lm = integer(member("ClikPts")
+                // .line[2].item[1])`.
+                Datum::StringChunk(_, _, resolved) => {
+                    let result = Self::integer_impl(resolved);
                     if let Some(int_value) = result {
                         Datum::Int(int_value)
                     } else {
@@ -739,6 +764,19 @@ impl TypeHandlers {
                         members.push(slot);
                     }
                     player.cursor = CursorRef::Member(members);
+                    player.cursor_is_hidden = false;
+                    player.wants_pointer_lock = false;
+                    Ok(DatumRef::Void)
+                } else if let Datum::CastMember(member_ref) = arg {
+                    // Director accepts a single cast member directly:
+                    //   cursor(member("HandCursor"))
+                    // Treated as a one-element list — equivalent to
+                    //   cursor([member("HandCursor")])
+                    let slot = CastMemberRefHandlers::get_cast_slot_number(
+                        member_ref.cast_lib as u32,
+                        member_ref.cast_member as u32,
+                    ) as i32;
+                    player.cursor = CursorRef::Member(vec![slot]);
                     player.cursor_is_hidden = false;
                     player.wants_pointer_lock = false;
                     Ok(DatumRef::Void)

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -1830,6 +1830,10 @@ impl DirPlayer {
             },
             "mouseH" => Ok(self.alloc_datum(Datum::Int(self.mouse_loc.0 as i32))),
             "mouseV" => Ok(self.alloc_datum(Datum::Int(self.mouse_loc.1 as i32))),
+            "mouseChar" => {
+                let val = compute_mouse_char(self);
+                Ok(self.alloc_datum(Datum::Int(val)))
+            },
             "stillDown" => Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))),
             "rollover" => {
                 let sprite = get_sprite_at(self, self.mouse_loc.0, self.mouse_loc.1, false);
@@ -2125,6 +2129,25 @@ impl DirPlayer {
             "mouseLoc" => {
                 Ok(self.alloc_datum(Datum::Point([self.mouse_loc.0 as f64, self.mouse_loc.1 as f64], 0)))
             }
+            "clickOn" => Ok(self.alloc_datum(Datum::Int(self.click_on_sprite as i32))),
+            // `_mouse.clickLoc` — point where the user last clicked,
+            // captured at mouseDown (distinct from mouseLoc which tracks
+            // current cursor position). Fugue No.4's Narrative_Float
+            // mouseWithin reads `getAt(_mouse.clickLoc, 2)`.
+            "clickLoc" => Ok(self.alloc_datum(Datum::Point(
+                [self.movie.click_loc.0 as f64, self.movie.click_loc.1 as f64], 0,
+            ))),
+            "mouseH" => Ok(self.alloc_datum(Datum::Int(self.mouse_loc.0 as i32))),
+            "mouseV" => Ok(self.alloc_datum(Datum::Int(self.mouse_loc.1 as i32))),
+            "mouseChar" => {
+                let val = compute_mouse_char(self);
+                Ok(self.alloc_datum(Datum::Int(val)))
+            }
+            "mouseDown" => Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))),
+            "mouseUp" => Ok(self.alloc_datum(datum_bool(!self.movie.mouse_down))),
+            "stillDown" => Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))),
+            "rightMouseDown" => Ok(self.alloc_datum(datum_bool(self.movie.right_mouse_down))),
+            "rightMouseUp" => Ok(self.alloc_datum(datum_bool(!self.movie.right_mouse_down))),
             _ => Err(ScriptError::new(format!("Unknown _mouse prop {}", prop))),
         }
     }
@@ -3912,6 +3935,305 @@ pub async fn run_single_frame() -> (bool, bool) {
     });
 
     (is_playing, is_script_paused)
+}
+
+/// Compute Lingo's `the mouseChar` / `_mouse.mouseChar` — the 1-based
+/// character index in the field/text member currently under the mouse
+/// pointer. Returns -1 if the pointer is not over a field/text sprite
+/// or is in the "gutter" outside the text content. Matches Director
+/// 11.5 Scripting Dictionary entry for `mouseChar`.
+///
+/// Used by Fugue No.4's Narrative member script:
+///   if the textStyle of char the mouseChar of member nar = "underline"
+/// to detect clicks on inline underlined links.
+fn compute_mouse_char(player: &mut DirPlayer) -> i32 {
+    let (mx, my) = player.mouse_loc;
+    let sprite_num = match score::get_sprite_at(player, mx, my, false) {
+        Some(n) => n,
+        None => return -1,
+    };
+    let sprite = match player.movie.score.get_sprite(sprite_num as i16) {
+        Some(s) => s,
+        None => return -1,
+    };
+    let member_ref = match sprite.member.as_ref() {
+        Some(r) => r,
+        None => return -1,
+    };
+    let member = match player.movie.cast_manager.find_member_by_ref(member_ref) {
+        Some(m) => m,
+        None => return -1,
+    };
+    // Pull the wrap width + scroll_top so wrapped/paged fields (Fugue No.4
+    // Narrative scrolls in chunks via PageNext/PagePrior to a scroll_top
+    // pixel offset) map clicks back to the right character index.
+    // Also pull the font name + size so we hit-test using the SAME atlas
+    // the renderer drew with — using `get_system_font()` here used to
+    // mean clicks were resolved against system Arial widths while the
+    // renderer drew with the field's PFR Arial. The two layouts diverged
+    // by enough to land Fugue No.4 clicks on the wrong underlined run.
+    let (text, line_spacing, top_spacing, wrap_width, scroll_top, word_wrap, font_name, font_size, formatting_runs) =
+        match &member.member_type {
+            CastMemberType::Field(f) => (
+                f.text.clone(), f.fixed_line_space, f.top_spacing,
+                f.width as i32, f.scroll_top as i32, f.word_wrap,
+                f.font.clone(), f.font_size,
+                f.formatting_runs.clone(),
+            ),
+            CastMemberType::Text(t) => (
+                t.text.clone(), t.fixed_line_space, t.top_spacing,
+                t.width as i32,
+                t.info.as_ref().map(|i| i.scroll_top as i32).unwrap_or(0),
+                t.word_wrap,
+                t.font.clone(), t.font_size,
+                Vec::new(),
+            ),
+            _ => return -1,
+        };
+    // Pull the cast lib's font_table snapshot before dropping the member
+    // borrow — needed to resolve each formatting_run.font_id to a name
+    // (Arial / Arial Bold / Arial Italic) for per-run advance lookups.
+    let field_font_table: std::collections::HashMap<u16, String> = player
+        .movie
+        .cast_manager
+        .get_cast(member_ref.cast_lib as u32)
+        .map(|cl| cl.font_table.clone())
+        .unwrap_or_default();
+    // Explicitly release the immutable borrow on `player.movie` (held
+    // through `member`) before we touch `player.font_manager` /
+    // `player.bitmap_manager` mutably below.
+    drop(member);
+    let rect = score::get_sprite_rect_in_context(player, sprite_num as i16);
+    let local_x = mx - rect.0 as i32;
+    let local_y = my - rect.1 as i32;
+    if local_x < 0 || local_y < 0
+        || local_x >= (rect.2 - rect.0) as i32
+        || local_y >= (rect.3 - rect.1) as i32
+    {
+        return -1;
+    }
+    // Shift the y-coord into the FULL text coordinate space (member-local
+    // top of all text, not just the visible page). Without this, paged
+    // fields return char indices from the first page even when the user
+    // is looking at page 3+.
+    let text_y = local_y + scroll_top;
+    // Resolve the field's actual font via font_manager. The member borrow
+    // was dropped above (we cloned everything into owned locals), so the
+    // mutable borrow on font_manager + bitmap_manager is safe. Fall back
+    // to the system font only when the named font isn't available.
+    let font_arc = player.font_manager.get_font_with_cast_and_bitmap(
+        &font_name,
+        &player.movie.cast_manager,
+        &mut player.bitmap_manager,
+        if font_size > 0 { Some(font_size) } else { None },
+        None,
+    );
+    let font_rc = match font_arc.or_else(|| player.font_manager.get_system_font()) {
+        Some(f) => f,
+        None => return -1,
+    };
+    let font: crate::player::font::BitmapFont = (*font_rc).clone();
+    let min_space_adv = {
+        let sz = font.font_size.max(font.char_height) as i32;
+        let v = ((sz as f32) * 0.30).round() as i16;
+        if v > 0 { Some(v) } else { None }
+    };
+
+    // Build per-character advances using the same per-run atlas the
+    // renderer draws with. Without this, a field that mixes Arial body
+    // text and Arial Bold underlined chunks (Fugue No.4 Narrative) would
+    // have hit-test wrap with regular Arial widths everywhere while the
+    // renderer wraps with Bold widths for the underlined runs. The
+    // accumulated drift makes clicks on visual "Christ's passion" return
+    // a char position deep into "the sign of the cross" / "three motives".
+    let per_char_advances_vec: Option<Vec<i32>> = if !formatting_runs.is_empty() {
+        // Map each char index to which formatting_run covers it.
+        // Runs use BYTE positions; convert via char_indices.
+        let chars_total = text.chars().count();
+        let mut advances: Vec<i32> = Vec::with_capacity(chars_total);
+        // Cache loaded variant atlases by canonical name so we don't
+        // re-load Arial Bold once per run.
+        let mut variant_cache: std::collections::HashMap<String, std::rc::Rc<crate::player::font::BitmapFont>> =
+            std::collections::HashMap::new();
+        let min_sp = min_space_adv.unwrap_or(0) as i32;
+        // Resolve each run's font once (lazy via cache).
+        let resolve_font = |player: &mut DirPlayer,
+                            cache: &mut std::collections::HashMap<String, std::rc::Rc<crate::player::font::BitmapFont>>,
+                            run_font_id: u16|
+         -> Option<std::rc::Rc<crate::player::font::BitmapFont>> {
+            let resolved_name = field_font_table.get(&run_font_id).cloned()?;
+            if let Some(f) = cache.get(&resolved_name) {
+                return Some(f.clone());
+            }
+            let f = player.font_manager.get_font_with_cast_and_bitmap(
+                &resolved_name,
+                &player.movie.cast_manager,
+                &mut player.bitmap_manager,
+                if font_size > 0 { Some(font_size) } else { None },
+                None,
+            )?;
+            cache.insert(resolved_name, f.clone());
+            Some(f)
+        };
+        // Walk chars, looking up which run covers each (by BYTE position).
+        // Renderer-side scaling: each char's advance is multiplied by
+        // `run.font_size / field.font_size` because the renderer loads
+        // variant atlases at the FIELD's base size and scales when drawing
+        // chars at oversize (24pt "Fugue No. 4" header runs render at 2×
+        // the advance of the loaded-at-12 Arial Bold atlas). Without this
+        // scaling, hit-test underestimates the width consumed by the
+        // header runs, the header wraps differently than the renderer
+        // drew it, and every body line below the header is shifted in
+        // source-text content.
+        let field_base_size = if font_size > 0 { font_size as i32 } else { 12 };
+        let mut char_iter = text.char_indices().enumerate();
+        // Pre-resolve a "default base" advance per char for fallback.
+        while let Some((_ci, (byte_pos, c))) = char_iter.next() {
+            // Find the active run for this byte position.
+            let active_run = formatting_runs.iter().rev()
+                .find(|r| (r.start_position as usize) <= byte_pos);
+            let run_font_opt = active_run
+                .and_then(|r| resolve_font(player, &mut variant_cache, r.font_id));
+            let run_font_for_char = run_font_opt.as_deref().unwrap_or(&font);
+            let run_size = active_run
+                .map(|r| if r.font_size >= 6 { r.font_size as i32 } else { field_base_size })
+                .unwrap_or(field_base_size);
+            let raw_atlas = run_font_for_char.get_char_advance(c as u8) as i32;
+            // Mirror the renderer's `size_px / base_size` scale factor
+            // applied per-char in the PFR multi-span draw loop.
+            let raw = (raw_atlas * run_size / field_base_size.max(1)).max(if c == ' ' { 0 } else { 1 });
+            let clamped = if c == ' ' { raw.max(min_sp) } else { raw };
+            advances.push(clamped);
+        }
+        Some(advances)
+    } else {
+        None
+    };
+
+    // Per-char effective font_size (for variable-line-height hit-testing).
+    // Needed because the Narrative field has a 24pt "Fugue No. 4" header
+    // on a wrap-line that also carries 12pt content — the renderer makes
+    // that visual line as tall as its max font_size (24px), while a
+    // plain hit-test using a fixed line_h (12) drifts a full line below
+    // the renderer's actual layout for every click on the body.
+    let per_char_font_sizes_vec: Option<Vec<i16>> = if !formatting_runs.is_empty() {
+        let chars_total = text.chars().count();
+        let mut sizes: Vec<i16> = Vec::with_capacity(chars_total);
+        let base_size = if font_size > 0 { font_size as i16 } else { 12 };
+        for (byte_pos, _c) in text.char_indices() {
+            let active_run = formatting_runs.iter().rev()
+                .find(|r| (r.start_position as usize) <= byte_pos);
+            let s = active_run
+                .map(|r| if r.font_size >= 6 { r.font_size as i16 } else { base_size })
+                .unwrap_or(base_size);
+            sizes.push(s);
+        }
+        Some(sizes)
+    } else {
+        None
+    };
+
+    // Variable-line-height hit-test. Walks chars, wraps using per-char
+    // advances, finalizes each visual line's height as the max of the
+    // per-char font_sizes (matching the renderer's `line.max_size` rule),
+    // and finds the char at the target (local_x, text_y).
+    let idx = if let (Some(advs), Some(sizes)) = (per_char_advances_vec.as_ref(), per_char_font_sizes_vec.as_ref()) {
+        let wrap_max = if word_wrap && wrap_width > 0 { wrap_width as i32 } else { i32::MAX };
+        let base_size = if font_size > 0 { font_size as i32 } else { 12 };
+        let chars_vec: Vec<char> = text.chars().collect();
+        let mut line_start_idx: usize = 0;
+        let mut line_w: i32 = 0;
+        let mut last_space_idx_after: Option<usize> = None; // idx AFTER the space
+        let mut last_space_w_at: i32 = 0;
+        let mut line_y: i32 = top_spacing as i32;
+        // Visual lines as (start_idx_inclusive, end_idx_exclusive, line_h)
+        let mut visual_lines: Vec<(usize, usize, i32)> = Vec::new();
+        let mut line_max_size: i32 = base_size;
+        let finalize_line = |start: usize, end: usize, max_size: i32, lines: &mut Vec<(usize, usize, i32)>, line_y: &mut i32| {
+            let line_h = max_size.max(base_size).max(1);
+            lines.push((start, end, line_h));
+            *line_y += line_h;
+        };
+        let mut ci: usize = 0;
+        while ci < chars_vec.len() {
+            let c = chars_vec[ci];
+            let cs = sizes.get(ci).copied().unwrap_or(base_size as i16) as i32;
+            line_max_size = line_max_size.max(cs);
+            if c == '\r' || c == '\n' {
+                finalize_line(line_start_idx, ci, line_max_size, &mut visual_lines, &mut line_y);
+                ci += 1;
+                line_start_idx = ci;
+                line_w = 0;
+                line_max_size = base_size;
+                last_space_idx_after = None;
+                last_space_w_at = 0;
+                continue;
+            }
+            let cw = advs.get(ci).copied().unwrap_or(0);
+            if line_w + cw > wrap_max && ci > line_start_idx {
+                if let Some(sp) = last_space_idx_after.filter(|&sp| sp > line_start_idx) {
+                    finalize_line(line_start_idx, sp, line_max_size, &mut visual_lines, &mut line_y);
+                    line_start_idx = sp;
+                    line_w -= last_space_w_at;
+                    last_space_idx_after = None;
+                    last_space_w_at = 0;
+                    line_max_size = base_size;
+                    // Re-evaluate max for the wrapped tail (chars sp..ci).
+                    for k in sp..=ci {
+                        let ks = sizes.get(k).copied().unwrap_or(base_size as i16) as i32;
+                        line_max_size = line_max_size.max(ks);
+                    }
+                }
+            }
+            line_w += cw;
+            if c == ' ' {
+                last_space_idx_after = Some(ci + 1);
+                last_space_w_at = line_w;
+            }
+            ci += 1;
+        }
+        if line_start_idx < chars_vec.len() {
+            finalize_line(line_start_idx, chars_vec.len(), line_max_size, &mut visual_lines, &mut line_y);
+        }
+        // Find the visual line containing text_y, then the char in it.
+        let mut chosen_idx = chars_vec.len().saturating_sub(1);
+        let mut accum_y: i32 = top_spacing as i32;
+        for &(start, end, line_h) in &visual_lines {
+            if text_y >= accum_y && text_y < accum_y + line_h {
+                // Walk x within this line.
+                let mut x_accum: i32 = 0;
+                let mut found = end.saturating_sub(1);
+                for k in start..end {
+                    let cw = advs.get(k).copied().unwrap_or(0);
+                    if local_x < x_accum + cw {
+                        found = k;
+                        break;
+                    }
+                    x_accum += cw;
+                    found = k;
+                }
+                chosen_idx = found;
+                break;
+            }
+            accum_y += line_h;
+        }
+        chosen_idx
+    } else {
+        let params = crate::player::font::DrawTextParams {
+            font: &font,
+            line_height: None,
+            line_spacing,
+            top_spacing,
+            char_spacing: 0,
+            member_width: if word_wrap && wrap_width > 0 { Some(wrap_width as i16) } else { None },
+            min_space_advance: min_space_adv,
+            per_char_advances: per_char_advances_vec.as_deref(),
+        };
+        crate::player::font::get_text_index_at_pos(&text, &params, local_x, text_y)
+    };
+    let total = text.chars().count();
+
+    if idx >= total { -1 } else { (idx + 1) as i32 }
 }
 
 /// Tick the global SoundManager by `delta` seconds — advances fades

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -255,6 +255,23 @@ pub struct DirPlayer {
     pub drag_offset: (i32, i32),
     pub trails_bitmap: Option<bitmap::bitmap::Bitmap>,
     pub click_on_sprite: i16,
+    /// Queue of pending `on cuePassed` events that `SoundChannel::update`
+    /// has detected but not yet dispatched. The frame loop drains this
+    /// after `tick_sound_manager` (`SoundChannel::update` runs synchronously
+    /// from inside that tick, so the actual `player_invoke_frame_and_movie_scripts`
+    /// call — which is `async` — has to happen outside the tick).
+    /// Tuple: (channel_num_1_based, cue_number_1_based, cue_name).
+    pub pending_cue_events: Vec<(i32, i32, String)>,
+    /// Anchor for syncing score-frame advance to audio-context time while
+    /// sound channel 1 is playing. Set the moment audio actually starts
+    /// (`source.start()`), cleared when audio stops. The frame loop uses
+    /// this to compute the target frame from `audio_currentTime` and skip
+    /// the per-frame `target_delay_ms` wait when the score is behind —
+    /// without it, the wall-clock'd frame loop drifts behind audio over
+    /// time and visuals (Fugue No.4's Cross sprites tweened by the score)
+    /// fall behind the audio-clocked `on cuePassed` driven cursor.
+    /// Tuple: (score_frame_at_audio_start, audio_context_time_at_audio_start).
+    pub audio_sync_anchor: Option<(u32, f64)>,
     pub subscribed_member_refs: Vec<CastMemberRef>, // TODO move to debug module
     pub is_subscribed_to_channel_names: bool,       // TODO move to debug module
     pub font_manager: FontManager,
@@ -483,6 +500,8 @@ impl DirPlayer {
             date_objects: HashMap::new(),
             math_objects: HashMap::new(),
             click_on_sprite: 0,
+            pending_cue_events: Vec::new(),
+            audio_sync_anchor: None,
             enable_stream_status_handler: false,
             stream_status_reported: HashMap::new(),
             is_in_frame_update: false,
@@ -3996,6 +4015,32 @@ pub async fn run_frame_loop() {
             let tempo = reserve_player_ref(|player| player.current_frame_tempo);
             let delta = if tempo == 0 { 1.0 / 30.0 } else { 1.0 / tempo as f64 };
             tick_sound_manager(delta);
+        }
+
+        // Drain cue-point events SoundChannel::update detected. The handler
+        // dispatch is async — has to happen out here in the frame loop, not
+        // inside the synchronous sound tick. Pass each as
+        // `on cuePassed channelSymbol, number, name` per Director 11.5 spec
+        // (channel arg is a symbol like `#sound1`). Dispatched to frame +
+        // movie scripts in order.
+        loop {
+            let events = reserve_player_mut(|player| std::mem::take(&mut player.pending_cue_events));
+            if events.is_empty() {
+                break;
+            }
+            for (channel_num, cue_number, cue_name) in events {
+                let args = reserve_player_mut(|player| {
+                    let chan_sym = player.alloc_datum(crate::director::lingo::datum::Datum::Symbol(
+                        format!("sound{}", channel_num),
+                    ));
+                    let number_ref = player.alloc_datum(crate::director::lingo::datum::Datum::Int(cue_number));
+                    let name_ref = player.alloc_datum(crate::director::lingo::datum::Datum::String(cue_name));
+                    vec![chan_sym, number_ref, name_ref]
+                });
+                if let Err(err) = player_invoke_frame_and_movie_scripts("cuePassed", &args).await {
+                    warn!("cuePassed dispatch failed: {}", err.message);
+                }
+            }
         }
 
         // Also check after frame execution: if scripts tried to access a Flash

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -114,6 +114,14 @@ pub struct Score {
     pub sprite_spans: Vec<ScoreSpriteSpan>,
     pub channel_initialization_data: Vec<(u32, u16, ScoreFrameChannelData)>,
     pub sound_channel_data: Vec<(u32, u16, SoundChannelData)>,
+    /// Sound channel sprite spans extracted from `frame_intervals`. Keyed by
+    /// channel_index (4 = Sound1, 3 = Sound2 on D6+). Used by the audio-time
+    /// score-sync logic in `run_frame_loop` so it only catches up to audio
+    /// time while the playhead is inside the authored sound 1 span — outside
+    /// that range, the score is meant to advance at its own tempo. The
+    /// regular `sprite_spans` Vec excludes effects channels (1-5) so we
+    /// stash these separately.
+    pub sound_channel_spans: HashMap<u32, (u32, u32)>,
     pub tempo_channel_data: Vec<(u32, TempoChannelData)>,
     pub palette_channel_data: Vec<(u32, i16, i16)>,
     pub frame_labels: Vec<FrameLabel>,
@@ -238,6 +246,7 @@ impl Score {
             frame_labels: vec![],
             channel_initialization_data: vec![],
             sound_channel_data: vec![],
+            sound_channel_spans: HashMap::new(),
             tempo_channel_data: vec![],
             palette_channel_data: vec![],
             sprite_spans: vec![],
@@ -2545,6 +2554,21 @@ impl Score {
             &score_chunk.frame_data.frame_channel_data,
             &score_chunk.frame_intervals
         ));
+
+        // Capture sound-channel sprite spans (channel_index 3 = Sound2,
+        // 4 = Sound1 on D6+). These are excluded from the regular
+        // sprite_spans Vec below, but the audio-time score-sync code
+        // needs Sound1's span range so it only catches up while the
+        // playhead is inside the authored span.
+        for (primary, _) in &score_chunk.frame_intervals {
+            if primary.channel_index == 3 || primary.channel_index == 4 {
+                let entry = self.sound_channel_spans
+                    .entry(primary.channel_index)
+                    .or_insert((primary.start_frame, primary.end_frame));
+                entry.0 = entry.0.min(primary.start_frame);
+                entry.1 = entry.1.max(primary.end_frame);
+            }
+        }
 
         for (primary, secondary) in &score_chunk.frame_intervals {
             let is_frame_script_or_sprite_script =

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -194,7 +194,7 @@ pub fn get_sprite_in_context_mut<'a>(player: &'a mut DirPlayer, sprite_id: i16) 
 }
 
 /// Get sprite rect using current score context
-fn get_sprite_rect_in_context(player: &DirPlayer, sprite_id: i16) -> IntRectTuple {
+pub fn get_sprite_rect_in_context(player: &DirPlayer, sprite_id: i16) -> IntRectTuple {
     let sprite = get_sprite_in_context(player, sprite_id);
     let sprite = match sprite {
         Some(sprite) => sprite,
@@ -4160,8 +4160,10 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         ),
         "loc" => borrow_sprite_mut(
             sprite_id,
-            |_| value.clone(),  // Pass the value through so we can use it in the sprite closure
-            |sprite, value| -> Result<(), ScriptError> {
+            // flag (D6+) so the sprite-mut closure doesn't need to re-borrow.
+            |player| Ok::<_, ScriptError>(value.clone()),
+            |sprite, prep| -> Result<(), ScriptError> {
+                let value = prep?;
                 match value {
                     Datum::Point(vals, _) => {
                         sprite.loc_h = vals[0] as i32;
@@ -4193,67 +4195,68 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             },
         ),
         "rect" => reserve_player_mut(|player| {
-            borrow_sprite_mut(
-                sprite_id,
-                |player| {
-                    let sprite = player.movie.score.get_sprite(sprite_id).unwrap();
-                    let member_ref = sprite.member.as_ref();
-                    let cast_member =
-                        member_ref.and_then(|x| player.movie.cast_manager.find_member_by_ref(&x));
-                    let reg_point = cast_member
-                        .map(|x| match &x.member_type {
-                            CastMemberType::Bitmap(bitmap) => bitmap.reg_point,
-                            CastMemberType::FilmLoop(film_loop) => {
-                                // For filmloops, registration point is the center of the content bounds
-                                let w = film_loop.initial_rect.width();
-                                let h = film_loop.initial_rect.height();
-                                ((w / 2) as i16, (h / 2) as i16)
-                            }
-                            CastMemberType::Flash(flash) => flash.reg_point,
-                            _ => (0, 0),
-                        })
-                        .unwrap_or((0, 0));
+            // Extract the target rect from `value`.
+            let rect_values = match value {
+                Datum::Rect(ref vals, _) => {
+                    Some([vals[0] as i32, vals[1] as i32, vals[2] as i32, vals[3] as i32])
+                }
+                Datum::List(_, ref items, _) if items.len() == 4 => {
+                    Some([
+                        player.get_datum(&items[0]).int_value()?,
+                        player.get_datum(&items[1]).int_value()?,
+                        player.get_datum(&items[2]).int_value()?,
+                        player.get_datum(&items[3]).int_value()?,
+                    ])
+                }
+                Datum::Point(ref vals, _) => {
+                    let s = player.movie.score.get_sprite(sprite_id);
+                    let (sw, sh) = s.map(|s| (s.width, s.height)).unwrap_or((0, 0));
+                    let x = vals[0] as i32;
+                    let y = vals[1] as i32;
+                    Some([x, y, x + sw, y + sh])
+                }
+                _ => return Err(ScriptError::new(format!(
+                    "rect must be a rect (got {})", value.type_str()
+                ))),
+            };
+            let [left, top, right, bottom] = rect_values
+                .ok_or_else(|| ScriptError::new("rect parse failed".to_string()))?;
+            let new_width = right - left;
+            let new_height = bottom - top;
 
-                    reg_point
-                },
-                |sprite, reg_point| {
-                    let rect_values = match value {
-                        Datum::Rect(ref vals, _) => {
-                            Some([
-                                vals[0] as i32,
-                                vals[1] as i32,
-                                vals[2] as i32,
-                                vals[3] as i32,
-                            ])
-                        }
-                        Datum::List(_, ref items, _) if items.len() == 4 => {
-                            Some([
-                                player.get_datum(&items[0]).int_value()?,
-                                player.get_datum(&items[1]).int_value()?,
-                                player.get_datum(&items[2]).int_value()?,
-                                player.get_datum(&items[3]).int_value()?,
-                            ])
-                        }
-                        Datum::Point(ref vals, _) => {
-                            let x = vals[0] as i32;
-                            let y = vals[1] as i32;
-                            Some([x, y, x + sprite.width, y + sprite.height])
-                        }
-                        _ => None,
-                    };
-                    match rect_values {
-                        Some([left, top, right, bottom]) => {
-                            sprite.loc_h = left + reg_point.0 as i32;
-                            sprite.loc_v = top + reg_point.1 as i32;
-                            sprite.width = right - left;
-                            sprite.height = bottom - top;
-                            sprite.has_size_changed = true;
-                            Ok(())
-                        }
-                        None => Err(ScriptError::new(format!("rect must be a rect (got {})", value.type_str()))),
-                    }
-                },
-            )
+            // Probe approach: clone the sprite, apply the new dimensions with
+            // loc=0,0, then ask the *real* renderer logic what rect it would
+            // produce. Whatever offset it picks (scaled reg point, bbox-driven
+            // reg, centerRegPoint, vector-shape natural-rect scaling, …)
+            // becomes the offset we need to invert. This guarantees the
+            // round-trip property `sprite.rect = R → sprite.left == R.left`
+            // that Director provides, regardless of which member type or
+            // heuristic path the renderer takes. Fugue No.4's `cueCursor`
+            // relies on this for `if sprite(6).left < 20`.
+            let mut probe: Sprite = match player.movie.score.get_sprite(sprite_id) {
+                Some(s) => s.clone(),
+                None => return Err(ScriptError::new(format!(
+                    "rect: sprite {} not found", sprite_id
+                ))),
+            };
+            probe.loc_h = 0;
+            probe.loc_v = 0;
+            probe.width = new_width;
+            probe.height = new_height;
+            probe.has_size_changed = true;
+            let probe_rect = get_concrete_sprite_rect(player, &probe);
+            // probe_rect.left = -effective_reg_x with loc=0, so to make the
+            // real getter return `left`, write loc_h = left - probe_rect.left.
+            let new_loc_h = left - probe_rect.left;
+            let new_loc_v = top - probe_rect.top;
+
+            let s = player.movie.score.get_sprite_mut(sprite_id);
+            s.loc_h = new_loc_h;
+            s.loc_v = new_loc_v;
+            s.width = new_width;
+            s.height = new_height;
+            s.has_size_changed = true;
+            Ok(())
         }),
         "scriptInstanceList" => {
             let ref_list = value.to_list()?;
@@ -4638,6 +4641,30 @@ fn is_click_transparent_sprite(player: &DirPlayer, sprite: &Sprite) -> bool {
                         || script.get_own_handler("mouseUpOutSide").is_some()
                     {
                         return false;
+                    }
+                }
+            }
+            // Fallback: behavior scripts attached to Field/Text members live
+            // in the cast's lctx, not as Script-type cast members, so
+            // get_script_by_ref above can return None for them. Consult
+            // get_script_id() → lctx.scripts directly. This is the path
+            // used by member-attached BehaviorScripts in Director 11.5
+            // (e.g. Fugue No.4's Narrative / Portuguese / Spanish fields).
+            if let Some(script_id) = member.get_script_id() {
+                if let Ok(cast) = player.movie.cast_manager.get_cast(member_ref.cast_lib as u32) {
+                    if let Some(lctx) = cast.lctx.as_ref() {
+                        if let Some(script_chunk) = lctx.scripts.get(&script_id) {
+                            let has_mouse_handler = script_chunk.handlers.iter().any(|h| {
+                                lctx.names.get(h.name_id as usize)
+                                    .map(|n| n.eq_ignore_ascii_case("mouseDown")
+                                        || n.eq_ignore_ascii_case("mouseUp")
+                                        || n.eq_ignore_ascii_case("mouseUpOutSide"))
+                                    .unwrap_or(false)
+                            });
+                            if has_mouse_handler {
+                                return false;
+                            }
+                        }
                     }
                 }
             }

--- a/vm-rust/src/player/script.rs
+++ b/vm-rust/src/player/script.rs
@@ -763,7 +763,7 @@ pub fn get_obj_prop(
                 }
                 _ if matches!(prop_name.to_ascii_lowercase().as_str(),
                     "fixedlinespace" | "topspacing" | "bottomspacing"
-                    | "font" | "fontsize" | "fontstyle"
+                    | "font" | "fontsize" | "fontstyle" | "textstyle"
                     | "color" | "bgcolor" | "alignment") => {
                     // Per-chunk properties — walk to the source member and
                     // resolve the chunk's char range, then look up the
@@ -782,9 +782,156 @@ pub fn get_obj_prop(
                     let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) else {
                         return Ok(player.alloc_datum(Datum::Void));
                     };
-                    // Field path: lacks per-paragraph data; fall back to
-                    // member-level values for the chunk too.
-                    if let Some(_field) = member.member_type.as_field() {
+                    // Field path: per-character styles live in the STXT
+                    // formatting_runs (start_position + style byte).
+                    // Director's `the textStyle of char N of member`
+                    // returns a comma-separated string like "underline"
+                    // or "bold,italic"; `fontStyle` returns a list of
+                    // symbols. The Fugue No.4 Narrative script branches
+                    // on `the textStyle of char ... = "underline"` so
+                    // the string form has to work for fields. Other
+                    // chunk-level field props still fall back to the
+                    // member-wide values (fields don't have per-line
+                    // par_infos like text members do).
+                    // Snapshot the cast lib's font_table so font_id → name
+                    // lookups inside the field branch don't need to re-borrow
+                    // cast_manager (which is already lent immutably via the
+                    // `member` borrow above). The font_table is the only
+                    // authoritative mapping from STXT formatting_run.font_id
+                    // to a resolved font name like "Arial Italic" — bit
+                    // heuristics on font_id mis-tag bold vs italic depending
+                    // on how the file packed its table.
+                    let font_table_snapshot: std::collections::HashMap<u16, String> = player
+                        .movie
+                        .cast_manager
+                        .get_cast(member_ref.cast_lib as u32)
+                        .map(|cl| cl.font_table.clone())
+                        .unwrap_or_default();
+                    let resolve_run_style = |font_id: u16, style_byte: u8| -> (bool, bool, Option<String>) {
+                        let resolved = font_table_snapshot.get(&font_id).cloned();
+                        let name_bold = resolved.as_ref()
+                            .map(|n| n.to_ascii_lowercase().contains("bold"))
+                            .unwrap_or(false);
+                        let name_italic = resolved.as_ref()
+                            .map(|n| n.to_ascii_lowercase().contains("italic"))
+                            .unwrap_or(false);
+                        let bold = (style_byte & 0x01) != 0 || name_bold;
+                        let italic = (style_byte & 0x02) != 0 || name_italic;
+                        (bold, italic, resolved)
+                    };
+                    if let Some(field) = member.member_type.as_field() {
+                        let lc = prop_name.to_ascii_lowercase();
+                        if lc == "textstyle" || lc == "fontstyle" {
+                            // STXT formatting_runs use BYTE positions, not
+                            // char positions. Convert char_start -> byte
+                            // offset so multi-byte chars (ñ/ç/é in
+                            // Narrative's Spanish/Portuguese text) don't
+                            // shift the run-boundary lookup by 1 char per
+                            // multi-byte char before the queried char.
+                            let byte_start: usize = field.text
+                                .char_indices()
+                                .nth(char_start)
+                                .map(|(b, _)| b)
+                                .unwrap_or_else(|| field.text.len());
+                            let active_run = field.formatting_runs.iter()
+                                .rev()
+                                .find(|r| (r.start_position as usize) <= byte_start);
+                            let (active_style, active_font_id) = active_run
+                                .map(|r| (r.style, r.font_id))
+                                .unwrap_or((0, 0));
+                            // Resolve via the file's font_table (the only
+                            // authoritative source). The STXT `style` byte
+                            // can also independently signal bold/italic on
+                            // movies that ship just one Arial cast member
+                            // and rely on style bits — OR with name match.
+                            let (bold, italic, _resolved) =
+                                resolve_run_style(active_font_id, active_style);
+                            let underline = (active_style & 0x04) != 0;
+                            if lc == "textstyle" {
+                                // Director string form (legacy `the textStyle`).
+                                let mut parts: Vec<&str> = Vec::new();
+                                if bold { parts.push("bold"); }
+                                if italic { parts.push("italic"); }
+                                if underline { parts.push("underline"); }
+                                let s = if parts.is_empty() {
+                                    "plain".to_string()
+                                } else {
+                                    parts.join(",")
+                                };
+                                return Ok(player.alloc_datum(Datum::String(s)));
+                            } else {
+                                // fontStyle list form.
+                                let mut items = std::collections::VecDeque::new();
+                                if bold {
+                                    items.push_back(player.alloc_datum(Datum::Symbol("bold".to_string())));
+                                }
+                                if italic {
+                                    items.push_back(player.alloc_datum(Datum::Symbol("italic".to_string())));
+                                }
+                                if underline {
+                                    items.push_back(player.alloc_datum(Datum::Symbol("underline".to_string())));
+                                }
+                                if items.is_empty() {
+                                    items.push_back(player.alloc_datum(Datum::Symbol("plain".to_string())));
+                                }
+                                return Ok(player.alloc_datum(Datum::List(
+                                    crate::director::lingo::datum::DatumType::List,
+                                    items,
+                                    false,
+                                )));
+                            }
+                        }
+                        // `the font of char N..M of member` returns the
+                        // font name of those chars. Director synthesizes
+                        // a "FontName Bold *" / "FontName Italic *" name
+                        // when the run has bold/italic style bits set —
+                        // Fugue No.4 Cues#AdvanceScroll relies on this:
+                        // `if member(nar).line[o].char[1..x].font =
+                        //   "Arial Bold *"` to detect bold-styled
+                        // hyperlink anchors. Look up the active run at
+                        // char_start in field.formatting_runs and emit
+                        // the synthesized name with the field's base
+                        // font as prefix.
+                        if lc == "font" {
+                            let byte_start: usize = field.text
+                                .char_indices()
+                                .nth(char_start)
+                                .map(|(b, _)| b)
+                                .unwrap_or_else(|| field.text.len());
+                            let active_run = field.formatting_runs.iter().rev()
+                                .find(|r| (r.start_position as usize) <= byte_start);
+                            let (active_style, active_font_id) = active_run
+                                .map(|r| (r.style, r.font_id))
+                                .unwrap_or((0, 0));
+                            let (bold, italic, resolved_name) =
+                                resolve_run_style(active_font_id, active_style);
+                            // Prefer the font_table's resolved name (e.g.
+                            // "Arial Italic") so the AdvanceScroll-style
+                            // `if .font = "Arial Bold *"` comparisons see
+                            // the exact variant the file authored. If the
+                            // table doesn't list this id (fallback path),
+                            // synthesise from the field's base font + the
+                            // bold/italic flags we just derived.
+                            let base_for_synth = field.font.trim_end_matches(" *")
+                                .trim_end_matches('*')
+                                .trim()
+                                .to_string();
+                            let s = if let Some(name) = resolved_name {
+                                let trimmed = name.trim_end_matches(" *")
+                                    .trim_end_matches('*')
+                                    .trim()
+                                    .to_string();
+                                format!("{} *", trimmed)
+                            } else {
+                                let mut parts: Vec<&str> = Vec::new();
+                                let base_owned = if base_for_synth.is_empty() { "Arial".to_string() } else { base_for_synth };
+                                parts.push(base_owned.as_str());
+                                if bold { parts.push("Bold"); }
+                                if italic { parts.push("Italic"); }
+                                format!("{} *", parts.join(" "))
+                            };
+                            return Ok(player.alloc_datum(Datum::String(s)));
+                        }
                         return Ok(player.alloc_datum(StringDatumUtils::get_built_in_prop(
                             &obj_clone.string_value()?,
                             &prop_name,

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -2052,6 +2052,169 @@ impl WebGL2Renderer {
                         style |= 4;
                     }
 
+                    // Build StyledSpans from STXT formatting_runs so the
+                    // renderer can apply per-character underline visually.
+                    // Use the field-level font/size/color as the DEFAULT
+                    // for each span — don't override font_size from each
+                    // run because Director field styling per-run is
+                    // style-only (bold/italic/underline), not size; a
+                    // per-run size from STXT can be a stale member-level
+                    // snapshot and would split words onto wrong-sized lines.
+                    // Snapshot the cast lib's font_table once so the per-run
+                    // bold/italic detection below can resolve `run.font_id`
+                    // to an actual font name (e.g. "Arial Italic") rather
+                    // than guessing via bit heuristics. Same lookup the
+                    // Lingo `.font` / `.fontStyle` chunk getters use — keeps
+                    // the renderer and the script-visible style in sync so
+                    // a run that reports `[#italic]` to Lingo also draws
+                    // italic on stage.
+                    let field_font_table: std::collections::HashMap<u16, String> = player
+                        .movie
+                        .cast_manager
+                        .get_cast(member_ref.cast_lib as u32)
+                        .map(|cl| cl.font_table.clone())
+                        .unwrap_or_default();
+                    let field_styled_spans: Option<Vec<crate::player::handlers::datum_handlers::cast_member::font::StyledSpan>>
+                        = if field_member.formatting_runs.len() >= 2 {
+                        use crate::player::handlers::datum_handlers::cast_member::font::{StyledSpan, HtmlStyle};
+                        let text_str = &field_member.text;
+                        // STXT formatting_runs use BYTE positions in
+                        // Director's text data. Build a byte→char index map
+                        // so multi-byte chars (ñ/ç/é in Narrative's
+                        // Spanish/Portuguese text) don't shift visual spans
+                        // by 1 char per multi-byte char before them.
+                        let mut byte_to_char: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+                        let mut total_chars: Vec<char> = Vec::new();
+                        for (ci, (bi, c)) in text_str.char_indices().enumerate() {
+                            byte_to_char.insert(bi, ci);
+                            total_chars.push(c);
+                        }
+                        byte_to_char.insert(text_str.len(), total_chars.len());
+                        let resolve_char = |byte_pos: usize| -> usize {
+                            // Snap to nearest known boundary <= byte_pos.
+                            // STXT positions should sit on char boundaries
+                            // but guard against malformed offsets.
+                            for b in (0..=byte_pos.min(text_str.len())).rev() {
+                                if let Some(&c) = byte_to_char.get(&b) { return c; }
+                            }
+                            0
+                        };
+                        let mut spans: Vec<StyledSpan> = Vec::new();
+                        let runs = &field_member.formatting_runs;
+                        // Detect whether the runs actually carry non-trivial
+                        // per-run sizes (≥6pt and at least one differing from
+                        // the member default). Director STXT runs that just
+                        // tag style changes typically share `font_size == 0`
+                        // or share the member's default; in that case keep
+                        // uniform sizing so Canvas2D anti-aliasing lands on
+                        // integer pixels (per-run sizes blur it). When the
+                        // movie actually authored per-section sizes (Fugue
+                        // No. 4 Narrative: 18pt section headers + 12pt body,
+                        // David's Notes 18pt title + 12pt body), feed the
+                        // real per-run sizes through — the PFR multi-span
+                        // path scales each run individually and wrap
+                        // positions then match Shockwave's layout.
+                        let member_size = field_member.font_size as i32;
+                        let per_run_sizing = {
+                            let mut seen_size: Option<i32> = None;
+                            let mut differs = false;
+                            for run in runs.iter() {
+                                let s = run.font_size as i32;
+                                if s < 6 { continue; }
+                                match seen_size {
+                                    None => seen_size = Some(s),
+                                    Some(prev) if prev != s => { differs = true; break; }
+                                    _ => {}
+                                }
+                            }
+                            if differs {
+                                true
+                            } else if let Some(s) = seen_size {
+                                member_size > 0 && s != member_size
+                            } else {
+                                false
+                            }
+                        };
+                        for (i, run) in runs.iter().enumerate() {
+                            let start = resolve_char(run.start_position as usize);
+                            let end = if i + 1 < runs.len() {
+                                resolve_char(runs[i + 1].start_position as usize)
+                            } else {
+                                total_chars.len()
+                            };
+                            if start >= total_chars.len() || end <= start {
+                                continue;
+                            }
+                            let end = end.min(total_chars.len());
+                            let span_text: String = total_chars[start..end].iter().collect();
+                            // Resolve the run's font name via the file's
+                            // Fmap/VWFM table. Movies that ship separate
+                            // "Arial", "Arial Bold", "Arial Italic" cast
+                            // members signal the variant by mapping the
+                            // run's `font_id` to one of those names — the
+                            // style byte often stays at 0x00. OR with the
+                            // style-byte bits so movies that author bold/
+                            // italic via the style byte (single Arial cast
+                            // member) still work.
+                            let resolved_font = field_font_table.get(&run.font_id);
+                            let name_bold = resolved_font
+                                .map(|n| n.to_ascii_lowercase().contains("bold"))
+                                .unwrap_or(false);
+                            let name_italic = resolved_font
+                                .map(|n| n.to_ascii_lowercase().contains("italic"))
+                                .unwrap_or(false);
+                            let bold = (run.style & 0x01) != 0 || name_bold;
+                            let italic = (run.style & 0x02) != 0 || name_italic;
+                            let underline = (run.style & 0x04) != 0;
+                            let span_font_size = if per_run_sizing && (run.font_size as i32) >= 6 {
+                                Some(run.font_size as i32)
+                            } else if field_member.font_size > 0 {
+                                Some(field_member.font_size as i32)
+                            } else {
+                                None
+                            };
+                            // Use the run's resolved font name (e.g.
+                            // "Arial Bold" / "Arial Italic") as the span's
+                            // font_face so the per-span atlas-loader in
+                            // render_text_to_texture can pick the correct
+                            // variant PFR atlas for that run. Without this
+                            // every span carries field_member.font ("Arial")
+                            // and the loader sees no variants to load.
+                            let span_font_face = resolved_font
+                                .cloned()
+                                .filter(|s| !s.is_empty())
+                                .or_else(|| {
+                                    if field_member.font.is_empty() {
+                                        None
+                                    } else {
+                                        Some(field_member.font.clone())
+                                    }
+                                });
+                            spans.push(StyledSpan {
+                                text: span_text,
+                                style: HtmlStyle {
+                                    font_face: span_font_face,
+                                    font_size: span_font_size,
+                                    color: None,
+                                    bg_color: None,
+                                    bold,
+                                    italic,
+                                    underline,
+                                    kerning: 0,
+                                    char_spacing: 0,
+                                    hyperlink: None,
+                                },
+                            });
+                        }
+                        if spans.is_empty() {
+                            None
+                        } else {
+                            Some(spans)
+                        }
+                    } else {
+                        None
+                    };
+
                     // Color priority for fields:
                     // 1. Non-default RGB sprite color wins outright. Covers both
                     //    score-frame-data tweens (FurniFactory; sprite.color = RGB but
@@ -2100,6 +2263,24 @@ impl WebGL2Renderer {
                         field_member.box_type, field_member.editable, field_member.border, width, height,
                     );
 
+                    // `scrollTop` (Director 11.5 Scripting Dictionary p.1158)
+                    // is "the distance, in pixels, from the top of the field
+                    // cast member to the top of the field that is currently
+                    // visible". We implement it by shifting the text-draw
+                    // origin upward via top_spacing: a positive scroll_top
+                    // produces a negative effective top_spacing, so the
+                    // first lines render above the bitmap top (clipped) and
+                    // the visible content appears scrolled up. Hashing the
+                    // adjusted top_spacing into the cache key (which already
+                    // hashes top_spacing) makes the texture re-rasterize each
+                    // time scrollTop changes. Force keep_authored_height so
+                    // the bitmap stays at sprite height instead of shrinking
+                    // to fit the scrolled-up content.
+                    let scroll_top_i = field_member.scroll_top as i32;
+                    let effective_top_spacing = (field_member.top_spacing as i32 - scroll_top_i)
+                        .clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+                    let scroll_active = scroll_top_i != 0;
+
                     // Include focus state in cache key so cursor state changes invalidate cache
                     let field_caret_blink = caret_blink_visible_now();
                     let mut cache_key = RenderedTextCacheKey::new_with_focus(
@@ -2121,11 +2302,26 @@ impl WebGL2Renderer {
                         field_member.font_size,
                         if style == 0 { None } else { Some(style) },
                         field_member.fixed_line_space,
-                        field_member.top_spacing,
+                        effective_top_spacing,
                     );
                     let transform_active =
                         skew.abs() > 0.001 || rotation.abs() > 0.1;
-                    cache_key.keep_authored_height = transform_active;
+                    // Paged/scrollable fields (box_type #scroll, #fixed,
+                    // #limit) must keep the bitmap at the sprite's
+                    // authored height regardless of how tall the
+                    // wrapped content is — otherwise switching from a
+                    // short to a long member (Narrative -> Spanish,
+                    // which has 28k chars wrapping to thousands of
+                    // pixels) blows the bitmap up to the full text
+                    // height and the overflow renders all over the
+                    // stage instead of clipping to the visible field.
+                    // #adjust is the only box_type where the field is
+                    // expected to grow to fit content.
+                    let box_clipped = matches!(
+                        field_member.box_type.as_str(),
+                        "scroll" | "fixed" | "limit"
+                    );
+                    cache_key.keep_authored_height = transform_active || scroll_active || box_clipped;
                     cache_key.transform_active = transform_active;
 
                     TextureSource::RenderedText {
@@ -2136,14 +2332,14 @@ impl WebGL2Renderer {
                         font_style: if style == 0 { None } else { Some(style) },
                         font_id: field_member.font_id,
                         line_spacing: field_member.fixed_line_space,
-                        top_spacing: field_member.top_spacing,
+                        top_spacing: effective_top_spacing,
                         bottom_spacing: 0,
                         width,
                         height,
                         wrap_width,
                         text_fg_color: effective_fg,
                         text_bg_color: effective_bg,
-                        styled_spans: None,
+                        styled_spans: field_styled_spans,
                         alignment: field_member.alignment.clone(),
                         word_wrap: field_member.word_wrap,
                         border: field_member.border,
@@ -4539,9 +4735,15 @@ impl WebGL2Renderer {
         let underline = (style_bits & 4) != 0;
         let alignment_key = alignment.trim().trim_start_matches('#').to_ascii_lowercase();
 
-        // Get the font bitmap
-        let font_bitmap = match player.bitmap_manager.get_bitmap(font.bitmap_ref) {
-            Some(b) => b,
+        // Get the font bitmap. We clone it locally so the immutable
+        // borrow on `player.bitmap_manager` is released — the PFR
+        // multi-span path below needs to call back into
+        // `player.font_manager.get_font_with_cast_and_bitmap` (which
+        // mutably borrows `bitmap_manager`) to load per-span variant
+        // atlases. Cloning ~88KB once per render is cheap vs. the
+        // borrow-checker dance of holding the original `&Bitmap`.
+        let font_bitmap_owned = match player.bitmap_manager.get_bitmap(font.bitmap_ref) {
+            Some(b) => b.clone(),
             None => {
                 // Font bitmap not found - log warning and return None
                 web_sys::console::warn_1(
@@ -4550,6 +4752,7 @@ impl WebGL2Renderer {
                 return None;
             }
         };
+        let font_bitmap = &font_bitmap_owned;
 
         let mut render_width = width as u16;
         let mut render_height = height as u16;
@@ -5141,6 +5344,13 @@ impl WebGL2Renderer {
                     bold: bool,
                     italic: bool,
                     underline: bool,
+                    /// Resolved font name for this run (e.g. "Arial",
+                    /// "Arial Bold", "Arial Italic"). Used to pick a
+                    /// variant atlas at draw time so bold/italic runs
+                    /// render from their pre-designed PFR cast members
+                    /// rather than applying fake-bold double-strike or
+                    /// fake-italic shear to the field's base atlas.
+                    font_name: Option<String>,
                 }
 
                 #[derive(Clone)]
@@ -5205,19 +5415,81 @@ impl WebGL2Renderer {
                         bold: style.bold,
                         italic: style.italic,
                         underline: style.underline,
+                        font_name: style.font_face.clone(),
                     }
                 };
 
+                // Minimum space-character advance. Some PFR1 fonts ship
+                // a space `set_width` so narrow that at small render sizes
+                // (12 pt) the advance rounds to 1–2 px and text wraps way
+                // later than Shockwave's reference — extra words squeeze
+                // onto each line. Shockwave's authentic render of these
+                // movies uses what looks like GDI's default Arial space
+                // (~30% em). 0.30 × size_px ≈ 4 px at 12 pt — within a
+                // half-pixel of Windows Arial's space metric. Clamps
+                // only spaces; non-space glyph advances are untouched.
+                let space_min_advance = |size_px: i32| -> i32 {
+                    ((size_px as f32 * 0.30).round() as i32).max(2)
+                };
+                // Pre-load variant atlases for every distinct `font_face`
+                // referenced by the styled spans (Arial, Arial Bold, Arial
+                // Italic, …). The map is used twice: by `token_width` below
+                // to compute WRAP-time widths with the same per-run atlas
+                // the draw uses, AND by the per-line draw loop further down.
+                // Doing wrap measurement with regular Arial while drawing
+                // with Arial Bold made the rendered bold text overflow the
+                // wrap boundary, which then made `the mouseChar` resolve
+                // clicks on visual "Christ's passion" to char positions
+                // deep inside "the sign of the cross" / "three motives".
+                struct PfrWrapVariant {
+                    font: std::rc::Rc<crate::player::font::BitmapFont>,
+                }
+                let mut wrap_variants: std::collections::HashMap<String, PfrWrapVariant> = std::collections::HashMap::new();
+                {
+                    let mut unique_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+                    if let Some(spans) = styled_spans {
+                        for span in spans {
+                            if let Some(ref name) = span.style.font_face {
+                                if !name.is_empty() && !name.eq_ignore_ascii_case(font_name) {
+                                    unique_names.insert(name.clone());
+                                }
+                            }
+                        }
+                    }
+                    for variant_name in unique_names {
+                        if let Some(vf) = player.font_manager.get_font_with_cast_and_bitmap(
+                            &variant_name,
+                            &player.movie.cast_manager,
+                            &mut player.bitmap_manager,
+                            Some(requested_font_size),
+                            None,
+                        ) {
+                            if vf.char_widths.is_some() {
+                                wrap_variants.insert(
+                                    variant_name.to_ascii_lowercase(),
+                                    PfrWrapVariant { font: vf },
+                                );
+                            }
+                        }
+                    }
+                }
                 let token_width = |token_text: &str, style: &PfrRunStyle| -> i32 {
-                    // See blit logic below for the rationale on
-                    // `size_px / base_size` vs `size_px / native_char_height`.
                     let scale_num = style.size_px.max(1);
                     let scale_den = base_size.max(1);
+                    let space_min = space_min_advance(style.size_px);
+                    // Pick the run's variant atlas font for wrap-time
+                    // advances when available, so wrap widths match the
+                    // per-span draw widths.
+                    let variant_font = style.font_name.as_ref()
+                        .and_then(|n| wrap_variants.get(&n.to_ascii_lowercase()))
+                        .map(|v| &*v.font);
+                    let measure_font = variant_font.unwrap_or(&*font);
                     token_text
                         .chars()
                         .map(|c| {
-                            ((font.get_char_advance(c as u8) as i32) * scale_num / scale_den)
-                                .max(1)
+                            let raw = ((measure_font.get_char_advance(c as u8) as i32) * scale_num / scale_den)
+                                .max(1);
+                            if c == ' ' { raw.max(space_min) } else { raw }
                         })
                         .sum()
                 };
@@ -5340,6 +5612,58 @@ impl WebGL2Renderer {
                     );
                 }
 
+                // Pre-load every variant atlas referenced by the styled
+                // spans (typically "Arial" / "Arial Bold" / "Arial Italic"
+                // for Fugue No. 4's Narrative field). Cloning the bitmap
+                // up-front sidesteps the borrow-checker conflict between
+                // looking up `player.bitmap_manager` for the source atlas
+                // while the destination text_bitmap is being mutated, and
+                // means we only need the `&Bitmap` reference inside the
+                // per-glyph draw call. ~88KB per variant × ~4 variants
+                // = ~350KB per cache miss; cached afterwards.
+                struct PfrVariantAtlas {
+                    font: std::rc::Rc<crate::player::font::BitmapFont>,
+                    bitmap: Bitmap,
+                }
+                let mut variant_atlases: std::collections::HashMap<String, PfrVariantAtlas> = std::collections::HashMap::new();
+                {
+                    let mut unique_names: std::collections::HashSet<String> = std::collections::HashSet::new();
+                    for line in &lines {
+                        for run in &line.runs {
+                            if let Some(ref name) = run.style.font_name {
+                                if !name.is_empty() && !name.eq_ignore_ascii_case(font_name) {
+                                    unique_names.insert(name.clone());
+                                }
+                            }
+                        }
+                    }
+                    for variant_name in unique_names {
+                        if let Some(variant_font) = player.font_manager.get_font_with_cast_and_bitmap(
+                            &variant_name,
+                            &player.movie.cast_manager,
+                            &mut player.bitmap_manager,
+                            Some(requested_font_size),
+                            None,
+                        ) {
+                            if variant_font.char_widths.is_some() {
+                                if let Some(bmp) = player.bitmap_manager.get_bitmap(variant_font.bitmap_ref) {
+                                    variant_atlases.insert(
+                                        variant_name.to_ascii_lowercase(),
+                                        PfrVariantAtlas { font: variant_font.clone(), bitmap: bmp.clone() },
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    if DEBUG_WEBGL2_TEXT {
+                        debug!(
+                            "[webgl2.text.pfr.variants] base='{}' variants_loaded={}",
+                            font_name,
+                            variant_atlases.len()
+                        );
+                    }
+                }
+
                 // Paragraph-boundary spacing rule (XMED-verified against
                 // Buggy info-card):
                 //
@@ -5413,46 +5737,55 @@ impl WebGL2Renderer {
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
                         };
 
-                        // Scale glyphs by per-span size relative to the
-                        // member's base size, then map onto native cell
-                        // dimensions. When style.size_px == base_size (the
-                        // common default-size case), this yields a 1:1
-                        // render at native (matching the non-multi-span
-                        // bitmap path). The previous formula
-                        // `size_px / native_char_height` was off when
-                        // base_size != native_char_height (e.g. 04b_08 *:
-                        // base 12, native cell 14 — glyphs got blitted
-                        // at 12/14=86% size, making CS Junkbot WELCOME
-                        // text visibly thinner than READY TO PLAY which
-                        // used the non-multi-span path at 100%).
+                        // Pick the run's atlas. When the run names a variant
+                        // we've pre-loaded (e.g. "Arial Bold" or "Arial
+                        // Italic" cast members in Fugue No. 4), draw the
+                        // glyphs directly from that atlas — the variant
+                        // PFR1 already encodes bold/italic stroke shapes,
+                        // so no double-strike or shear is needed. Falling
+                        // back to the field's base atlas means we apply
+                        // the legacy fake-bold / fake-italic transforms.
+                        let run_variant = run.style.font_name.as_ref()
+                            .and_then(|n| variant_atlases.get(&n.to_ascii_lowercase()));
+                        let (run_font, run_font_bitmap, use_variant) = match run_variant {
+                            Some(v) => (&*v.font as &crate::player::font::BitmapFont, &v.bitmap, true),
+                            None => (&*font, font_bitmap, false),
+                        };
+                        let run_native_char_h = run_font.char_height.max(1) as i32;
+                        let run_native_char_w = run_font.char_width as i32;
                         let span_scale_num = run.style.size_px.max(1);
                         let span_scale_den = base_size.max(1);
-                        let char_h = (native_char_height * span_scale_num / span_scale_den).max(1);
+                        let char_h = (run_native_char_h * span_scale_num / span_scale_den).max(1);
                         let char_w =
-                            ((font.char_width as i32) * span_scale_num / span_scale_den).max(1);
-                        // When the span uses the document's default size,
-                        // dispatch to the unscaled `bitmap_font_copy_char`
-                        // (the same call the non-multi-span path uses).
-                        // `bitmap_font_copy_char_scaled` adds sampling
-                        // overhead even for 1:1 dimensions and produced
-                        // visibly thinner glyphs on CS Junkbot credits
-                        // vs. WELCOME (which used the unscaled path).
+                            (run_native_char_w * span_scale_num / span_scale_den).max(1);
                         let span_is_default_size = span_scale_num == span_scale_den;
+                        // When drawing from a pre-designed variant atlas
+                        // (Arial Bold / Italic), the style is already in
+                        // the glyph shapes — suppress fake-bold and
+                        // fake-italic so we don't stack them on top.
+                        let apply_fake_bold = run.style.bold && !use_variant;
+                        let apply_fake_italic = run.style.italic && !use_variant;
+                        let italic_default_size = apply_fake_italic && span_is_default_size;
                         let underline_y = y + char_h - 1;
                         let run_start_x = x;
 
+                        let space_min = space_min_advance(run.style.size_px);
                         for ch in run.text.chars() {
-                            // Map Unicode char -> Win-1252 atlas slot before
-                            // looking up glyph width/cell. `c as u8` truncates
-                            // codepoints like € (U+20AC=0x20AC) to 0xAC, so the
-                            // renderer would pull the wrong glyph from the
-                            // atlas.
                             let glyph_b = crate::io::encoding::glyph_byte_for(ch);
-                            let advance = if span_is_default_size {
-                                font.get_char_advance(glyph_b) as i32
+                            let raw_advance = if span_is_default_size {
+                                run_font.get_char_advance(glyph_b) as i32
                             } else {
-                                ((font.get_char_advance(glyph_b) as i32) * span_scale_num / span_scale_den)
+                                ((run_font.get_char_advance(glyph_b) as i32) * span_scale_num / span_scale_den)
                                     .max(1)
+                            };
+                            // Mirror the wrap-time clamp: spaces with a tiny
+                            // stored set_width get widened to ≥ font_size/4 so
+                            // word advance matches measurement and lines wrap
+                            // where we said they would.
+                            let advance = if ch == ' ' {
+                                raw_advance.max(space_min)
+                            } else {
+                                raw_advance
                             };
 
                             if ch == ' ' {
@@ -5460,31 +5793,24 @@ impl WebGL2Renderer {
                                 continue;
                             }
 
-                            // Each glyph is drawn exactly once. Bold uses fake
-                            // double-strike (x and x+1); italic uses per-row
-                            // shear via the _italic helpers. Italic is only
-                            // available at default size — _scaled doesn't have
-                            // an italic variant yet, so scaled italic falls
-                            // through to the non-italic scaled copy.
-                            let italic_default_size = run.style.italic && span_is_default_size;
                             let draw_glyph = |dest: &mut Bitmap, dx: i32| {
                                 if italic_default_size {
                                     bitmap_font_copy_char_italic(
-                                        &font, font_bitmap, glyph_b, dest, dx, y, &palettes, &run_params,
+                                        run_font, run_font_bitmap, glyph_b, dest, dx, y, &palettes, &run_params,
                                     );
                                 } else if span_is_default_size {
                                     bitmap_font_copy_char(
-                                        &font, font_bitmap, glyph_b, dest, dx, y, &palettes, &run_params,
+                                        run_font, run_font_bitmap, glyph_b, dest, dx, y, &palettes, &run_params,
                                     );
                                 } else {
                                     bitmap_font_copy_char_scaled(
-                                        &font, font_bitmap, glyph_b, dest, dx, y,
+                                        run_font, run_font_bitmap, glyph_b, dest, dx, y,
                                         char_w, char_h, &palettes, &run_params,
                                     );
                                 }
                             };
                             draw_glyph(&mut text_bitmap, x);
-                            if run.style.bold {
+                            if apply_fake_bold {
                                 draw_glyph(&mut text_bitmap, x + 1);
                             }
 


### PR DESCRIPTION
#146 

f24ca0b2 — **io**: UTF-8 fallback for D10+ field/text bytes (read_string + xmedia section 3).
2b9cd491 — **score**: accept extended-size primary spans on D8.5+ (path-keyframe-bearing entries 72-336+ bytes).
69254c17 — **js_api**: don't panic when a cast member vanishes mid-snapshot dispatch.
395efa36 — **sound**: parse cupt chunk, fire on cuePassed, honour [#startTime: ms], anchor score-frame loop to audio time on sound 1 start.
3da9f774 — **score**: probe-based sprite.rect setter (round-trip-safe across all member types) + let is_click_transparent_sprite reach member-attached behavior scripts via get_script_id() → lctx.scripts.
35fd8e0d — **text**: per-char STXT styling (formatting_runs end-to-end), multi-span PFR rendering with variant atlases (Arial / Bold / Italic), chunk chaining for member.line[N].word[M].font/.fontStyle/.textStyle, mouseChar hit-test that mirrors the renderer's wrap, scrollTop + paged box types.
54ad23c5 — Snapshot reference bump.