### PR TITLE
camera: fix Habbo MUS photo media format and ink 41 duotone rendering

### DIFF
--- a/vm-rust/src/director/media/reader.rs
+++ b/vm-rust/src/director/media/reader.rs
@@ -9,9 +9,19 @@ pub trait MediaReader {
 
 impl MediaReader for BinaryReader {
     fn read_media(&mut self) -> Result<Media, std::io::Error> {
-        let magic = self.read_u32()?; // Bitmap: e8 92 14 68
+        let magic = self.read_u32()?;
         match magic {
-            0xE8921468 => {
+            // Known bitmap-media magics:
+            //   0x18438963 — indexed PixMap; what real Shockwave emits for
+            //                <=8-bit media (v7 camera photos). Ground truth.
+            //   0xE8921468 — direct-color; the form dirplayer historically
+            //                wrote (and still writes for >8-bit media).
+            //   0x88811468 — an interim value dirplayer briefly wrote for
+            //                indexed media; accepted so already-stored photos
+            //                still load.
+            // The metadata parse below masks the rowBytes PixMap flag and
+            // ignores the format byte, so the body is identical for all three.
+            0xE8921468 | 0x88811468 | 0x18438963 => {
                 let metadata = self.read_bitmap_media_metadata()?;
                 let chunk_id = self.read_u32()?;
                 let endian = if chunk_id == FOURCC("BITD") {
@@ -24,7 +34,18 @@ impl MediaReader for BinaryReader {
                 self.set_endian(endian);
                 let chunk_size = self.read_u32()? as usize;
                 let chunk_data = self.read_bytes(chunk_size)?.to_vec();
-                let decompressed = decompress_bitmap(&chunk_data, &metadata, 0, 0).unwrap();
+                // decompress_bitmap previously .unwrap()ed here — a malformed
+                // or unexpected chunk would panic and poison MUS message
+                // processing (manifesting as VOID content + disconnect).
+                // Surface it as an Err instead so the caller falls back to Void.
+                let decompressed = decompress_bitmap(&chunk_data, &metadata, 0, 0)
+                    .map_err(|e| {
+                        log::warn!(
+                            "read_media: decompress_bitmap failed (magic=0x{:08X}, {}x{}, depth={}): {:?}",
+                            magic, metadata.width, metadata.height, metadata.bit_depth, e
+                        );
+                        std::io::Error::new(std::io::ErrorKind::InvalidData, "decompress_bitmap failed")
+                    })?;
                 Ok(Media::Bitmap { bitmap: decompressed, reg_point: (metadata.reg_y, metadata.reg_x) })
             }
             _ => Err(std::io::Error::new(std::io::ErrorKind::InvalidData, format!("Unknown media magic number: {}", magic))),

--- a/vm-rust/src/director/media/writer.rs
+++ b/vm-rust/src/director/media/writer.rs
@@ -46,8 +46,27 @@ impl MediaWriter for BinaryWriter<'_> {
                 let raw_data = encode_bitmap_data(bitmap, target_bit_depth, pitch)
                     .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
 
-                // Compress with PackBits RLE
-                let compressed = compress_bitmap(&raw_data);
+                // Compress with PackBits RLE, ONE ROW AT A TIME. Director's
+                // BITD/DTIB RLE is per-row: every row of `pitch` bytes is
+                // compressed independently and must decode back to exactly
+                // `pitch` bytes before the next row begins. Compressing the
+                // whole image as a single stream lets a run or literal span a
+                // row boundary (e.g. the row's pad byte + the next row's first
+                // pixel as one literal). dirplayer's own stream decoder
+                // tolerates that, but the real Director Multiuser xtra decodes
+                // per row, so a boundary-crossing op makes a row decode to the
+                // wrong length, desyncs the bitmap, and drops the connection
+                // when a real Shockwave client *views* the photo. Matching the
+                // per-row scheme keeps each row aligned to `pitch`.
+                let pitch_bytes = pitch as usize;
+                let mut compressed = Vec::new();
+                if pitch_bytes > 0 {
+                    for row in raw_data.chunks(pitch_bytes) {
+                        compressed.extend_from_slice(&compress_bitmap(row));
+                    }
+                } else {
+                    compressed = compress_bitmap(&raw_data);
+                }
 
                 // Use compressed only if it's actually smaller
                 let chunk_data = if compressed.len() < raw_data.len() {
@@ -56,8 +75,25 @@ impl MediaWriter for BinaryWriter<'_> {
                     raw_data
                 };
 
-                // Write magic
-                let mut written = self.write_u32(0xE8921468u32).map_err(map_err)?;
+                // The MUS media header encodes the imaging model. Director
+                // serializes an indexed (<=8-bit) PixMap with magic
+                // 0x18438963, and a direct-color (>=16-bit) image with
+                // 0xE8921468. Habbo v7's camera photos are 8-bit #grayscale,
+                // so they MUST use the paletted magic — otherwise the real
+                // Multiuser xtra can't instantiate the value, the message
+                // content comes through VOID, and the client disconnects.
+                // The magic value (and the rest of the header) is verified
+                // byte-for-byte against the bytes a real Shockwave v7 client
+                // sends to the woodpecker server (server log: head=[18 43 89
+                // 63 02 00 .. 80 A2 .. C0 08 .. DTIB]). The >8-bit path keeps
+                // the pre-existing magic (unverified, left unchanged so
+                // truecolor media doesn't regress).
+                let magic = if target_bit_depth <= 8 {
+                    0x18438963u32
+                } else {
+                    0xE8921468u32
+                };
+                let mut written = self.write_u32(magic).map_err(map_err)?;
 
                 // Write metadata
                 written += self.write_bitmap_media_metadata(&info)?;
@@ -91,11 +127,20 @@ impl MediaWriter for BinaryWriter<'_> {
     }
 
     fn write_bitmap_media_metadata(&mut self, info: &BitmapInfo) -> Result<usize, std::io::Error> {
+        // Indexed bitmaps (2..=8-bit) are QuickDraw PixMaps: rowBytes carries
+        // the 0x8000 high-bit flag and the format byte (_unknown_6) is 0xC0.
+        // Direct-color / 1-bit images use the plain pitch and 0xA0. The 8-bit
+        // case is verified against the real Shockwave v7 photo; the others are
+        // left at the previous values to avoid regressing untested paths.
+        let is_indexed_pixmap = info.bit_depth >= 2 && info.bit_depth <= 8;
+        let row_bytes_field = if is_indexed_pixmap { info.pitch | 0x8000 } else { info.pitch };
+        let format_byte: u8 = if is_indexed_pixmap { 0xC0 } else { 0xA0 };
+
         let mut written = self.write_u16(0x0200u16).map_err(map_err)?;       // _unknown_0: Constant 02 00
         written += self.write_bytes(&[0u8; 14]).map_err(map_err)?;            // _unknown_1: All zeros
         written += self.write_u16(0x0100u16).map_err(map_err)?;               // _unknown_2: Constant 01 00
         written += self.write_bytes(&[0u8; 6]).map_err(map_err)?;             // _unknown_3: All zeros
-        written += self.write_u16(info.pitch).map_err(map_err)?;              // row_bytes (pitch)
+        written += self.write_u16(row_bytes_field).map_err(map_err)?;        // row_bytes (pitch) [+0x8000 PixMap flag]
         written += self.write_i16(0i16).map_err(map_err)?;                    // rect_top
         written += self.write_i16(0i16).map_err(map_err)?;                    // rect_left
         written += self.write_i16(info.height as i16).map_err(map_err)?;      // rect_bottom
@@ -104,7 +149,7 @@ impl MediaWriter for BinaryWriter<'_> {
         written += self.write_bytes(&[0u8; 7]).map_err(map_err)?;             // _unknown_5: All zeros
         written += self.write_i16(info.reg_y).map_err(map_err)?;              // reg_y
         written += self.write_i16(info.reg_x).map_err(map_err)?;              // reg_x
-        written += self.write_i8(0xa0u8 as i8).map_err(map_err)?;            // _unknown_6: Constant 0xa0
+        written += self.write_i8(format_byte as i8).map_err(map_err)?;       // _unknown_6: 0xC0 indexed PixMap / 0xA0 otherwise
         written += self.write_u8(info.bit_depth).map_err(map_err)?;           // depth
         written += self.write_i16(-1i16).map_err(map_err)?;                   // clut_cast_lib: -1 for builtin palettes
         written += self.write_i16(info.palette_id + 1).map_err(map_err)?;     // palette stored as BuiltInPalette enum value + 1

--- a/vm-rust/src/player/bitmap/bitmap.rs
+++ b/vm-rust/src/player/bitmap/bitmap.rs
@@ -1031,15 +1031,24 @@ fn encode_bitmap_32bit(bitmap: &Bitmap, scan_width: u16) -> Result<Vec<u8>, Stri
 ///   0x00..0x7F: literal run of (control + 1) bytes follows
 ///   0x80:       no-op (not emitted by compressor)
 ///   0x81..0xFF: repeat run, next byte repeated (257 - control) times
+///
+/// Runs and literals are capped at 127 (not the PackBits theoretical max of
+/// 128). Real Director / Shockwave never emits a 128-length op — its longest
+/// repeat control is 0x82 (127×) and longest literal is 0x7E (127 bytes). The
+/// old Director Multiuser xtra's RLE decoder sizes its run buffer for 127, so
+/// a 128-length run (control 0x81) overruns it and crashes the connection when
+/// the receiving client deserializes the media (observed: real Shockwave
+/// disconnects while *viewing* a dirplayer photo). Matching the 127 cap keeps
+/// dirplayer's media byte-compatible with what Director itself produces.
 pub fn compress_bitmap(data: &[u8]) -> Vec<u8> {
     let mut result = Vec::new();
     let len = data.len();
     let mut i = 0;
 
     while i < len {
-        // Look ahead for a run of identical bytes
+        // Look ahead for a run of identical bytes (capped at 127)
         let mut run_len = 1;
-        while i + run_len < len && data[i + run_len] == data[i] && run_len < 128 {
+        while i + run_len < len && data[i + run_len] == data[i] && run_len < 127 {
             run_len += 1;
         }
 
@@ -1049,11 +1058,11 @@ pub fn compress_bitmap(data: &[u8]) -> Vec<u8> {
             result.push(data[i]);
             i += run_len;
         } else {
-            // Collect literal bytes until we hit a run of 3+
+            // Collect literal bytes until we hit a run of 3+ (capped at 127)
             let start = i;
             let mut literal_len = 0;
 
-            while i < len && literal_len < 128 {
+            while i < len && literal_len < 127 {
                 // Check if we're about to start a run of 3+ identical bytes
                 if i + 2 < len && data[i] == data[i + 1] && data[i] == data[i + 2] {
                     break;

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -3143,6 +3143,7 @@ impl WebGL2Renderer {
         let u_rotation = program.u_rotation.clone();
         let u_rotation_center = program.u_rotation_center.clone();
         let u_blend = program.u_blend.clone();
+        let u_fg_color = program.u_fg_color.clone();
         let u_bg_color = program.u_bg_color.clone();
         let u_color_tolerance = program.u_color_tolerance.clone();
 
@@ -3300,6 +3301,20 @@ impl WebGL2Renderer {
                     0.01
                 };
                 gl.uniform1f(Some(loc), tolerance);
+            }
+        }
+
+        // Darken (ink 41) is a foreColor/bgColor duotone — feed the shader the
+        // sprite's foreColor as well as the bgColor set above.
+        if effective_ink == InkMode::Darken {
+            if let Some(ref loc) = u_fg_color {
+                gl.uniform4f(
+                    Some(loc),
+                    fg_color_rgb.0 as f32 / 255.0,
+                    fg_color_rgb.1 as f32 / 255.0,
+                    fg_color_rgb.2 as f32 / 255.0,
+                    1.0,
+                );
             }
         }
 

--- a/vm-rust/src/rendering_gpu/webgl2/shaders.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/shaders.rs
@@ -372,6 +372,7 @@ in vec2 v_texcoord;
 
 uniform sampler2D u_texture;
 uniform float u_blend;
+uniform vec4 u_fg_color;
 uniform vec4 u_bg_color;
 
 out vec4 fragColor;
@@ -382,14 +383,16 @@ void main() {
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
 
-    // Director ink 41 (Darken): multiply source by bgColor
-    // result_color = src.rgb * bgColor.rgb
-    // Then alpha-blend with destination using standard blending
-    vec3 darkened = src.rgb * u_bg_color.rgb;
+    // Director ink 41 (Darken): a foreColor/bgColor brightness duotone, NOT a
+    // multiply. Map the source's luminance through the foreColor..bgColor
+    // range — dark areas take foreColor, light areas take bgColor. Habbo's
+    // camera renders the grayscale photo this way (color=dark, bgColor=light)
+    // to get its sepia look. Then alpha-blend the result normally.
+    float lum = dot(src.rgb, vec3(0.299, 0.587, 0.114));
+    vec3 duotone = mix(u_fg_color.rgb, u_bg_color.rgb, lum);
 
-    // Apply blend factor and source alpha
     float alpha = src.a * u_blend;
-    fragColor = vec4(darkened, alpha);
+    fragColor = vec4(duotone, alpha);
 }
 "#;
 


### PR DESCRIPTION
The Habbo camera serializes the captured photo (an 8-bit #grayscale bitmap) as a Lingo media datum over the MUS protocol, and renders it as a sprite with ink 41 (Darken) + foreColor/bgColor. Two areas were broken.

MUS media serialization (director/media/writer.rs, reader.rs, bitmap.rs) so a real Shockwave client can read a dirplayer-taken photo without disconnecting:
- writer: indexed (<=8-bit) media uses magic 0x18438963 with the 0x8000 QuickDraw PixMap flag on rowBytes and format byte 0xC0 (verified byte-for-byte against a real Shockwave v7 capture). Direct-color media keeps the previous 0xE8921468 header.
- writer: PackBits is now emitted PER ROW, and runs/literals are capped at
  127. Director's BITD/DTIB RLE is per-row and its decoder buffers 127; a whole-image stream or a 128-length run desynced/overran the real xtra's decoder and dropped the connection when viewing the photo.
- reader: accept 0x18438963 / 0xE8921468 / 0x88811468; decompress_bitmap no longer .unwrap()-panics (returns Err so a bad chunk can't poison MUS message processing).

Ink 41 (Darken) rendering (rendering_gpu/webgl2/shaders.rs, mod.rs):
- the Darken shader did src * bgColor (a multiply, marked TODO) and ignored foreColor, so the grayscale photo came out olive/black. Director's Darken is a foreColor/bgColor brightness duotone: dark areas take foreColor, light areas take bgColor. The shader now does mix(fg, bg, luminance) and is fed the sprite's foreColor (u_fg_color). For default-foreColor sprites this is identical to the old multiply, so only explicitly-tinted ink 41 sprites (the photo) change.