### PR TITLE
sound: honor the member loop flag for puppetSound / score sounds

### DIFF
--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -160,7 +160,7 @@ impl SoundChannelDatumHandlers {
                         "playFile requires a member argument".to_string(),
                     ));
                 }
-                Self::handle_play_file(player, datum, &args[0])?;
+                Self::handle_play_file(player, datum, &args[0], 1)?;
                 Ok(datum.clone())
             }
             "playnext" => {
@@ -452,15 +452,22 @@ impl SoundChannelDatumHandlers {
         player: &mut DirPlayer,
         datum: &DatumRef,
         member: &DatumRef,
+        loop_count: i32,
     ) -> Result<(), ScriptError> {
         // Get the channel as Rc<RefCell<SoundChannel>> (do NOT borrow)
         let channel_rc = Self::get_sound_channel_mut(player, datum)?;
 
-        // Reset loop_count to play-once (1) so stale loopCount settings don't leak
+        // Apply the caller's loop count (overwriting any stale value from a
+        // previous sound). `puppet_sound` passes the value derived from the
+        // member's loop flag (0 = loop forever, 1 = play once); direct
+        // `playFile` passes 1. Previously this was hardcoded to 1, which
+        // clobbered the loop count `puppet_sound` had just set and broke
+        // looping for score / puppetSound sounds whose member has the loop
+        // flag enabled (e.g. mobilesdisco's intro music in sound channel 1).
         {
             let mut ch = channel_rc.borrow_mut();
-            ch.loop_count = 1;
-            ch.loops_remaining = 1;
+            ch.loop_count = loop_count;
+            ch.loops_remaining = loop_count;
         }
 
         // Call the associated function with the Rc
@@ -474,9 +481,8 @@ impl SoundChannelDatumHandlers {
         datum: &DatumRef,
         member_ref: &DatumRef,
     ) -> Result<DatumRef, ScriptError> {
-        // Don't get the channel at all - just call play_member directly
-        // which will get the channel internally
-        Self::handle_play_file(player, datum, member_ref)?;
+        // Direct `sound playFile` plays the external file once.
+        Self::handle_play_file(player, datum, member_ref, 1)?;
         Ok(DatumRef::Void)
     }
 

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -2403,19 +2403,12 @@ impl DirPlayer {
                 1
             }
         };
-        
-        // Set the loop count on the channel BEFORE playing
-        let channel_rc = self.sound_manager
-            .get_channel_mut((channel_num - 1) as usize)
-            .ok_or_else(|| ScriptError::new(format!("Invalid sound channel {}", channel_num)))?;
-        
-        {
-            let mut channel = channel_rc.borrow_mut();
-            channel.loop_count = loop_count;
-            channel.loops_remaining = loop_count;
-        }
-        
-        SoundChannelDatumHandlers::handle_play_file(self, &sound_channel, &member_ref)
+
+        // handle_play_file applies this loop count to the channel right before
+        // it starts the sound. (It used to be set here AND reset to 1 inside
+        // handle_play_file, which clobbered looping — now the derived value is
+        // threaded through.)
+        SoundChannelDatumHandlers::handle_play_file(self, &sound_channel, &member_ref, loop_count)
     }
 
     // Lingo: sound stop channelNum


### PR DESCRIPTION
handle_play_file unconditionally reset loop_count to 1 right after puppet_sound had derived it from the sound member's loop flag (0 = loop forever, 1 = play once). That clobber made every score-channel and puppetSound sound play once — a looping intro track (e.g. mobilesdisco's music in sound channel 1, member loop enabled) never repeated.

Thread the loop count through handle_play_file instead of hardcoding it: puppet_sound passes the derived value; direct `sound playFile` passes 1 (unchanged play-once). Once loop_count is 0, play_file stores the member for replay and start_sound enables native looping.