### PR TITLE
sound: support runtime sound members for Habbo v31 trax

### DIFF
--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::{
     director::{
-        cast::CastDef, enums::{ScriptType, BitmapInfo},
+        cast::CastDef, chunks::sound::SoundChunk, enums::{ScriptType, BitmapInfo, SoundInfo},
         file::{read_director_file_bytes, DirectorFile},
         lingo::{datum::Datum, script::ScriptContext},
     },
@@ -21,7 +21,8 @@ use super::{
         manager::BitmapManager,
     },
     cast_member::{
-        BitmapMember, CastMember, CastMemberType, FieldMember, PaletteMember, TextMember,
+        BitmapMember, CastMember, CastMemberType, FieldMember, PaletteMember, SoundMember,
+        TextMember,
     },
     datum_ref::DatumRef,
     handlers::datum_handlers::cast_member_ref::CastMemberRefHandlers,
@@ -417,6 +418,17 @@ impl CastLib {
             "palette" => Ok(CastMember::new(
                 number,
                 CastMemberType::Palette(PaletteMember::new()),
+            )),
+            // `new(#sound, castLib)` creates an empty sound member; its media is
+            // populated later, typically via `importFileInto` (Director 11.5
+            // Scripting Dictionary, `new()` / `importFileInto()`). Habbo's
+            // Download Manager relies on this for streamed trax samples.
+            "sound" => Ok(CastMember::new(
+                number,
+                CastMemberType::Sound(SoundMember {
+                    info: SoundInfo::default(),
+                    sound: SoundChunk::default(),
+                }),
             )),
             "script" => Ok(CastMember::new(
                 number,

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -39,7 +39,8 @@ pub struct CastMember {
 pub enum Media {
     Field(FieldMember),
     Bitmap { bitmap: Bitmap, reg_point: (i16, i16) },
-    Palette(PaletteMember)
+    Palette(PaletteMember),
+    Sound(SoundMember),
 }
 
 #[derive(Clone, Default)]

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/sound.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/sound.rs
@@ -1,6 +1,6 @@
 use crate::{
     director::lingo::datum::Datum,
-    player::{cast_lib::CastMemberRef, reserve_player_mut, DirPlayer, ScriptError},
+    player::{cast_lib::CastMemberRef, cast_member::Media, reserve_player_mut, DirPlayer, ScriptError},
 };
 
 pub struct SoundMemberHandlers {}
@@ -19,6 +19,12 @@ impl SoundMemberHandlers {
         let sound = member.member_type.as_sound().unwrap();
 
         match prop {
+            // `the media of member` is a read/write opaque media blob
+            // (Director 11.5 Scripting Dictionary, `media`). The documented
+            // idiom is `member(dst).media = member(src).media` to copy content
+            // between members — Habbo's Dynamic Downloader uses it to clone a
+            // downloaded sound into a bin member.
+            "media" => Ok(Datum::Media(Media::Sound(sound.clone()))),
             "duration" => Ok(Datum::Int(sound.info.duration as i32)),
             "sampleRate" => Ok(Datum::Int(sound.info.sample_rate as i32)),
             "sampleSize" => Ok(Datum::Int(sound.info.sample_size as i32)),
@@ -38,6 +44,24 @@ impl SoundMemberHandlers {
         value: Datum,
     ) -> Result<(), ScriptError> {
         match prop {
+            "media" => {
+                let media = value.media_value()?;
+                let new_sound = match media {
+                    Media::Sound(s) => s,
+                    _ => return Err(ScriptError::new("Expected a sound media".to_string())),
+                };
+                reserve_player_mut(|player| {
+                    let member = player
+                        .movie
+                        .cast_manager
+                        .find_mut_member_by_ref(member_ref)
+                        .ok_or_else(|| ScriptError::new("Cast member not found".to_string()))?;
+                    let sound = member.member_type.as_sound_mut()
+                        .ok_or_else(|| ScriptError::new("Cast member is not a sound".to_string()))?;
+                    *sound = new_sound;
+                    Ok(())
+                })
+            }
             "loop" => {
                 let loop_enabled = value.bool_value()?;
                 reserve_player_mut(|player| {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -711,20 +711,27 @@ impl BuiltInHandlerManager {
             Ok((member_ref, file_or_url, trim_white_space))
         })?;
 
-        // Validate the target is a bitmap member up front so we don't
-        // fetch + decode for nothing.
-        let existing_bitmap_ref = reserve_player_ref(|player| {
+        // Determine the target member kind up front so we don't fetch for a
+        // member type we can't import into. importFileInto replaces a member's
+        // content with the named file (Director 11.5 Scripting Dictionary,
+        // `importFileInto()`); we support bitmap and sound members.
+        enum ImportTarget {
+            Bitmap(crate::player::bitmap::manager::BitmapRef),
+            Sound,
+        }
+        let import_target = reserve_player_ref(|player| {
             let member = player.movie.cast_manager.find_member_by_ref(&member_ref);
             match member.map(|m| &m.member_type) {
-                Some(CastMemberType::Bitmap(b)) => Some(b.image_ref),
+                Some(CastMemberType::Bitmap(b)) => Some(ImportTarget::Bitmap(b.image_ref)),
+                Some(CastMemberType::Sound(_)) => Some(ImportTarget::Sound),
                 _ => None,
             }
         });
-        let existing_bitmap_ref = match existing_bitmap_ref {
-            Some(r) => r,
+        let import_target = match import_target {
+            Some(t) => t,
             None => {
                 warn!(
-                    "importFileInto: member ({}, {}) is not a bitmap (v1 scope)",
+                    "importFileInto: member ({}, {}) is not a bitmap or sound (v1 scope)",
                     member_ref.cast_lib, member_ref.cast_member
                 );
                 return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-2))));
@@ -753,6 +760,34 @@ impl BuiltInHandlerManager {
             Some(Err(code)) => {
                 warn!("importFileInto: net fetch failed ({}) for '{}'", code, file_or_url);
                 return reserve_player_mut(|player| Ok(player.alloc_datum(Datum::Int(-200))));
+            }
+        };
+
+        // Sound members: store the downloaded media verbatim. The playback
+        // path (sound_channel.rs) sniffs MP3 frames and hands compressed data
+        // to the browser's decodeAudioData, so the raw file bytes are exactly
+        // what it expects — no eager decode here. Sample metadata stays at
+        // defaults until the browser decodes the buffer at play time.
+        let existing_bitmap_ref = match import_target {
+            ImportTarget::Bitmap(r) => r,
+            ImportTarget::Sound => {
+                use crate::director::chunks::sound::SoundChunk;
+                let byte_len = bytes.len();
+                return reserve_player_mut(|player| {
+                    if let Some(member) =
+                        player.movie.cast_manager.find_mut_member_by_ref(&member_ref)
+                    {
+                        if let CastMemberType::Sound(s) = &mut member.member_type {
+                            s.sound = SoundChunk::new(bytes);
+                        }
+                    }
+                    debug!(
+                        "importFileInto: imported '{}' ({} bytes) into sound member ({}, {})",
+                        file_or_url, byte_len, member_ref.cast_lib, member_ref.cast_member
+                    );
+                    JsApi::dispatch_cast_member_changed(member_ref.clone());
+                    Ok(player.alloc_datum(Datum::Int(0)))
+                });
             }
         };
 


### PR DESCRIPTION
Habbo's Resource/Download/Dynamic-Downloader chain creates and streams trax samples at runtime. Three Director member surfaces were missing, each erroring out the trax load:

- new(#sound, castLib) -> create an empty sound member. create_member_at now handles "sound" (Director 11.5 Scripting Dictionary, new()).
- importFileInto on a sound member -> store the downloaded media verbatim. The playback path already MP3-sniffs the SoundChunk and hands compressed data to the browser, so no eager decode is needed.
- the media of member (read/write) on sound members -> opaque media blob so member(dst).media = member(src).media copies a sound between members (Dynamic Downloader copyMemberToBin). Added a Media::Sound variant.