### PR TITLE
support spectral wizard game

### DIFF
--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -726,9 +726,14 @@ function getVariable(spriteNum: number, path: string): string | null {
 function setVariable(spriteNum: number, path: string, value: string): boolean {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
-  if (!instance) {
-    console.warn(`ruffleSetVariable: no instance for sprite#${spriteNum}`);
-    return false;
+  // The instance may not exist / be ready yet: a script can push values into
+  // the SWF (e.g. spectral-wizard's loader writing `playerScore`) before the
+  // renderer has lazily created the Flash instance and finished AS init.
+  // Queue the write and replay it on ready (in frame order with goto/play/etc)
+  // instead of dropping it. Same pre-instance pattern as gotoFrame/play/stop.
+  if (!instance || !instance.ready) {
+    queueOp(spriteNum, { kind: 'setVariable', path, value });
+    return true; // optimistic — the write will land once the instance is ready
   }
 
   try {
@@ -760,7 +765,8 @@ type PendingOp =
   | { kind: 'gotoLabel'; label: string }
   | { kind: 'play' }
   | { kind: 'stop' }
-  | { kind: 'rewind' };
+  | { kind: 'rewind' }
+  | { kind: 'setVariable'; path: string; value: string };
 const pendingOps = new Map<number, PendingOp[]>();
 
 /**
@@ -937,6 +943,9 @@ function flushPendingGoto(spriteNum: number): void {
         case 'rewind':
           pinTarget.delete(spriteNum);
           instance.rufflePlayer.GotoFrame(1, true);
+          break;
+        case 'setVariable':
+          instance.rufflePlayer.SetVariable(translateLevel0(op.path), op.value);
           break;
       }
     } catch (e) {

--- a/vm-rust/src/director/chunks/literal.rs
+++ b/vm-rust/src/director/chunks/literal.rs
@@ -70,7 +70,11 @@ impl LiteralStore {
                 let length = reader.read_u32().unwrap() as usize;
                 match record.literal_type {
                     LiteralType::String => {
-                        value = Datum::String(reader.read_string(length - 1).unwrap());
+                        // Lingo script string literals are Mac Roman on every
+                        // platform (e.g. `§` = byte 0xA4, which Win-1252 would
+                        // mis-decode as `¤`). Decode UTF-8 first, then Mac
+                        // Roman — matching ProjectorRays' Lscr string handling.
+                        value = Datum::String(reader.read_string_macroman(length - 1).unwrap());
                     }
                     LiteralType::Float => {
                         let float_val = if length == 8 {

--- a/vm-rust/src/director/chunks/xmedia_styled_text.rs
+++ b/vm-rust/src/director/chunks/xmedia_styled_text.rs
@@ -134,6 +134,13 @@ pub struct XmedStyledText {
     /// style is style[3] = Verdana 9. `None` when char-run sections
     /// don't point at a parsed style.
     pub default_font_name: Option<String>,
+    /// Hyperlink ranges from Section 0x0129 (`hyperlink_key`), as 1-based
+    /// inclusive `[startChar, endChar]` pairs (Director's `the hyperlinks of
+    /// member` format). Empty when the member has no links. Each XMED record
+    /// stores a 0-based half-open range + a URL target; we convert to
+    /// `[start+1, end]` here (verified against help_menu, whose menu words
+    /// line up exactly).
+    pub hyperlinks: Vec<(i32, i32)>,
 }
 
 /// Section 1 data - document header with page/field properties
@@ -787,6 +794,16 @@ pub fn parse_xmed(data: &[u8]) -> Result<XmedStyledText, String> {
         })
         .collect();
 
+    // Hyperlink section — `hyperlink_key` (Paige enum 296 = raw header key
+    // 0x0128). NOTE the key: PgWalkStyle prints sections as `rawKey+1`, so its
+    // log shows this section as "0x0129", but dirplayer's `sections` map is
+    // keyed by the *raw* header value (0x0128). The companion 0x0129 (raw;
+    // PgWalkStyle "0x012A") is `hyperlink_target_key`/url-image, not the range
+    // table.
+    let hyperlinks = sections.get(&0x0128)
+        .map(|s| parse_hyperlinks(s, doc_version))
+        .unwrap_or_default();
+
     Ok(XmedStyledText {
         text: text_data.text,
         styled_spans,
@@ -809,7 +826,53 @@ pub fn parse_xmed(data: &[u8]) -> Result<XmedStyledText, String> {
         bg_color: section1_data.bg_color,
         default_font_size,
         default_font_name,
+        hyperlinks,
     })
+}
+
+/// Parse Section 0x0129 (`hyperlink_key`) into 1-based inclusive
+/// `[startChar, endChar]` ranges. Ported from PgWalkStyle's
+/// `ProcessHyperlinkSection` (which mirrors Paige's `pgReadHyperlinkProc`) and
+/// validated against help_menu. Each record:
+///   start, end                 — applied_range (UnpackNum, 0-based half-open)
+///   4 style shorts             — active/state1/state2/state3 (UnpackNum)
+///   version-gated id fields     — gated on the doc version (`int4`)
+///   urlLen + URL bytes         — link target (UnpackNum + ptr-bytes block)
+/// We keep only the range, converted to Director's 1-based `[start+1, end]`.
+fn parse_hyperlinks(data: &[u8], doc_version: i32) -> Vec<(i32, i32)> {
+    let mut packer = Packer::new(data.to_vec());
+    let mut links: Vec<(i32, i32)> = Vec::new();
+    // Guard against malformed data with a generous cap.
+    while packer.remaining() > 2 && links.len() < 256 {
+        let start = packer.unpack_num();
+        let end = packer.unpack_num();
+        let _active_style = packer.unpack_num();
+        let _state1 = packer.unpack_num();
+        let _state2 = packer.unpack_num();
+        let _state3 = packer.unpack_num();
+
+        // Version-gated id fields (unique_id, target_id, type, refcon).
+        if doc_version >= 131087 {
+            packer.unpack_num();
+            packer.unpack_num();
+            if doc_version >= 131088 { packer.unpack_num(); }
+            if doc_version >= 196610 { packer.unpack_num(); }
+        }
+
+        let url_len = packer.unpack_num();
+        if url_len > 0 {
+            // Consume the URL block so the next record aligns: 0x00 marker +
+            // hex-encoded size + 0x2C separator + `size` data bytes.
+            packer.consume_ptr_bytes();
+        }
+
+        // Drop degenerate records (e.g. the trailing url_image section
+        // misrouting) and convert to Director's 1-based inclusive range.
+        if end > start {
+            links.push((start + 1, end));
+        }
+    }
+    links
 }
 
 /// Parse Section 3 - Text Content
@@ -1041,6 +1104,41 @@ impl Packer {
     /// Unpack a single number from the packed data
     fn unpack_num(&mut self) -> i32 {
         self.unpack_num_debug(false)
+    }
+
+    /// Consume a packed pointer-bytes block and return its bytes (Paige
+    /// `pgUnpackPtrBytes`): a `0x00` marker, a hex-ASCII size, a `0x2C`
+    /// separator, then `size` raw data bytes. Used for hyperlink URL targets.
+    /// Returns the data bytes (may be empty) and advances `pos` past the block.
+    fn consume_ptr_bytes(&mut self) -> Vec<u8> {
+        if self.pos >= self.data.len() || self.data[self.pos] != 0 {
+            return Vec::new();
+        }
+        self.pos += 1; // 0x00 marker
+        // Hex-ASCII size (optional leading '-', digits 0-9/A-F).
+        let mut size: i32 = 0;
+        let mut negative = false;
+        if self.pos < self.data.len() && self.data[self.pos] == b'-' {
+            negative = true;
+            self.pos += 1;
+        }
+        while self.pos < self.data.len() {
+            let b = self.data[self.pos];
+            let digit = match b {
+                b'0'..=b'9' => (b - b'0') as i32,
+                b'A'..=b'F' => (b - b'A' + 10) as i32,
+                _ => break,
+            };
+            size = size * 16 + digit;
+            self.pos += 1;
+        }
+        if negative { size = -size; }
+        self.pos += 1; // 0x2C separator (the `+1` in PgUnpackHex's hexLen)
+        let size = size.max(0) as usize;
+        let end = (self.pos + size).min(self.data.len());
+        let bytes = self.data[self.pos..end].to_vec();
+        self.pos = end;
+        bytes
     }
 
     /// Debug version of unpack_num that can log details

--- a/vm-rust/src/director/enums.rs
+++ b/vm-rust/src/director/enums.rs
@@ -561,16 +561,21 @@ pub struct VectorShapeVertex {
     pub handle2_y: f32,
 }
 
-/// Which slot of a `VectorShapeVertex` a parsed FLSH point refers to.
-/// FLSH tags the points within the FIRST vertex with their symbol names
-/// (`#vertex`, `#handle1`, `#handle2`); subsequent vertices use opaque
-/// 4-byte hash keys. We learn the role-by-position layout from the first
-/// vertex and re-use it for the rest.
+/// Which slot of a vector-shape entry a parsed FLSH point refers to.
+/// FLSH keys each point by symbol: the FIRST time a symbol appears it is
+/// written by name (`#vertex`, `#handle1`, `#handle2`, `#newCurve`); every
+/// later use is an opaque reference `0x8000_000N` (N = order of first
+/// occurrence). We discriminate the two encodings by the high bit of the
+/// 4-byte field after the point's `0x02` type marker (a string length is
+/// always small; a reference always has bit 31 set) and build a symbol
+/// table as names are first seen.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum VertexRole {
     Vertex,
     Handle1,
     Handle2,
+    /// A `#newCurve` marker — starts a new sub-path/curve. Carries no vertex.
+    NewCurve,
     Unknown,
 }
 
@@ -631,6 +636,10 @@ pub struct VectorShapeInfo {
     pub reg_point_vertex: i32, // not persisted; default 0
     pub direct_to_stage: bool,
     pub origin_mode: String,   // "center" | "topLeft" | "point"
+    /// Number of `#newCurve` markers in the vertex list (sub-path breaks).
+    /// Director's `vertexList` ends with one `[#newCurve]` entry per extra
+    /// curve; ui_pratbubbla has 4 trailing markers.
+    pub new_curve_count: usize,
 }
 
 impl From<&[u8]> for VectorShapeInfo {
@@ -704,53 +713,54 @@ impl From<&[u8]> for VectorShapeInfo {
         // We learn the role-by-position from the first vertex and reuse
         // it for the rest (positional fallback works because every vertex
         // within one shape uses the same point ordering).
-        let num_vertices = read_u32(228) as usize;
-        let mut vertices: Vec<VectorShapeVertex> = Vec::with_capacity(num_vertices);
+        let num_entries = read_u32(228) as usize;
+        let mut vertices: Vec<VectorShapeVertex> = Vec::with_capacity(num_entries);
+        let mut new_curve_count = 0usize;
         let mut pos = 224 + 8; // skip list marker + count
-        let mut role_by_position: Vec<VertexRole> = Vec::new();
+        // Symbol table: index = reference low bits (`0x8000_000N` → N), value =
+        // the role first written by name at that index. Built as names appear.
+        let mut symbol_roles: Vec<VertexRole> = Vec::new();
 
-        for i in 0..num_vertices {
+        for _ in 0..num_entries {
             if pos + 8 > data.len() {
                 break;
             }
-            // Per-vertex header: type(4) + item_count(4)
+            // Per-entry header: type(4) + item_count(4). type 0x0a = vertex,
+            // 0x07 = #newCurve. The header type is authoritative: a #newCurve
+            // entry can have item_count 0 (an empty marker) or 1 (the named
+            // "newCurve" item), and parsing an empty one as a vertex would
+            // inject a spurious point(0,0) into the outline (a stray spike).
+            let entry_type = read_u32(pos);
             let item_count = read_u32(pos + 4) as usize;
             pos += 8;
 
             let mut vertex = (0i32, 0i32);
             let mut handle1 = (0i32, 0i32);
             let mut handle2 = (0i32, 0i32);
+            let mut is_new_curve = entry_type == 0x07;
 
-            for slot_idx in 0..item_count {
-                let (role, point) = if i == 0 {
-                    let (key_name, point) = parse_string_keyed_point(data, &mut pos);
-                    let role = match key_name.as_str() {
-                        "vertex" => VertexRole::Vertex,
-                        "handle1" => VertexRole::Handle1,
-                        "handle2" => VertexRole::Handle2,
-                        _ => VertexRole::Unknown,
-                    };
-                    role_by_position.push(role);
-                    (role, point)
-                } else {
-                    let (_key_hash, point) = parse_hash_keyed_point(data, &mut pos);
-                    let role = role_by_position
-                        .get(slot_idx)
-                        .copied()
-                        .unwrap_or(VertexRole::Unknown);
-                    (role, point)
-                };
-                assign_role(&mut vertex, &mut handle1, &mut handle2, role, point);
+            // Always parse the items so `pos` advances correctly, even for a
+            // #newCurve entry (whose item names the symbol on first use).
+            for _ in 0..item_count {
+                let (role, point) = parse_keyed_point(data, &mut pos, &mut symbol_roles);
+                match role {
+                    VertexRole::NewCurve => is_new_curve = true,
+                    _ => assign_role(&mut vertex, &mut handle1, &mut handle2, role, point),
+                }
             }
 
-            vertices.push(VectorShapeVertex {
-                x: vertex.0 as f32,
-                y: vertex.1 as f32,
-                handle1_x: handle1.0 as f32,
-                handle1_y: handle1.1 as f32,
-                handle2_x: handle2.0 as f32,
-                handle2_y: handle2.1 as f32,
-            });
+            if is_new_curve {
+                new_curve_count += 1;
+            } else {
+                vertices.push(VectorShapeVertex {
+                    x: vertex.0 as f32,
+                    y: vertex.1 as f32,
+                    handle1_x: handle1.0 as f32,
+                    handle1_y: handle1.1 as f32,
+                    handle2_x: handle2.0 as f32,
+                    handle2_y: handle2.1 as f32,
+                });
+            }
         }
 
         debug!(
@@ -789,13 +799,29 @@ impl From<&[u8]> for VectorShapeInfo {
             reg_point_vertex: 0,
             direct_to_stage,
             origin_mode,
+            new_curve_count,
         }
     }
 }
 
-/// Parse a string-keyed point entry: `type(4) + strlen(4) + string + datasize(4) + locV(4) + locH(4)`.
-/// FLSH stores points as (locV, locH) — QuickDraw .y/.x order. Returns (key_name, (x, y)).
-fn parse_string_keyed_point(data: &[u8], pos: &mut usize) -> (String, (i32, i32)) {
+/// Parse one keyed item, auto-detecting the key encoding.
+///
+/// Layout after the `0x02` type marker:
+///  - string-keyed (first use of a symbol): `strlen(4) + name [+ datasize(4) + locV(4) + locH(4)]`
+///  - reference-keyed (later uses):          `ref(4)=0x8000_000N [+ datasize(4) + locV(4) + locH(4)]`
+///
+/// We discriminate by bit 31 of that field (a length is small; a reference
+/// has bit 31 set). A newly-named symbol is appended to `symbol_roles` so a
+/// later `0x8000_000N` reference resolves to the same role. Coordinate-bearing
+/// items (#vertex/#handle1/#handle2) carry the trailing
+/// `datasize(4) + locV(4) + locH(4)`; the `#newCurve` marker does NOT — reading
+/// those phantom 12 bytes for it desyncs the rest of the list. FLSH stores the
+/// point as (locV, locH) — QuickDraw .y/.x order. Returns (role, (x, y)).
+fn parse_keyed_point(
+    data: &[u8],
+    pos: &mut usize,
+    symbol_roles: &mut Vec<VertexRole>,
+) -> (VertexRole, (i32, i32)) {
     let read_u32 = |p: usize| -> u32 {
         if p + 4 <= data.len() {
             u32::from_be_bytes([data[p], data[p + 1], data[p + 2], data[p + 3]])
@@ -807,46 +833,42 @@ fn parse_string_keyed_point(data: &[u8], pos: &mut usize) -> (String, (i32, i32)
         } else { 0 }
     };
 
-    *pos += 4;                                              // type marker (always 0x02)
-    let str_len = read_u32(*pos) as usize;
+    *pos += 4; // type marker (always 0x02)
+    let disc = read_u32(*pos);
     *pos += 4;
-    let key_name = if *pos + str_len <= data.len() {
-        String::from_utf8_lossy(&data[*pos..*pos + str_len]).to_string()
+    let role = if disc & 0x8000_0000 != 0 {
+        // Reference to a previously-named symbol.
+        let idx = (disc & 0x7FFF_FFFF) as usize;
+        symbol_roles.get(idx).copied().unwrap_or(VertexRole::Unknown)
     } else {
-        String::new()
+        // First use of a symbol: `disc` is the name length.
+        let str_len = disc as usize;
+        let key_name = if *pos + str_len <= data.len() {
+            String::from_utf8_lossy(&data[*pos..*pos + str_len]).to_string()
+        } else {
+            String::new()
+        };
+        *pos += str_len;
+        let role = match key_name.as_str() {
+            "vertex" => VertexRole::Vertex,
+            "handle1" => VertexRole::Handle1,
+            "handle2" => VertexRole::Handle2,
+            "newCurve" => VertexRole::NewCurve,
+            _ => VertexRole::Unknown,
+        };
+        symbol_roles.push(role);
+        role
     };
-    *pos += str_len;
-    *pos += 4;                                              // datasize (always 8)
+    // The #newCurve marker has no coordinate payload — stop after the key.
+    if role == VertexRole::NewCurve {
+        return (role, (0, 0));
+    }
+    *pos += 4; // datasize (always 8)
     let loc_v = read_i32(*pos);
     *pos += 4;
     let loc_h = read_i32(*pos);
     *pos += 4;
-    (key_name, (loc_h, loc_v))
-}
-
-/// Parse a hash-keyed point entry: `type(4) + hash(4) + datasize(4) + locV(4) + locH(4)`.
-/// Returns (key_hash, (x, y)) so the caller can dispatch via the hash→role table.
-fn parse_hash_keyed_point(data: &[u8], pos: &mut usize) -> (u32, (i32, i32)) {
-    let read_u32 = |p: usize| -> u32 {
-        if p + 4 <= data.len() {
-            u32::from_be_bytes([data[p], data[p + 1], data[p + 2], data[p + 3]])
-        } else { 0 }
-    };
-    let read_i32 = |p: usize| -> i32 {
-        if p + 4 <= data.len() {
-            i32::from_be_bytes([data[p], data[p + 1], data[p + 2], data[p + 3]])
-        } else { 0 }
-    };
-
-    *pos += 4;                                              // type marker (always 0x02)
-    let key_hash = read_u32(*pos);
-    *pos += 4;
-    *pos += 4;                                              // datasize (always 8)
-    let loc_v = read_i32(*pos);
-    *pos += 4;
-    let loc_h = read_i32(*pos);
-    *pos += 4;
-    (key_hash, (loc_h, loc_v))
+    (role, (loc_h, loc_v))
 }
 
 fn assign_role(
@@ -860,7 +882,7 @@ fn assign_role(
         VertexRole::Vertex => *vertex = point,
         VertexRole::Handle1 => *handle1 = point,
         VertexRole::Handle2 => *handle2 = point,
-        VertexRole::Unknown => { /* ignored */ }
+        VertexRole::NewCurve | VertexRole::Unknown => { /* ignored */ }
     }
 }
 

--- a/vm-rust/src/director/lingo/datum.rs
+++ b/vm-rust/src/director/lingo/datum.rs
@@ -59,6 +59,7 @@ pub enum DatumType {
     Transform3d,
     HavokObjectRef,
     PhysXObjectRef,
+    VectorVertexRef,
 }
 
 #[derive(Clone, PartialEq, FromPrimitive)]
@@ -254,6 +255,12 @@ pub enum Datum {
     Transform3d([f64; 16]),
     HavokObjectRef(HavokObjectRef),
     PhysXObjectRef(PhysXObjectRef),
+    /// A writable reference to a single vertex of a `#vectorShape` member,
+    /// produced by `getPropRef` for `member.vertex[i]`. Carries the owning
+    /// member and the 0-based vertex index so `.handle1` / `.handle2` /
+    /// `.vertex` reads and writes resolve straight back into the member's
+    /// vertex list (Director 11.5 Scripting Dictionary, `vertex`).
+    VectorVertexRef(CastMemberRef, usize),
 }
 
 impl DatumType {
@@ -307,6 +314,7 @@ impl DatumType {
             DatumType::Transform3d => "transform",
             DatumType::HavokObjectRef => "havok_object_ref",
             DatumType::PhysXObjectRef => "physx_object_ref",
+            DatumType::VectorVertexRef => "vector_vertex_ref",
         }
     }
 }
@@ -358,6 +366,7 @@ impl Datum {
             Datum::Transform3d(_) => DatumType::Transform3d,
             Datum::HavokObjectRef(_) => DatumType::HavokObjectRef,
             Datum::PhysXObjectRef(_) => DatumType::PhysXObjectRef,
+            Datum::VectorVertexRef(..) => DatumType::VectorVertexRef,
         }
     }
 

--- a/vm-rust/src/io/encoding.rs
+++ b/vm-rust/src/io/encoding.rs
@@ -126,3 +126,73 @@ pub fn decode_text_auto(bytes: &[u8]) -> String {
         Err(_) => decode_win1252(bytes),
     }
 }
+
+/// Mac Roman byte → Unicode codepoint table for bytes 0x80-0xFF.
+///
+/// Director historically stored Lingo SCRIPT string literals (the Lscr
+/// literal store) in Mac Roman regardless of the authoring/packaging
+/// platform — Director originated on the Mac and kept Mac Roman as the
+/// canonical script-text encoding. So a Windows-packaged (XFIR) movie can
+/// still carry Mac Roman bytes in its script literals: e.g. the section
+/// sign `§` is byte 0xA4 in Mac Roman (it is `¤` in Win-1252). The
+/// reference decompiler (ProjectorRays) likewise decodes Lscr strings as
+/// Mac Roman. Member/field text is a separate concern (UTF-8 or Win-1252)
+/// and is NOT decoded with this table.
+///
+/// Values follow Apple's canonical `ROMAN.TXT` mapping (post-euro: 0xDB =
+/// €). 0xF0 is the Apple-logo PUA codepoint U+F8FF.
+const MACROMAN_HIGH: [char; 128] = [
+    '\u{00C4}', '\u{00C5}', '\u{00C7}', '\u{00C9}', '\u{00D1}', '\u{00D6}', '\u{00DC}', '\u{00E1}', // 80-87
+    '\u{00E0}', '\u{00E2}', '\u{00E4}', '\u{00E3}', '\u{00E5}', '\u{00E7}', '\u{00E9}', '\u{00E8}', // 88-8F
+    '\u{00EA}', '\u{00EB}', '\u{00ED}', '\u{00EC}', '\u{00EE}', '\u{00EF}', '\u{00F1}', '\u{00F3}', // 90-97
+    '\u{00F2}', '\u{00F4}', '\u{00F6}', '\u{00F5}', '\u{00FA}', '\u{00F9}', '\u{00FB}', '\u{00FC}', // 98-9F
+    '\u{2020}', '\u{00B0}', '\u{00A2}', '\u{00A3}', '\u{00A7}', '\u{2022}', '\u{00B6}', '\u{00DF}', // A0-A7
+    '\u{00AE}', '\u{00A9}', '\u{2122}', '\u{00B4}', '\u{00A8}', '\u{2260}', '\u{00C6}', '\u{00D8}', // A8-AF
+    '\u{221E}', '\u{00B1}', '\u{2264}', '\u{2265}', '\u{00A5}', '\u{00B5}', '\u{2202}', '\u{2211}', // B0-B7
+    '\u{220F}', '\u{03C0}', '\u{222B}', '\u{00AA}', '\u{00BA}', '\u{03A9}', '\u{00E6}', '\u{00F8}', // B8-BF
+    '\u{00BF}', '\u{00A1}', '\u{00AC}', '\u{221A}', '\u{0192}', '\u{2248}', '\u{2206}', '\u{00AB}', // C0-C7
+    '\u{00BB}', '\u{2026}', '\u{00A0}', '\u{00C0}', '\u{00C3}', '\u{00D5}', '\u{0152}', '\u{0153}', // C8-CF
+    '\u{2013}', '\u{2014}', '\u{201C}', '\u{201D}', '\u{2018}', '\u{2019}', '\u{00F7}', '\u{25CA}', // D0-D7
+    '\u{00FF}', '\u{0178}', '\u{2044}', '\u{20AC}', '\u{2039}', '\u{203A}', '\u{FB01}', '\u{FB02}', // D8-DF
+    '\u{2021}', '\u{00B7}', '\u{201A}', '\u{201E}', '\u{2030}', '\u{00C2}', '\u{00CA}', '\u{00C1}', // E0-E7
+    '\u{00CB}', '\u{00C8}', '\u{00CD}', '\u{00CE}', '\u{00CF}', '\u{00CC}', '\u{00D3}', '\u{00D4}', // E8-EF
+    '\u{F8FF}', '\u{00D2}', '\u{00DA}', '\u{00DB}', '\u{00D9}', '\u{0131}', '\u{02C6}', '\u{02DC}', // F0-F7
+    '\u{00AF}', '\u{02D8}', '\u{02D9}', '\u{02DA}', '\u{00B8}', '\u{02DD}', '\u{02DB}', '\u{02C7}', // F8-FF
+];
+
+/// Decode a single Mac Roman byte into its Unicode `char`.
+#[inline]
+pub fn macroman_byte_to_char(byte: u8) -> char {
+    if byte < 0x80 {
+        byte as char
+    } else {
+        MACROMAN_HIGH[(byte - 0x80) as usize]
+    }
+}
+
+/// Decode a slice of Mac Roman bytes into a Rust `String`.
+pub fn decode_macroman(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len());
+    for &b in bytes {
+        s.push(macroman_byte_to_char(b));
+    }
+    s
+}
+
+/// Like [`decode_text_auto`] but falls back to **Mac Roman** instead of
+/// Windows-1252 when the bytes aren't valid UTF-8. Use this for Lingo
+/// script string literals, which Director stores in Mac Roman on every
+/// platform (see [`MACROMAN_HIGH`]). Pure-ASCII and genuine UTF-8 (D11+
+/// Unicode authoring) still decode correctly via the strict-UTF-8 first
+/// pass; only the single-byte fallback differs.
+pub fn decode_text_auto_macroman(bytes: &[u8]) -> String {
+    let bytes = if bytes.starts_with(&[0xEF, 0xBB, 0xBF]) {
+        &bytes[3..]
+    } else {
+        bytes
+    };
+    match std::str::from_utf8(bytes) {
+        Ok(s) => s.to_owned(),
+        Err(_) => decode_macroman(bytes),
+    }
+}

--- a/vm-rust/src/io/reader.rs
+++ b/vm-rust/src/io/reader.rs
@@ -2,13 +2,14 @@ use std::io::Read;
 
 use binary_reader::BinaryReader;
 
-use crate::io::encoding::decode_text_auto;
+use crate::io::encoding::{decode_text_auto, decode_text_auto_macroman};
 
 pub trait DirectorExt {
     fn read_var_int(&mut self) -> Result<i32, std::io::Error>;
     fn read_zlib_bytes(&mut self, length: usize) -> Result<Vec<u8>, std::io::Error>;
     fn read_pascal_string(&mut self) -> Result<String, std::io::Error>;
     fn read_string(&mut self, len: usize) -> Result<String, std::io::Error>;
+    fn read_string_macroman(&mut self, len: usize) -> Result<String, std::io::Error>;
     fn read_apple_float_80(&mut self) -> Result<f64, String>;
     fn eof(&self) -> bool;
     fn bytes_left(&self) -> usize;
@@ -66,6 +67,17 @@ impl DirectorExt for BinaryReader {
         // path. Older movies keep working; D11 Unicode authoring works.
         let bytes = self.read_bytes(len).unwrap();
         return Ok(decode_text_auto(&bytes));
+    }
+
+    fn read_string_macroman(&mut self, len: usize) -> Result<String, std::io::Error> {
+        // Lingo SCRIPT string literals are stored in Mac Roman on every
+        // platform (Director's canonical script-text encoding), so a
+        // Windows-packaged movie can still carry e.g. `§` as byte 0xA4
+        // (Mac Roman) which Win-1252 would mis-read as `¤`. Decode UTF-8
+        // first (D11+ Unicode), then fall back to Mac Roman rather than
+        // Win-1252. See `decode_text_auto_macroman`.
+        let bytes = self.read_bytes(len).unwrap();
+        return Ok(decode_text_auto_macroman(&bytes));
     }
 
     fn read_apple_float_80(&mut self) -> Result<f64, String> {

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -2196,6 +2196,12 @@ fn concrete_datum_to_js_bridge(datum: &Datum, player: &DirPlayer, depth: u8) -> 
             map.str_set("type", &safe_js_string("physxObject"));
             map.str_set("value", &safe_js_string(&format!("{}(\"{}\")", px_ref.object_type, px_ref.name)));
         }
+        Datum::VectorVertexRef(member_ref, index) => {
+            map.str_set("type", &safe_js_string("vectorVertexRef"));
+            map.str_set("value", &safe_js_string(&format!(
+                "vertex[{}] of member({}, {})", index + 1, member_ref.cast_member, member_ref.cast_lib
+            )));
+        }
     }
     return map.to_js_object();
 }

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -105,21 +105,23 @@ fn director_blend_ink0(
     src_alpha: f32,
     blend: f32,
 ) -> (u8, u8, u8) {
-    // Premultiply source by its own alpha
-    let sr = src.0 as f32 * src_alpha;
-    let sg = src.1 as f32 * src_alpha;
-    let sb = src.2 as f32 * src_alpha;
-
-    let dr = dst.0 as f32;
-    let dg = dst.1 as f32;
-    let db = dst.2 as f32;
-
-    let inv = 1.0 - blend;
-
+    // Straight-alpha source-over compositing: the source pixel's own alpha and
+    // the #blend parameter combine into ONE effective coverage, and the
+    // destination's complementary weight must use that SAME coverage.
+    //
+    // The previous formula weighted dst by (1 - blend) while only premultiplying
+    // src by src_alpha — so a partial-alpha (anti-aliased) edge at e.g.
+    // src_alpha=0.5, blend=1.0 produced `src*0.5` with ZERO destination
+    // contribution, i.e. the edge darkened toward black (a halo) instead of
+    // blending with what's behind it. spectral-wizard's splashName title
+    // fade-in (`copyPixels(..., [#blend: theBlendItems])`, blend ramping 0→100)
+    // showed that black fringe against the scrolling menu background.
+    let eff = (src_alpha * blend).clamp(0.0, 1.0);
+    let inv = 1.0 - eff;
     (
-        (dr * inv + sr * blend).round().clamp(0.0, 255.0) as u8,
-        (dg * inv + sg * blend).round().clamp(0.0, 255.0) as u8,
-        (db * inv + sb * blend).round().clamp(0.0, 255.0) as u8,
+        (dst.0 as f32 * inv + src.0 as f32 * eff).round().clamp(0.0, 255.0) as u8,
+        (dst.1 as f32 * inv + src.1 as f32 * eff).round().clamp(0.0, 255.0) as u8,
+        (dst.2 as f32 * inv + src.2 as f32 * eff).round().clamp(0.0, 255.0) as u8,
     )
 }
 
@@ -1208,7 +1210,7 @@ impl Bitmap {
     }
 
     /// Draw an anti-aliased thick line segment using signed distance from the line.
-    fn draw_line_aa(
+    pub(crate) fn draw_line_aa(
         &mut self,
         x1: f32, y1: f32,
         x2: f32, y2: f32,
@@ -1253,7 +1255,7 @@ impl Bitmap {
     }
 
     /// Draw an anti-aliased filled circle for round line joins/caps.
-    fn draw_circle_aa(
+    pub(crate) fn draw_circle_aa(
         &mut self,
         cx: f32, cy: f32,
         radius: f32,
@@ -1811,7 +1813,24 @@ impl Bitmap {
                 if sx < 0 || sx >= src.width as i32 || sy < 0 || sy >= src.height as i32 {
                     continue;
                 }
-                let (r, g, bl, _) = src.get_pixel_color_with_alpha(palettes, sx as u16, sy as u16);
+                let (r, g, bl, a) = src.get_pixel_color_with_alpha(palettes, sx as u16, sy as u16);
+                // Honor the source's per-pixel alpha for 32-bit useAlpha images,
+                // otherwise the rotated/warped blit paints the transparent
+                // background as opaque. The player's rope-swing frames
+                // (hero1_s1/s2 — 32-bit, useAlpha) are drawn through this quad
+                // path; without this their black background showed as a solid
+                // box around the hero. Fully transparent → skip; partial →
+                // alpha-blend over the destination; opaque → straight copy.
+                if src.use_alpha {
+                    if a == 0 {
+                        continue;
+                    } else if a < 255 {
+                        let dst = self.get_pixel_color(palettes, x as u16, y as u16);
+                        let blended = blend_color_alpha(dst, (r, g, bl), a as f32 / 255.0);
+                        self.set_pixel(x, y, blended, palettes);
+                        continue;
+                    }
+                }
                 self.set_pixel(x, y, (r, g, bl), palettes);
             }
         }
@@ -2465,10 +2484,19 @@ impl Bitmap {
 
                     let dst_color = if !dst_palette_cache.is_empty() { self.get_pixel_color_fast(&dst_palette_cache, dst_x as u16, dst_y as u16) } else { self.get_pixel_color(palettes, dst_x as u16, dst_y as u16) };
 
-                    let blended = if alpha >= 0.999 {
+                    // Honor the per-pixel source alpha for use_alpha bitmaps,
+                    // combined with the #blend factor. Without this a soft
+                    // (semi-transparent) glow — e.g. the rune/coin shine in
+                    // `inventory_goldBall*`, drawn with ink 36 — rendered as a
+                    // hard opaque grey halo because only the whole-blit #blend
+                    // was applied. Non-alpha 32-bit bitmaps keep src_a = 1.0,
+                    // so their color-key behavior is unchanged.
+                    let src_a = if src.use_alpha { a as f32 / 255.0 } else { 1.0 };
+                    let eff = src_a * alpha;
+                    let blended = if eff >= 0.999 {
                         src_color
                     } else {
-                        blend_color_alpha(dst_color, src_color, alpha)
+                        blend_color_alpha(dst_color, src_color, eff)
                     };
 
                     self.set_pixel_fast(dst_x, dst_y, blended, &dst_palette_cache);

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -22,7 +22,7 @@ use super::{
     },
     cast_member::{
         BitmapMember, CastMember, CastMemberType, FieldMember, PaletteMember, SoundMember,
-        TextMember,
+        TextMember, VectorShapeMember,
     },
     datum_ref::DatumRef,
     handlers::datum_handlers::cast_member_ref::CastMemberRefHandlers,
@@ -395,7 +395,9 @@ impl CastLib {
         member_type: &str,
         bitmap_manager: &mut BitmapManager,
     ) -> Result<CastMemberRef, ScriptError> {
-        let member = match member_type {
+        // Director symbols are case-insensitive (`new(#vectorShape)` ==
+        // `new(#vectorshape)`), so match member-type names through `match_ci!`.
+        let member = match_ci!(member_type, {
             "field" => Ok(CastMember::new(
                 number,
                 CastMemberType::Field(FieldMember::new()),
@@ -424,10 +426,18 @@ impl CastLib {
                         info: BitmapInfo::default(),
                     }),
                 ))
-            }
+            },
             "palette" => Ok(CastMember::new(
                 number,
                 CastMemberType::Palette(PaletteMember::new()),
+            )),
+            // `new(#vectorShape)` creates an empty vector shape; the script
+            // populates vertices via `addVertex` and sets fill/stroke/gradient
+            // props (Director 11.5 Scripting Dictionary). spectral-wizard's
+            // parent_grad builds gradient backgrounds this way at runtime.
+            "vectorshape" => Ok(CastMember::new(
+                number,
+                CastMemberType::VectorShape(VectorShapeMember::new()),
             )),
             // `new(#sound, castLib)` creates an empty sound member; its media is
             // populated later, typically via `importFileInto` (Director 11.5
@@ -454,7 +464,7 @@ impl CastLib {
                 "Cannot create member of type {}",
                 member_type
             ))),
-        }?;
+        })?;
         self.insert_member(number, member);
         JsApi::dispatch_cast_member_list_changed(self.number);
         Ok(cast_member_ref(self.number as i32, number as i32))

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -170,6 +170,10 @@ pub struct TextMember {
     /// given text offset is the one whose `position` is the largest
     /// value ≤ that offset. See `line_spacing_at()` helper.
     pub par_runs: Vec<crate::director::chunks::xmedia_styled_text::ParRun>,
+    /// Hyperlink ranges from XMED Section 0x0129, as 1-based inclusive
+    /// `[startChar, endChar]` pairs (Director's `the hyperlinks of member`
+    /// format). Empty for members with no links.
+    pub hyperlinks: Vec<(i32, i32)>,
     pub info: Option<TextInfo>,
     /// Embedded 3D world for Director's "3D Text" feature (text extrusion).
     /// Lazily initialized when 3D methods (.model(), .camera(), etc.) are called.
@@ -365,6 +369,7 @@ impl TextMember {
             html_styled_spans: Vec::new(),
             par_infos: Vec::new(),
             par_runs: Vec::new(),
+            hyperlinks: Vec::new(),
             info: None,
             w3d: None,
             sel_start: 0,
@@ -694,6 +699,10 @@ pub struct VectorShapeMember {
     pub reg_point_vertex: i32,    // default 0     (FLSH offset TBD)
     pub direct_to_stage: bool,    // default false (FLSH offset TBD)
     pub origin_mode: String,      // default "center" (FLSH offset TBD)
+    /// Count of trailing `#newCurve` markers in the vertex list (sub-path
+    /// breaks). Preserved so the `vertexList` getter round-trips Director's
+    /// output (e.g. ui_pratbubbla has 4).
+    pub new_curve_count: usize,
 }
 
 impl VectorShapeMember {
@@ -720,6 +729,80 @@ impl VectorShapeMember {
     /// the bitmap that backs `member.image`.
     pub fn bbox_width(&self) -> f32 { self.bbox_right - self.bbox_left }
     pub fn bbox_height(&self) -> f32 { self.bbox_bottom - self.bbox_top }
+
+    /// An empty vector shape, as produced by Lingo `new(#vectorShape)`
+    /// (Director 11.5 Scripting Dictionary). No vertices yet; the script
+    /// populates them via `addVertex` and sets fill/stroke/gradient props.
+    /// `member_width`/`member_height` stay 0 so `width()`/`height()` fall
+    /// back to the (vertex-derived) bbox once vertices are added.
+    pub fn new() -> VectorShapeMember {
+        VectorShapeMember {
+            stroke_color: (0, 0, 0),
+            fill_color: (0, 0, 0),
+            bg_color: (255, 255, 255),
+            end_color: (0, 0, 0),
+            stroke_width: 1.0,
+            fill_mode: 0, // #none
+            closed: false,
+            vertices: Vec::new(),
+            bbox_left: 0.0,
+            bbox_top: 0.0,
+            bbox_right: 0.0,
+            bbox_bottom: 0.0,
+            member_width: 0,
+            member_height: 0,
+            reg_point: (0, 0),
+            gradient_type: "linear".to_string(),
+            fill_scale: 100.0,
+            fill_direction: 0.0,
+            fill_offset: (0, 0),
+            fill_cycles: 1,
+            scale_mode: "showAll".to_string(),
+            scale: 100.0,
+            antialias: true,
+            center_reg_point: false,
+            reg_point_vertex: 0,
+            direct_to_stage: false,
+            origin_mode: "center".to_string(),
+            new_curve_count: 0,
+        }
+    }
+
+    /// Recompute the bounding box from the current vertices + Bezier
+    /// control points + stroke padding. Must be called after any runtime
+    /// mutation of `vertices` (e.g. `addVertex`) so the `.image` rasterizer
+    /// and `width()`/`height()` fallbacks stay correct. Mirrors the bbox
+    /// computation in `From<VectorShapeInfo>`.
+    pub fn recompute_bbox(&mut self) {
+        let mut left = f32::MAX;
+        let mut top = f32::MAX;
+        let mut right = f32::MIN;
+        let mut bottom = f32::MIN;
+        for v in &self.vertices {
+            for &(cx, cy) in &[
+                (v.x, v.y),
+                (v.x + v.handle1_x, v.y + v.handle1_y),
+                (v.x + v.handle2_x, v.y + v.handle2_y),
+            ] {
+                left = left.min(cx);
+                top = top.min(cy);
+                right = right.max(cx);
+                bottom = bottom.max(cy);
+            }
+        }
+        if self.vertices.is_empty() {
+            self.bbox_left = 0.0;
+            self.bbox_top = 0.0;
+            self.bbox_right = 0.0;
+            self.bbox_bottom = 0.0;
+            return;
+        }
+        let pad = self.stroke_width / 2.0;
+        self.bbox_left = left - pad;
+        self.bbox_top = top - pad;
+        self.bbox_right = right + pad;
+        self.bbox_bottom = bottom + pad;
+    }
 }
 
 impl From<crate::director::enums::VectorShapeInfo> for VectorShapeMember {
@@ -789,6 +872,7 @@ impl From<crate::director::enums::VectorShapeInfo> for VectorShapeMember {
             reg_point_vertex: info.reg_point_vertex,
             direct_to_stage: info.direct_to_stage,
             origin_mode: info.origin_mode,
+            new_curve_count: info.new_curve_count,
         }
     }
 }
@@ -3912,6 +3996,7 @@ impl CastMember {
             tab_stops: Vec::new(),
             par_infos: styled_text.par_infos.clone(),
             par_runs: styled_text.par_runs.clone(),
+            hyperlinks: styled_text.hyperlinks.clone(),
             html_styled_spans: styled_text.styled_spans,
             info: Some(text_info),
             w3d: None,

--- a/vm-rust/src/player/datum_formatting.rs
+++ b/vm-rust/src/player/datum_formatting.rs
@@ -196,6 +196,9 @@ pub fn format_concrete_datum_with_depth(datum: &Datum, player: &DirPlayer, depth
         Datum::PhysXObjectRef(pr) => {
             format!("{}(\"{}\")", pr.object_type, pr.name)
         }
+        Datum::VectorVertexRef(member_ref, index) => {
+            format!("vertex[{}] of member({}, {})", index + 1, member_ref.cast_member, member_ref.cast_lib)
+        }
     }
 }
 

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -204,12 +204,25 @@ pub fn eval_lingo_pair_static(pair: Pair<Rule>) -> Result<DatumRef, ScriptError>
         Rule::rgb_num_color => {
             let mut inner = pair.into_inner();
             reserve_player_mut(|player| {
-                let r = inner.next().ok_or_else(|| ScriptError::new("Expected red component".to_string()))?.as_str().parse::<u8>()
-                    .map_err(|e| ScriptError::new(format!("Invalid red: {}", e)))?;
-                let g = inner.next().ok_or_else(|| ScriptError::new("Expected green component".to_string()))?.as_str().parse::<u8>()
-                    .map_err(|e| ScriptError::new(format!("Invalid green: {}", e)))?;
-                let b = inner.next().ok_or_else(|| ScriptError::new("Expected blue component".to_string()))?.as_str().parse::<u8>()
-                    .map_err(|e| ScriptError::new(format!("Invalid blue: {}", e)))?;
+                // Trim each component: Director accepts whitespace inside the
+                // parens, e.g. `rgb( 255, 255, 255 )` (spectral-wizard's
+                // customHyperlink behavior params are authored this way). Parse
+                // as i32 then clamp to 0..=255 to tolerate negatives / >255,
+                // matching the LingoExpr-building rgb parser below.
+                let mut comp = |label: &str| -> Result<u8, ScriptError> {
+                    let s = inner
+                        .next()
+                        .ok_or_else(|| ScriptError::new(format!("Expected {} component", label)))?
+                        .as_str()
+                        .trim();
+                    let v = s
+                        .parse::<i32>()
+                        .map_err(|e| ScriptError::new(format!("Invalid {}: {}", label, e)))?;
+                    Ok(v.clamp(0, 255) as u8)
+                };
+                let r = comp("red")?;
+                let g = comp("green")?;
+                let b = comp("blue")?;
                 Ok(player.alloc_datum(Datum::ColorRef(ColorRef::Rgb(r, g, b))))
             })
         }

--- a/vm-rust/src/player/font/mod.rs
+++ b/vm-rust/src/player/font/mod.rs
@@ -1972,7 +1972,15 @@ pub fn get_text_index_at_pos(text: &str, params: &DrawTextParams, x: i32, y: i32
             // conversion — making `locToCharPos < text.length` FALSE and
             // breaking PageNext's "is there more content below?" probe at
             // scrollTop=0.
-            if y >= line_y && y < line_y + line_step && x < line_width {
+            //
+            // No `x < line_width` guard: if y is on this line we've already
+            // passed every char (the per-char checks return first while
+            // x < line_width), so reaching the \r means x is at/past the end
+            // of the line's text — resolve to this line's end rather than
+            // falling through to the whole member's last char. Otherwise a
+            // hover in the empty space right of a short line (help_menu's menu
+            // words) maps to the final link (FAQ).
+            if y >= line_y && y < line_y + line_step {
                 return index;
             }
             line_width = 0;

--- a/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
@@ -21,6 +21,23 @@ impl BitmapDatumHandlers {
         handler_name: &str,
         args: &Vec<DatumRef>,
     ) -> Result<DatumRef, ScriptError> {
+        // If a mutating op targets the persistent stage framebuffer, mark it
+        // dirty so the renderer begins compositing it over the sprite output
+        // (the "imaging Lingo" engine pattern — see stage.rs `image` getter).
+        if matches!(
+            handler_name,
+            "fill" | "draw" | "setPixel" | "copyPixels" | "applyFilter"
+                | "setAlpha" | "floodFill"
+        ) {
+            reserve_player_mut(|player| {
+                if let Ok(bref) = player.get_datum(datum).to_bitmap_ref() {
+                    if player.stage_image == Some(*bref) {
+                        player.stage_image_dirty = true;
+                    }
+                }
+                Ok::<(), ScriptError>(())
+            })?;
+        }
         match handler_name {
             "fill" => Self::fill(datum, args),
             "draw" => Self::draw(datum, args),
@@ -677,7 +694,7 @@ impl BitmapDatumHandlers {
     pub fn fill(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let bitmap = player.get_datum(datum);
-            let (rect_i32, color_ref) = if args.len() == 2 {
+            let (rect_i32, color_ref, shape) = if args.len() == 2 {
                 let (rect_vals, _flags) = player.get_datum(&args[0]).to_rect_inline()?;
                 let params = player.get_datum(&args[1]);
                 let (color, shape) = match params {
@@ -713,17 +730,12 @@ impl BitmapDatumHandlers {
                     }
                 };
                 
-                if shape != "rect" {
-                    log::warn!("Unsupported shapeType '{}' for bitmap fill handler, skipping", shape);
-                    return Ok(datum.clone()); // Silently ignore unsupported shape types for now
-                }
-
                 let x1 = rect_vals[0] as i32;
                 let y1 = rect_vals[1] as i32;
                 let x2 = rect_vals[2] as i32;
                 let y2 = rect_vals[3] as i32;
 
-                ((x1, y1, x2, y2), color)
+                ((x1, y1, x2, y2), color, shape)
             } else if args.len() == 5 {
                 let x = player.get_datum(&args[0]).int_value()?;
                 let y = player.get_datum(&args[1]).int_value()?;
@@ -747,7 +759,7 @@ impl BitmapDatumHandlers {
                         ))
                     }
                 };
-                ((x, y, width, height), color)
+                ((x, y, width, height), color, "rect".to_string())
             } else {
                 return Err(ScriptError::new(
                     "Invalid number of arguments for fill".to_string(),
@@ -767,7 +779,17 @@ impl BitmapDatumHandlers {
                 bitmap.original_bit_depth,
             );
             let bitmap = player.bitmap_manager.get_bitmap_mut(*bitmap_ref).unwrap();
-            bitmap.fill_rect(x1, y1, x2, y2, color, &palettes, 1.0);
+            // `image.fill(rect, [#color:.., #shapeType:..])` supports filled
+            // rect / oval / roundRect (Director 11.5 Scripting Dictionary).
+            // The worldMap reveals completed levels by punching white #oval
+            // holes into a grey overlay (`wmGreyBuffer.fill(dR, [#color:
+            // rgb(255,255,255), #shapeType: #oval])`) then keying them out
+            // with ink 36 — so without oval support the whole map stays grey.
+            match shape.as_str() {
+                "oval" => bitmap.fill_ellipse(x1, y1, x2, y2, color, &palettes, 1.0),
+                "roundRect" => bitmap.fill_round_rect(x1, y1, x2, y2, 12, color, &palettes, 1.0),
+                _ => bitmap.fill_rect(x1, y1, x2, y2, color, &palettes, 1.0),
+            }
             Ok(datum.clone())
         })
     }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
@@ -175,27 +175,20 @@ impl FieldMemberHandlers {
             // the field scrolls up." Fugue No.4's `fixSplitLines` passes
             // fractional amounts (±0.1) for sub-line nudges to align the
             // scroll position to a clean line boundary.
+            // `member.scrollByLine(amount)` / `member.scrollByPage(amount)` —
+            // Director 11.5 Scripting Dictionary p.618/619. Shared core in
+            // text.rs so field and text members (and the global builtin forms)
+            // behave identically.
             "scrollByLine" => {
                 let amount = player.get_datum(&args[0]).to_float()?;
                 let member_ref = player.get_datum(datum).to_member_ref()?;
-                let line_h = {
-                    let member = player.movie.cast_manager.find_member_by_ref(&member_ref).unwrap();
-                    let field = member.member_type.as_field().unwrap();
-                    if field.fixed_line_space > 0 {
-                        field.fixed_line_space as f64
-                    } else if field.font_size > 0 {
-                        field.font_size as f64
-                    } else {
-                        12.0
-                    }
-                };
-                let delta_px = (amount * line_h).round() as i32;
-                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
-                    if let Some(field) = member.member_type.as_field_mut() {
-                        let new_st = (field.scroll_top as i32 + delta_px).max(0) as u16;
-                        field.scroll_top = new_st;
-                    }
-                }
+                super::text::scroll_member_by_lines(player, &member_ref, amount);
+                Ok(DatumRef::Void)
+            }
+            "scrollByPage" => {
+                let amount = player.get_datum(&args[0]).to_float()?;
+                let member_ref = player.get_datum(datum).to_member_ref()?;
+                super::text::scroll_member_by_pages(player, &member_ref, amount);
                 Ok(DatumRef::Void)
             }
             // Director 11.5 Scripting Dictionary p.443 / p.449.
@@ -250,7 +243,49 @@ impl FieldMemberHandlers {
             "width" => Ok(Datum::Int(field.width as i32)),
             "alignment" => Ok(Datum::String(field.alignment.to_owned())),
             "wordWrap" => Ok(datum_bool(field.word_wrap)),
-            "fixedLineSpace" | "lineHeight" => Ok(Datum::Int(field.fixed_line_space as i32)),
+            // `the fixedLineSpace` is the raw fixed line-spacing override
+            // (0 = "use the font's natural line height").
+            "fixedLineSpace" => Ok(Datum::Int(field.fixed_line_space as i32)),
+            // `the lineHeight` is the ACTUAL rendered line height: the fixed
+            // override when set, otherwise derived from the font/size. A
+            // runtime `new(#field)` has fixedLineSpace = 0, so returning the
+            // raw 0 here made spectral-wizard's getDefaultFixedLineSpace return
+            // -1 and collapse every dialog box to a sliver. (Director 11.5
+            // Scripting Dictionary distinguishes lineHeight from fixedLineSpace.)
+            "lineHeight" => {
+                if field.fixed_line_space > 0 {
+                    Ok(Datum::Int(field.fixed_line_space as i32))
+                } else {
+                    let font_name = field.font.clone();
+                    let font_size = Some(field.font_size);
+                    let top_spacing = field.top_spacing;
+                    // `field` (and its `member` borrow of cast_manager) is no
+                    // longer used past this point in the arm, so the font
+                    // manager can be borrowed — same pattern as rect/height.
+                    let font = if !font_name.is_empty() {
+                        player.font_manager.get_font_with_cast_and_bitmap(
+                            &font_name,
+                            &player.movie.cast_manager,
+                            &mut player.bitmap_manager,
+                            font_size,
+                            None,
+                        )
+                    } else {
+                        None
+                    };
+                    let font = if let Some(f) = font {
+                        f
+                    } else {
+                        player.font_manager.get_system_font().ok_or_else(|| {
+                            ScriptError::new("System font not available".to_string())
+                        })?
+                    };
+                    // Measure a single line (tall ascender + descender) at the
+                    // natural line height (fixed_line_space = 0).
+                    let (_w, h) = measure_text("Wg", &font, None, 0, top_spacing, 0);
+                    Ok(Datum::Int(h as i32))
+                }
+            }
             "topSpacing" => Ok(Datum::Int(field.top_spacing as i32)),
             "boxType" => Ok(Datum::String(field.box_type.to_owned())),
             "antialias" => Ok(datum_bool(field.anti_alias)),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -32,6 +32,85 @@ pub(crate) fn line_step_px(fixed_line_space: u16, font_size: u16) -> i32 {
     if fixed_line_space > 0 { fixed_line_space as i32 } else { font_size as i32 }
 }
 
+/// Effective line height (px) used for scroll math on a field or text member:
+/// the fixed-line-space override, else the font size, else 12. Mirrors the
+/// fallback the field `scrollByLine` path used before it was shared.
+pub(crate) fn scroll_line_height(fixed_line_space: u16, font_size: u16) -> i32 {
+    if fixed_line_space > 0 {
+        fixed_line_space as i32
+    } else if font_size > 0 {
+        font_size as i32
+    } else {
+        12
+    }
+}
+
+/// Read `(fixed_line_space, font_size, height_px)` from a field or text member,
+/// or `None` for any other member type. `height_px` is the member's box height
+/// (used to size a "page" for `scrollByPage`).
+fn member_scroll_metrics(
+    player: &crate::player::DirPlayer,
+    member_ref: &CastMemberRef,
+) -> Option<(u16, u16, i32)> {
+    use crate::player::cast_member::CastMemberType;
+    let member = player.movie.cast_manager.find_member_by_ref(member_ref)?;
+    match &member.member_type {
+        CastMemberType::Field(f) => Some((f.fixed_line_space, f.font_size, f.height as i32)),
+        CastMemberType::Text(t) => Some((t.fixed_line_space, t.font_size, t.height as i32)),
+        _ => None,
+    }
+}
+
+/// Shared core for `member.scrollByLine(amount)` / global `scrollByLine`
+/// (Director 11.5 Scripting Dictionary): scroll a field/text member by `amount`
+/// lines (positive = down, negative = up). Fractional amounts are honored
+/// (Fugue No.4 nudges by ±0.1). `scrollTop` is clamped at 0; the upper bound is
+/// left to callers (the MM scroll bar clamps to its own maxScroll).
+pub(crate) fn scroll_member_by_lines(
+    player: &mut crate::player::DirPlayer,
+    member_ref: &CastMemberRef,
+    amount: f64,
+) {
+    let (fls, fs, _h) = match member_scroll_metrics(player, member_ref) {
+        Some(m) => m,
+        None => return,
+    };
+    let line_h = scroll_line_height(fls, fs) as f64;
+    let delta_px = (amount * line_h).round() as i32;
+    use crate::player::cast_member::CastMemberType;
+    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(member_ref) {
+        match &mut member.member_type {
+            CastMemberType::Field(field) => {
+                field.scroll_top = (field.scroll_top as i32 + delta_px).max(0) as u16;
+            }
+            CastMemberType::Text(text) => {
+                if let Some(info) = text.info.as_mut() {
+                    info.scroll_top = (info.scroll_top as i32 + delta_px).max(0) as u32;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Shared core for `member.scrollByPage(amount)` / global `scrollByPage`
+/// (Director 11.5 Scripting Dictionary): scroll by `amount` pages, where a page
+/// is the number of text lines visible in the member's box. Implemented as a
+/// line scroll of `amount * visibleLines`.
+pub(crate) fn scroll_member_by_pages(
+    player: &mut crate::player::DirPlayer,
+    member_ref: &CastMemberRef,
+    amount: f64,
+) {
+    let (fls, fs, height) = match member_scroll_metrics(player, member_ref) {
+        Some(m) => m,
+        None => return,
+    };
+    let line_h = scroll_line_height(fls, fs);
+    let visible_lines = (height / line_h.max(1)).max(1);
+    scroll_member_by_lines(player, member_ref, amount * visible_lines as f64);
+}
+
 /// Count the lines of a Director-style string. Director uses bare `\r` as
 /// its line separator; `str::lines()` only handles `\n` and `\r\n`, so a
 /// `\r`-separated text reads as a single line. We treat each `\r`, `\n`, or
@@ -149,6 +228,19 @@ impl TextMemberHandlers {
 
                 let index = get_text_index_at_pos(&text.text, &params, x, y);
                 Ok(player.alloc_datum(Datum::Int((index + 1) as i32)))
+            }
+            // `member.scrollByLine(amount)` / `member.scrollByPage(amount)` —
+            // Director 11.5 Scripting Dictionary p.618/619. Shared core handles
+            // both field and text members (see scroll_member_by_lines).
+            "scrollByLine" => {
+                let amount = player.get_datum(&args[0]).to_float()?;
+                scroll_member_by_lines(player, &member_ref, amount);
+                Ok(DatumRef::Void)
+            }
+            "scrollByPage" => {
+                let amount = player.get_datum(&args[0]).to_float()?;
+                scroll_member_by_pages(player, &member_ref, amount);
+                Ok(DatumRef::Void)
             }
             // Director 11.5 Scripting Dictionary p.443 / p.449.
             //
@@ -1922,6 +2014,26 @@ impl TextMemberHandlers {
                 }
                 Ok(Datum::List(DatumType::List, items, false))
             }
+            // `member.hyperlinks` — Director returns a linear list of
+            // [startChar, endChar] ranges, one per hyperlink (Director 11.5
+            // Scripting Dictionary). Parsed from XMED Section 0x0129 into
+            // 1-based inclusive pairs; empty for members with no links. Used by
+            // the `customHyperlink` behavior (help_menu navigation).
+            "hyperlinks" => {
+                let items: VecDeque<DatumRef> = text_data.hyperlinks
+                    .iter()
+                    .map(|(start, end)| {
+                        let s = player.alloc_datum(Datum::Int(*start));
+                        let e = player.alloc_datum(Datum::Int(*end));
+                        player.alloc_datum(Datum::List(
+                            DatumType::List,
+                            VecDeque::from(vec![s, e]),
+                            false,
+                        ))
+                    })
+                    .collect();
+                Ok(Datum::List(DatumType::List, items, false))
+            }
             _ => Err(ScriptError::new(format!(
                 "Cannot get castMember property {} for text",
                 prop
@@ -2295,6 +2407,19 @@ impl TextMemberHandlers {
                         cast_member.color = crate::player::sprite::ColorRef::Rgb(r, g, b);
                     } else {
                         cast_member.color = crate::player::sprite::ColorRef::PaletteIndex(color_val as u8);
+                    }
+                    // Director's `the color of member` recolors the WHOLE text,
+                    // overriding per-run/span colors. Clear the styled spans'
+                    // explicit colors so the renderer falls back to the new
+                    // member color (otherwise multi-span text — e.g. spectral-
+                    // wizard's LOADING dialog with two differently-sized lines —
+                    // keeps its authored black and ignores the white the script
+                    // sets). Per-line `member.line[i].color` setters run after
+                    // and re-apply concrete colors where needed.
+                    if let Some(text) = cast_member.member_type.as_text_mut() {
+                        for span in &mut text.html_styled_spans {
+                            span.style.color = None;
+                        }
                     }
                     Ok(())
                 },

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/vector_shape.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/vector_shape.rs
@@ -50,24 +50,45 @@ impl VectorShapeMemberHandlers {
         // `player.alloc_datum` calls — also a borrow conflict with
         // `cast_member`. Snapshot the data, drop the borrow, then build.
         if prop.eq_ignore_ascii_case("vertexList") {
-            // Director omits #handle1 / #handle2 keys for plain polygon
-            // vertices (both handles == 0,0) and includes them only for
-            // Bezier vertices. Verified against figure8 Slider Groove —
-            // its 4 plain vertices come back as `[#vertex: point(...)]`
-            // without handle keys.
+            // Director decides handle emission per *shape*, not per vertex: a
+            // bezier shape lists #handle1/#handle2 on EVERY vertex (even when
+            // they're point(0,0)), while a plain polygon shape (all handles
+            // zero — e.g. figure8 Slider Groove) lists none. So treat the
+            // shape as bezier if ANY vertex has a non-zero handle.
+            let shape_is_bezier = vs.vertices.iter().any(|v| {
+                v.handle1_x != 0.0 || v.handle1_y != 0.0
+                    || v.handle2_x != 0.0 || v.handle2_y != 0.0
+            });
             let verts: Vec<(i32, i32, i32, i32, i32, i32, bool)> = vs
                 .vertices
                 .iter()
                 .map(|v| {
-                    let h1x = v.handle1_x as i32;
-                    let h1y = v.handle1_y as i32;
-                    let h2x = v.handle2_x as i32;
-                    let h2y = v.handle2_y as i32;
-                    let is_bezier = !(h1x == 0 && h1y == 0 && h2x == 0 && h2y == 0);
-                    (v.x as i32, v.y as i32, h1x, h1y, h2x, h2y, is_bezier)
+                    (
+                        v.x as i32, v.y as i32,
+                        v.handle1_x as i32, v.handle1_y as i32,
+                        v.handle2_x as i32, v.handle2_y as i32,
+                        shape_is_bezier,
+                    )
                 })
                 .collect();
-            return Self::build_vertex_list(player, verts);
+            let new_curve_count = vs.new_curve_count;
+            return Self::build_vertex_list(player, verts, new_curve_count);
+        }
+
+        // `member.vertex` (chunk expression) — Director returns the list of
+        // vertex *locations* as points; `member.vertex[i]` then indexes it
+        // and `member.vertex.count` reads its length (Director 11.5 Scripting
+        // Dictionary, `vertex`). Handle1/handle2 are reached via the
+        // getPropRef path (`member.vertex[i].handle1`), not here. Snapshot
+        // the coords, drop the borrow, then allocate the point list.
+        if prop.eq_ignore_ascii_case("vertex") {
+            let pts: Vec<(f32, f32)> =
+                vs.vertices.iter().map(|v| (v.x, v.y)).collect();
+            let list: VecDeque<DatumRef> = pts
+                .iter()
+                .map(|(x, y)| player.alloc_datum(Datum::Point([*x as f64, *y as f64], 0)))
+                .collect();
+            return Ok(Datum::List(DatumType::List, list, false));
         }
 
         match_ci!(prop, {
@@ -129,6 +150,306 @@ impl VectorShapeMemberHandlers {
         })
     }
 
+    /// Method-call surface for `#vectorShape` members (`addVertex`,
+    /// `deleteVertex`, `moveVertex`, plus the indexed `vertex[i]` get/set
+    /// reference path). Director's Lingo is case-insensitive on handler
+    /// names, so they're matched via `match_ci!`. `erase` is handled
+    /// generically by `CastMemberRefHandlers` (it deletes the member), so it
+    /// is not routed here.
+    pub fn call(
+        player: &mut DirPlayer,
+        datum: &DatumRef,
+        handler_name: &str,
+        args: &Vec<DatumRef>,
+    ) -> Result<DatumRef, ScriptError> {
+        let member_ref = match player.get_datum(datum) {
+            Datum::CastMember(r) => r.to_owned(),
+            _ => return Err(ScriptError::new(
+                "Cannot call vectorShape handler on non-cast-member".to_string(),
+            )),
+        };
+        match_ci!(handler_name, {
+            // addVertex(indexToAddAt, point {, h1H, h1V, h2H, h2V})
+            // Inserts a vertex at the given 1-based index (Director 11.5
+            // Scripting Dictionary). Optional trailing ints are the two
+            // Bezier control-handle offsets, relative to the vertex.
+            "addVertex" => Self::add_vertex(player, &member_ref, args),
+            // deleteVertex(index) — removes the vertex at the 1-based index.
+            "deleteVertex" => Self::delete_vertex(player, &member_ref, args),
+            // moveVertex(index, dx, dy) — offsets an existing vertex.
+            "moveVertex" => Self::move_vertex(player, &member_ref, args),
+            // `member.vertex[i]` by reference (compiled as
+            // getPropRef(member, #vertex, i)) — returns a writable
+            // VectorVertexRef so `.handle1`/`.handle2`/`.vertex` reads and
+            // writes resolve back into the member (handled in
+            // player_get_obj_prop / player_set_obj_prop). The plain
+            // `getPropRef(member, #vertexList)` form (no index) has no
+            // chunk semantics, so it falls through to a normal prop read.
+            "getPropRef" => Self::get_vertex_ref(player, &member_ref, args),
+            // `member.vertex[i] = value` (compiled as
+            // setProp(member, #vertex, i, value)). Sets the vertex location
+            // from a point value (or a full [#vertex/#handle1/#handle2]
+            // property list, mirroring vertexList entries).
+            "setProp" => Self::set_vertex_by_index(player, &member_ref, args),
+            _ => Err(ScriptError::new(format!(
+                "No handler {} for vectorShape member", handler_name
+            ))),
+        })
+    }
+
+    /// getPropRef(member, #vertex, i) → a writable `VectorVertexRef`.
+    /// Only `#vertex` has indexed-reference semantics; any other prop name
+    /// (or a missing index) returns an error so the caller's getPropRef
+    /// fallback resolves it as a normal by-value property instead.
+    fn get_vertex_ref(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        args: &Vec<DatumRef>,
+    ) -> Result<DatumRef, ScriptError> {
+        if args.len() < 2 {
+            return Err(ScriptError::new(
+                "vectorShape getPropRef without an index".to_string(),
+            ));
+        }
+        let prop = player.get_datum(&args[0]).string_value().unwrap_or_default();
+        if !prop.eq_ignore_ascii_case("vertex") {
+            return Err(ScriptError::new(format!(
+                "vectorShape getPropRef unsupported for {}", prop
+            )));
+        }
+        let index = player.get_datum(&args[1]).int_value()?;
+        let count = Self::vertex_count(player, member_ref)?;
+        let pos = (index - 1).max(0) as usize;
+        if pos >= count {
+            return Err(ScriptError::new(format!(
+                "vertex index {} out of range (count {})", index, count
+            )));
+        }
+        Ok(player.alloc_datum(Datum::VectorVertexRef(member_ref.clone(), pos)))
+    }
+
+    /// setProp(member, #vertex, i, value) — set the i-th vertex location
+    /// (point value) or replace the whole vertex (property-list value).
+    fn set_vertex_by_index(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        args: &Vec<DatumRef>,
+    ) -> Result<DatumRef, ScriptError> {
+        if args.len() < 3 {
+            return Err(ScriptError::new(format!(
+                "No handler setProp for vectorShape member"
+            )));
+        }
+        let prop = player.get_datum(&args[0]).string_value().unwrap_or_default();
+        if !prop.eq_ignore_ascii_case("vertex") {
+            return Err(ScriptError::new(format!(
+                "vectorShape setProp unsupported for {}", prop
+            )));
+        }
+        let index = player.get_datum(&args[1]).int_value()?;
+        let (pt, _) = player.get_datum(&args[2]).to_point_inline()?;
+        let pos = (index - 1).max(0) as usize;
+        Self::with_vs_mut(player, member_ref, |vs| {
+            if let Some(v) = vs.vertices.get_mut(pos) {
+                v.x = pt[0] as f32;
+                v.y = pt[1] as f32;
+                Ok(())
+            } else {
+                Err(ScriptError::new(format!(
+                    "vertex index {} out of range", index
+                )))
+            }
+        })?;
+        Ok(DatumRef::Void)
+    }
+
+    /// Number of vertices in the referenced vectorShape member.
+    pub fn vertex_count(
+        player: &DirPlayer,
+        member_ref: &CastMemberRef,
+    ) -> Result<usize, ScriptError> {
+        let cast_member = player
+            .movie
+            .cast_manager
+            .find_member_by_ref(member_ref)
+            .ok_or_else(|| ScriptError::new("Cast member not found".to_string()))?;
+        match &cast_member.member_type {
+            CastMemberType::VectorShape(vs) => Ok(vs.vertices.len()),
+            _ => Err(ScriptError::new("Expected vectorShape member".to_string())),
+        }
+    }
+
+    /// Read a `VectorVertexRef` sub-property (`vertex` / `handle1` /
+    /// `handle2`) as a point. Used by `player_get_obj_prop`.
+    pub fn get_vertex_ref_prop(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        index: usize,
+        prop: &str,
+    ) -> Result<Datum, ScriptError> {
+        let cast_member = player
+            .movie
+            .cast_manager
+            .find_member_by_ref(member_ref)
+            .ok_or_else(|| ScriptError::new("Cast member not found".to_string()))?;
+        let vs = match &cast_member.member_type {
+            CastMemberType::VectorShape(vs) => vs,
+            _ => return Err(ScriptError::new("Expected vectorShape member".to_string())),
+        };
+        let v = vs.vertices.get(index).ok_or_else(|| {
+            ScriptError::new(format!("vertex index {} out of range", index + 1))
+        })?;
+        let pt = match_ci!(prop, {
+            "vertex"  => (v.x, v.y),
+            "handle1" => (v.handle1_x, v.handle1_y),
+            "handle2" => (v.handle2_x, v.handle2_y),
+            _ => return Err(ScriptError::new(format!(
+                "VectorVertexRef has no property {}", prop
+            ))),
+        });
+        Ok(Datum::Point([pt.0 as f64, pt.1 as f64], 0))
+    }
+
+    /// Write a `VectorVertexRef` sub-property (`vertex` / `handle1` /
+    /// `handle2`) from a point and recompute the bbox. Used by
+    /// `player_set_obj_prop`.
+    pub fn set_vertex_ref_prop(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        index: usize,
+        prop: &str,
+        value: &Datum,
+    ) -> Result<(), ScriptError> {
+        let (pt, _) = value.to_point_inline()?;
+        let prop = prop.to_owned();
+        Self::with_vs_mut(player, member_ref, |vs| {
+            let v = vs.vertices.get_mut(index).ok_or_else(|| {
+                ScriptError::new(format!("vertex index {} out of range", index + 1))
+            })?;
+            match_ci!(prop.as_str(), {
+                "vertex"  => { v.x = pt[0] as f32; v.y = pt[1] as f32; },
+                "handle1" => { v.handle1_x = pt[0] as f32; v.handle1_y = pt[1] as f32; },
+                "handle2" => { v.handle2_x = pt[0] as f32; v.handle2_y = pt[1] as f32; },
+                _ => return Err(ScriptError::new(format!(
+                    "VectorVertexRef has no property {}", prop
+                ))),
+            });
+            Ok(())
+        })
+    }
+
+    /// Borrow the member's `VectorShapeMember`, run `f`, then recompute the
+    /// bbox so the rasterizer / `width()`/`height()` stay correct.
+    fn with_vs_mut<F>(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        f: F,
+    ) -> Result<(), ScriptError>
+    where
+        F: FnOnce(&mut crate::player::cast_member::VectorShapeMember) -> Result<(), ScriptError>,
+    {
+        let cast_member = player
+            .movie
+            .cast_manager
+            .find_member_by_ref_mut(member_ref)
+            .ok_or_else(|| ScriptError::new("Cast member not found".to_string()))?;
+        let vs = match &mut cast_member.member_type {
+            CastMemberType::VectorShape(vs) => vs,
+            _ => return Err(ScriptError::new("Expected vectorShape member".to_string())),
+        };
+        f(vs)?;
+        vs.recompute_bbox();
+        Ok(())
+    }
+
+    fn add_vertex(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        args: &Vec<DatumRef>,
+    ) -> Result<DatumRef, ScriptError> {
+        if args.len() < 2 {
+            return Err(ScriptError::new(
+                "addVertex requires (index, point)".to_string(),
+            ));
+        }
+        let index = player.get_datum(&args[0]).int_value()?;
+        let (pt, _) = player.get_datum(&args[1]).to_point_inline()?;
+        // Optional Bezier control-handle offsets (relative to the vertex).
+        let read_i = |i: usize| -> i32 {
+            args.get(i)
+                .map(|a| player.get_datum(a).int_value().unwrap_or(0))
+                .unwrap_or(0)
+        };
+        let (h1x, h1y, h2x, h2y) =
+            (read_i(2) as f32, read_i(3) as f32, read_i(4) as f32, read_i(5) as f32);
+        let vertex = crate::director::enums::VectorShapeVertex {
+            x: pt[0] as f32,
+            y: pt[1] as f32,
+            handle1_x: h1x,
+            handle1_y: h1y,
+            handle2_x: h2x,
+            handle2_y: h2y,
+        };
+        let mut new_count = 0;
+        Self::with_vs_mut(player, member_ref, |vs| {
+            // Director uses a 1-based insert index; clamp into [0, len] so
+            // index 1 prepends and index > count appends (matches Director
+            // tolerating an out-of-range index by appending).
+            let pos = ((index - 1).max(0) as usize).min(vs.vertices.len());
+            vs.vertices.insert(pos, vertex);
+            new_count = vs.vertices.len();
+            Ok(())
+        })?;
+        Ok(player.alloc_datum(Datum::Int(new_count as i32)))
+    }
+
+    fn delete_vertex(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        args: &Vec<DatumRef>,
+    ) -> Result<DatumRef, ScriptError> {
+        if args.is_empty() {
+            return Err(ScriptError::new("deleteVertex requires (index)".to_string()));
+        }
+        let index = player.get_datum(&args[0]).int_value()?;
+        let mut removed = false;
+        Self::with_vs_mut(player, member_ref, |vs| {
+            let pos = (index - 1).max(0) as usize;
+            if pos < vs.vertices.len() {
+                vs.vertices.remove(pos);
+                removed = true;
+            }
+            Ok(())
+        })?;
+        Ok(player.alloc_datum(datum_bool(removed)))
+    }
+
+    fn move_vertex(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        args: &Vec<DatumRef>,
+    ) -> Result<DatumRef, ScriptError> {
+        if args.len() < 3 {
+            return Err(ScriptError::new(
+                "moveVertex requires (index, dx, dy)".to_string(),
+            ));
+        }
+        let index = player.get_datum(&args[0]).int_value()?;
+        let dx = player.get_datum(&args[1]).int_value()? as f32;
+        let dy = player.get_datum(&args[2]).int_value()? as f32;
+        let mut moved = false;
+        Self::with_vs_mut(player, member_ref, |vs| {
+            let pos = (index - 1).max(0) as usize;
+            if let Some(v) = vs.vertices.get_mut(pos) {
+                v.x += dx;
+                v.y += dy;
+                moved = true;
+            }
+            Ok(())
+        })?;
+        Ok(player.alloc_datum(datum_bool(moved)))
+    }
+
     pub fn set_prop(
         player: &mut DirPlayer,
         member_ref: &CastMemberRef,
@@ -151,6 +472,96 @@ impl VectorShapeMemberHandlers {
                 vs.reg_point = (vals[0] as i16, vals[1] as i16);
             }
             return Ok(());
+        }
+
+        // `member.vertexList = <list>` — replace the whole vertex list.
+        // Director's vertexList is `[[#vertex: point, #handle1: point,
+        // #handle2: point], ...]` (Director 11.5 Scripting Dictionary);
+        // #handle1/#handle2 are optional control-point offsets relative to
+        // the vertex. Parse the list (resolving sub-datums from `player`)
+        // BEFORE taking the mutable member borrow, then assign + recompute
+        // the bbox so the rasterizer / width()/height() stay correct.
+        // parent_talkBox restores a backed-up shape via
+        // `vsMem.vertexList = bupMem.vertexList`.
+        if prop.eq_ignore_ascii_case("vertexList") {
+            let items = match &value {
+                Datum::List(_, items, _) => items.clone(),
+                _ => return Err(ScriptError::new(
+                    "vertexList expects a list".to_string(),
+                )),
+            };
+            let mut verts: Vec<crate::director::enums::VectorShapeVertex> =
+                Vec::with_capacity(items.len());
+            let mut new_curve_count = 0usize;
+            for item_ref in &items {
+                let entry = player.get_datum(item_ref);
+                // A `[#newCurve]` marker is a linear list holding the symbol
+                // (not a prop-list). Count it and move on.
+                if let Datum::List(_, elems, _) = &entry {
+                    let is_new_curve = elems.iter().any(|e| {
+                        player.get_datum(e).string_value()
+                            .map_or(false, |s| s.eq_ignore_ascii_case("newCurve"))
+                    });
+                    if is_new_curve {
+                        new_curve_count += 1;
+                        continue;
+                    }
+                }
+                let pairs = match entry {
+                    Datum::PropList(pairs, _) => pairs.clone(),
+                    _ => return Err(ScriptError::new(
+                        "vertexList entry must be a property list".to_string(),
+                    )),
+                };
+                // Tolerate a #newCurve key inside a prop-list form too (older
+                // round-trips) — count it and skip the point parsing.
+                let is_new_curve = pairs.iter().any(|(k_ref, _)| {
+                    player.get_datum(k_ref).string_value()
+                        .map_or(false, |k| k.eq_ignore_ascii_case("newCurve"))
+                });
+                if is_new_curve {
+                    new_curve_count += 1;
+                    continue;
+                }
+                let mut v = crate::director::enums::VectorShapeVertex {
+                    x: 0.0, y: 0.0,
+                    handle1_x: 0.0, handle1_y: 0.0,
+                    handle2_x: 0.0, handle2_y: 0.0,
+                };
+                for (k_ref, val_ref) in &pairs {
+                    // Keys are symbols (#vertex); string_value handles both
+                    // Symbol and String forms.
+                    let key = player.get_datum(k_ref).string_value().unwrap_or_default();
+                    // Skip keys whose value isn't a point (defensive).
+                    let pt = match player.get_datum(val_ref).to_point_inline() {
+                        Ok((pt, _)) => pt,
+                        Err(_) => continue,
+                    };
+                    match_ci!(key.as_str(), {
+                        "vertex"  => { v.x = pt[0] as f32; v.y = pt[1] as f32; },
+                        "handle1" => { v.handle1_x = pt[0] as f32; v.handle1_y = pt[1] as f32; },
+                        "handle2" => { v.handle2_x = pt[0] as f32; v.handle2_y = pt[1] as f32; },
+                        _ => {},
+                    });
+                }
+                verts.push(v);
+            }
+            let cast_member = player
+                .movie
+                .cast_manager
+                .find_member_by_ref_mut(member_ref)
+                .ok_or_else(|| ScriptError::new("Cast member not found".to_string()))?;
+            match &mut cast_member.member_type {
+                CastMemberType::VectorShape(vs) => {
+                    vs.vertices = verts;
+                    vs.new_curve_count = new_curve_count;
+                    vs.recompute_bbox();
+                    return Ok(());
+                }
+                _ => return Err(ScriptError::new(
+                    "Expected vectorShape member".to_string(),
+                )),
+            }
         }
 
         // VectorShapeMember stores colors as flat (u8, u8, u8) RGB tuples
@@ -305,8 +716,9 @@ impl VectorShapeMemberHandlers {
     fn build_vertex_list(
         player: &mut DirPlayer,
         verts: Vec<(i32, i32, i32, i32, i32, i32, bool)>,
+        new_curve_count: usize,
     ) -> Result<Datum, ScriptError> {
-        let list: VecDeque<DatumRef> = verts
+        let mut list: VecDeque<DatumRef> = verts
             .iter()
             .map(|(vx, vy, h1x, h1y, h2x, h2y, is_bezier)| {
                 let vertex_key = player.alloc_datum(Datum::Symbol("vertex".to_string()));
@@ -327,6 +739,18 @@ impl VectorShapeMemberHandlers {
                 player.alloc_datum(prop_list)
             })
             .collect();
+        // Trailing `[#newCurve]` markers (sub-path breaks). Director prints
+        // these as a linear list holding just the symbol — `[#newCurve]` — not
+        // a prop-list, so emit Datum::List([#newCurve]) to round-trip exactly.
+        for _ in 0..new_curve_count {
+            let sym = player.alloc_datum(Datum::Symbol("newCurve".to_string()));
+            let marker = player.alloc_datum(Datum::List(
+                DatumType::List,
+                VecDeque::from(vec![sym]),
+                false,
+            ));
+            list.push_back(marker);
+        }
         Ok(Datum::List(DatumType::List, list, false))
     }
 
@@ -342,7 +766,7 @@ impl VectorShapeMemberHandlers {
     ) -> Result<Datum, ScriptError> {
         // Snapshot everything we need from the cast member before we
         // need `&mut player.bitmap_manager`.
-        let (w, h, fill, end, bg, fill_mode, closed, poly,
+        let (w, h, fill, end, bg, stroke, stroke_width, fill_mode, closed, poly,
              gradient_type, fill_scale, fill_offset) = {
             let cast_member = player
                 .movie
@@ -356,11 +780,36 @@ impl VectorShapeMemberHandlers {
             // For .image rasterization we want the vertex bbox dims (the
             // pixel extent the polygon actually occupies), NOT the
             // authored member.width/height which include extra padding.
-            let w = vs.bbox_width().ceil() as u16;
-            let h = vs.bbox_height().ceil() as u16;
+            //
+            // Guard against an absurd bbox: a corrupt/uninitialized vertex
+            // can make bbox_width/height enormous, and `f32 as u16`
+            // saturates to 65535 — a 65535² bitmap then overruns bitvec's
+            // mask capacity and panics. No legitimate vector shape in a
+            // Director movie is anywhere near this; clamp and log so the
+            // player keeps running and we can see the offending member/bbox.
+            const MAX_VS_IMAGE_DIM: f32 = 4096.0;
+            let raw_w = vs.bbox_width().ceil();
+            let raw_h = vs.bbox_height().ceil();
+            if raw_w > MAX_VS_IMAGE_DIM || raw_h > MAX_VS_IMAGE_DIM
+                || !raw_w.is_finite() || !raw_h.is_finite()
+            {
+                log::warn!(
+                    "[vectorShape .image] member ({}, {}) has absurd bbox \
+                     {}x{} (left={} top={} right={} bottom={}, {} verts) — \
+                     clamping to {}px to avoid an oversized-bitmap panic",
+                    member_ref.cast_lib, member_ref.cast_member,
+                    raw_w, raw_h,
+                    vs.bbox_left, vs.bbox_top, vs.bbox_right, vs.bbox_bottom,
+                    vs.vertices.len(), MAX_VS_IMAGE_DIM,
+                );
+            }
+            let w = raw_w.clamp(0.0, MAX_VS_IMAGE_DIM) as u16;
+            let h = raw_h.clamp(0.0, MAX_VS_IMAGE_DIM) as u16;
             let fill = vs.fill_color;
             let end = vs.end_color;
             let bg = vs.bg_color;
+            let stroke = vs.stroke_color;
+            let stroke_width = vs.stroke_width;
             let fill_mode = vs.fill_mode;
             let closed = vs.closed;
             let bbox_left = vs.bbox_left;
@@ -368,13 +817,50 @@ impl VectorShapeMemberHandlers {
             let gradient_type = vs.gradient_type.clone();
             let fill_scale = vs.fill_scale;
             let fill_offset = vs.fill_offset;
-            // Translate vertices into bitmap-local coords.
-            let poly: Vec<(f32, f32)> = vs
+            // Tessellate the closed cubic-Bezier outline into a dense polygon
+            // in bitmap-local coords. Each vertex carries two control-handle
+            // offsets: handle1 = outgoing (toward the next vertex), handle2 =
+            // incoming (from the previous vertex). For edge V[i]→V[i+1] the
+            // cubic is V[i], V[i]+h1, V[i+1]+h2, V[i+1]. Without this the
+            // rounded bubble/dialog shapes render as straight-edged polygons
+            // (the "drawn by a child" look). Verified against ui_pratbubbla.
+            let local: Vec<(f32, f32, f32, f32, f32, f32)> = vs
                 .vertices
                 .iter()
-                .map(|v| (v.x - bbox_left, v.y - bbox_top))
+                .map(|v| (
+                    v.x - bbox_left, v.y - bbox_top,
+                    v.handle1_x, v.handle1_y,
+                    v.handle2_x, v.handle2_y,
+                ))
                 .collect();
-            (w, h, fill, end, bg, fill_mode, closed, poly,
+            let has_curves = local.iter().any(|v| {
+                v.2 != 0.0 || v.3 != 0.0 || v.4 != 0.0 || v.5 != 0.0
+            });
+            let poly: Vec<(f32, f32)> = if has_curves && local.len() >= 2 {
+                const SEGS: usize = 12; // samples per Bezier edge
+                let n = local.len();
+                let mut out: Vec<(f32, f32)> = Vec::with_capacity(n * SEGS);
+                for i in 0..n {
+                    let a = local[i];
+                    let b = local[(i + 1) % n];
+                    let p0 = (a.0, a.1);
+                    let p1 = (a.0 + a.2, a.1 + a.3);          // V[i] + handle1 (out)
+                    let p2 = (b.0 + b.4, b.1 + b.5);          // V[i+1] + handle2 (in)
+                    let p3 = (b.0, b.1);
+                    // Sample t in [0,1); the next edge contributes its own p0.
+                    for s in 0..SEGS {
+                        let t = s as f32 / SEGS as f32;
+                        let mt = 1.0 - t;
+                        let x = mt*mt*mt*p0.0 + 3.0*mt*mt*t*p1.0 + 3.0*mt*t*t*p2.0 + t*t*t*p3.0;
+                        let y = mt*mt*mt*p0.1 + 3.0*mt*mt*t*p1.1 + 3.0*mt*t*t*p2.1 + t*t*t*p3.1;
+                        out.push((x, y));
+                    }
+                }
+                out
+            } else {
+                local.iter().map(|v| (v.0, v.1)).collect()
+            };
+            (w, h, fill, end, bg, stroke, stroke_width, fill_mode, closed, poly,
              gradient_type, fill_scale, fill_offset)
         };
 
@@ -386,19 +872,23 @@ impl VectorShapeMemberHandlers {
             0,
             PaletteRef::BuiltIn(BuiltInPalette::GrayScale),
         );
+        // The vector-shape image carries an alpha channel: inside the shape is
+        // opaque (the fill), outside is transparent. spectral-wizard's
+        // parent_talkBox builds the speech bubble via `_img.extractAlpha()` +
+        // `useAlpha`, so the area outside the polygon MUST be alpha 0 or the
+        // bubble's bounding box renders as a solid black rectangle.
+        bitmap.use_alpha = true;
         let bw = bitmap.width as usize;
         let bh = bitmap.height as usize;
 
-        // Pre-fill with BLACK, not vs.bg_color. Director's vector-shape
-        // .image always rasterizes onto a black backdrop regardless of
-        // `the backgroundColor of member` — verified empirically:
-        // `member("floor_shape_preview").backgroundColor` returns
-        // rgb(255,255,255) but `image.getPixel(2, 2)` returns rgb(0,0,0).
-        // CS catalog scripts rely on this: they composite floor preview
-        // shapes onto bitmaps with `[#ink: 5, #color: rgb(0,0,0), ...]`,
-        // using black as the transparency key. Filling with vs.bg_color
-        // (white) made the entire 106×46 rect contribute to the multiply
-        // blend and washed the destination to gray.
+        // Pre-fill with TRANSPARENT BLACK. The RGB stays black (not vs.bg_color):
+        // Director's vector-shape .image rasterizes onto a black backdrop
+        // regardless of `the backgroundColor of member` — verified empirically
+        // (`member("floor_shape_preview").backgroundColor` is rgb(255,255,255)
+        // but `image.getPixel(2,2)` returns rgb(0,0,0)), and CS catalog scripts
+        // key on that black via `[#ink: 5, #color: rgb(0,0,0), ...]`. The alpha
+        // is 0 so alpha-aware consumers (extractAlpha / useAlpha) treat the
+        // outside as transparent; color-key (ink 5) consumers still see black.
         let _ = bg;
         for y in 0..bh {
             for x in 0..bw {
@@ -406,7 +896,7 @@ impl VectorShapeMemberHandlers {
                 bitmap.data[i] = 0;
                 bitmap.data[i + 1] = 0;
                 bitmap.data[i + 2] = 0;
-                bitmap.data[i + 3] = 0xFF;
+                bitmap.data[i + 3] = 0x00;
             }
         }
 
@@ -507,6 +997,28 @@ impl VectorShapeMemberHandlers {
                     bitmap.data[i + 2] = c.2;
                     bitmap.data[i + 3] = 0xFF;
                 }
+            }
+        }
+
+        // Anti-aliased stroke along the (tessellated) outline. Without this,
+        // `member.image` produced only the fill — the talkbox / dialog shapes
+        // lost their black border (the old opaque-black bbox used to hide its
+        // absence). `blend_pixel_aa` accumulates alpha, so stroke pixels get
+        // opaque even where they sit outside the fill (alpha 0). Mirrors the
+        // stroke pass in drawing.rs::draw_vector_shape.
+        if stroke_width > 0.0 && poly.len() >= 2 {
+            let palettes = player.movie.cast_manager.palettes();
+            let half_w = stroke_width / 2.0;
+            let n = poly.len();
+            let seg_count = if closed { n } else { n - 1 };
+            for i in 0..seg_count {
+                let (x1, y1) = poly[i];
+                let (x2, y2) = poly[(i + 1) % n];
+                bitmap.draw_line_aa(x1, y1, x2, y2, half_w, stroke, &palettes, 1.0);
+            }
+            // Round caps/joins at each point so corners stay smooth.
+            for &(px, py) in &poly {
+                bitmap.draw_circle_aa(px, py, half_w, stroke, &palettes, 1.0);
             }
         }
 

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -452,6 +452,9 @@ impl CastMemberRefHandlers {
                 CastMemberType::PhysXPhysics(_) => {
                     PhysXPhysicsMemberHandlers::call(datum, handler_name, args)
                 }
+                CastMemberType::VectorShape(_) => {
+                    VectorShapeMemberHandlers::call(player, datum, handler_name, args)
+                }
                 _ => Err(ScriptError::new(format!(
                     "No handler {} for member type {:?}",
                     handler_name, cast_member.member_type.member_type_id()
@@ -1171,6 +1174,22 @@ impl CastMemberRefHandlers {
                     |_| {},
                     |cast_member, _| {
                         cast_member.color = value.to_color_ref()?.to_owned();
+                        // Director's `the color of member` recolors the WHOLE
+                        // text member, overriding per-run/span colors. Clear the
+                        // styled spans' explicit colors so `.image` (and the
+                        // renderer) fall back to the new member color. Without
+                        // this, spectral-wizard's LOADING dialog —
+                        // putTextImageWithShadow sets member.color to the shadow
+                        // then white between two `.image` reads — kept the spans'
+                        // authored black and rendered the text black both times.
+                        // Mirrors the text.rs member-prop setter. Per-line
+                        // `member.line[i].color` setters run afterward and
+                        // re-apply concrete colors where the script wants them.
+                        if let Some(text) = cast_member.member_type.as_text_mut() {
+                            for span in &mut text.html_styled_spans {
+                                span.style.color = None;
+                            }
+                        }
                         Ok(())
                     },
                 ),

--- a/vm-rust/src/player/handlers/datum_handlers/list_handlers.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/list_handlers.rs
@@ -116,6 +116,18 @@ impl ListDatumHandlers {
             let index = position - 1;
             let item_ref = &args[1];
 
+            // Non-positive positions: `index < list_vec.len()` is true for a
+            // negative index, so without this guard `list_vec[(-1) as usize]`
+            // indexes with a huge value and VecDeque panics (crashing the whole
+            // VM). Director's lists are 1-based and it tolerates setAt at
+            // position <= 0 as a no-op rather than erroring — spectral-wizard's
+            // generic `customHyperlink` behavior relies on this with
+            // `pVisited[pHyperLinks.count] = 0` when a member has no links
+            // (count 0 → `pVisited[0] = 0`). Silently ignore.
+            if index < 0 {
+                return Ok(DatumRef::Void);
+            }
+
             if index < list_vec.len() as i32 {
                 list_vec[index as usize] = item_ref.clone();
             } else {

--- a/vm-rust/src/player/handlers/datum_handlers/player.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/player.rs
@@ -14,6 +14,22 @@ impl PlayerDatumHandlers {
         match handler_name {
             "count" => Self::count(args),
             "cursor" => TypeHandlers::cursor(args),
+            // `_key.keyPressed()` — no-arg form returns the currently-pressed
+            // key character (Director 11.5: `_key.keyPressed() = SPACE`); the
+            // single-arg form `_key.keyPressed(charOrCode)` tests a specific
+            // key and is shared with the top-level `keyPressed()` builtin.
+            // parent_dialog's updateDialog (the key-rebind UI) calls the
+            // no-arg form: `nn = _key.keyPressed()`.
+            "keyPressed" | "keypressed" => {
+                if args.is_empty() {
+                    reserve_player_mut(|player| {
+                        let k = player.keyboard_manager.key_pressed();
+                        Ok(player.alloc_datum(Datum::String(k)))
+                    })
+                } else {
+                    crate::player::handlers::manager::BuiltInHandlerManager::key_pressed(args)
+                }
+            }
             _ => reserve_player_ref(|player| {
                 Err(ScriptError::new_code(
                     ScriptErrorCode::HandlerNotFound,

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -183,6 +183,26 @@ impl SpriteDatumHandlers {
     ) -> Result<DatumRef, ScriptError> {
         let name_lower = handler_name.to_lowercase();
         match name_lower.as_str() {
+            // `sprite(N).pointToChar(point)` — 1-based char index at a stage
+            // coordinate within the sprite's text/field member, or -1 if the
+            // point isn't within the text (Director 11.5 Scripting Dictionary).
+            // Shares the hit-test core with `the mouseChar` / the global
+            // `pointToChar()` builtin.
+            "pointtochar" => {
+                reserve_player_mut(|player| {
+                    if args.is_empty() {
+                        return Err(ScriptError::new(
+                            "pointToChar requires 1 argument (point)".to_string(),
+                        ));
+                    }
+                    let sprite_num = player.get_datum(datum).to_sprite_ref()?;
+                    let (pt_vals, _f) = player.get_datum(&args[0]).to_point_inline()?;
+                    let result = crate::player::compute_char_at(
+                        player, sprite_num, pt_vals[0] as i32, pt_vals[1] as i32,
+                    );
+                    Ok(player.alloc_datum(Datum::Int(result)))
+                })
+            }
             "intersects" => {
                 reserve_player_mut(|player| {
                     if args.is_empty() {

--- a/vm-rust/src/player/handlers/datum_handlers/string.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string.rs
@@ -55,7 +55,12 @@ impl StringDatumUtils {
         match prop_name {
             "length" => Ok(Datum::Int(value.chars().count() as i32)),
             "ilk" => Ok(Datum::Symbol("string".to_owned())),
-            "string" => Ok(Datum::String(value.to_owned())),
+            // `.text` yields the textual content. For a plain string (and for
+            // a resolved string chunk falling through here) it's the string
+            // itself — same as `.string`. spectral-wizard's
+            // getDefaultFixedLineSpace reads `member(..).char[1..1].ref.text`
+            // to copy a character into a probe field.
+            "string" | "text" => Ok(Datum::String(value.to_owned())),
             "value" => {
                 // Normalise (strip comments + trim unbalanced brackets) before
                 // parsing, then evaluate as a Lingo expression.
@@ -257,7 +262,7 @@ pub fn string_get_items(value: &str, delimiter: char) -> Vec<String> {
     }
 }
 
-fn is_director_whitespace(byte: char) -> bool {
+pub fn is_director_whitespace(byte: char) -> bool {
     if byte.is_ascii_control() || byte.is_ascii_whitespace() || byte == 2 as char {
         return true;
     } else {
@@ -272,6 +277,31 @@ pub fn string_get_words(value: &str) -> Vec<String> {
         .filter(|s| !s.is_empty())
         .map(|s| s.to_string())
         .collect()
+}
+
+/// Character-offset ranges `(start, end_exclusive)` of each word in `value`,
+/// consistent with `string_get_words` (a word is a maximal run of
+/// non-`is_director_whitespace` chars). Indices are CHAR indices. Used by
+/// in-place word deletion, which must preserve the surrounding whitespace
+/// Director leaves untouched (rejoining tokens with a single space loses it).
+pub fn word_char_ranges(value: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let mut start: Option<usize> = None;
+    let mut count = 0usize;
+    for (i, c) in value.chars().enumerate() {
+        if is_director_whitespace(c) {
+            if let Some(st) = start.take() {
+                ranges.push((st, i));
+            }
+        } else if start.is_none() {
+            start = Some(i);
+        }
+        count = i + 1;
+    }
+    if let Some(st) = start {
+        ranges.push((st, count));
+    }
+    ranges
 }
 
 pub fn string_get_lines(value: &str) -> Vec<String> {

--- a/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
@@ -177,18 +177,39 @@ impl StringChunkUtils {
                 Ok(new_chunks.join(&delimiter))
             },
             StringChunkType::Word => {
-                let chunk_list = 
-                    Self::resolve_chunk_list(string, chunk_expr.chunk_type.clone(), chunk_expr.item_delimiter)?;
-                let (start, end) = 
-                    Self::vm_range_to_host((chunk_expr.start, chunk_expr.end), chunk_list.len());
-
-                if chunk_list.len() == 0 {
+                // Delete the word(s) in place, preserving the surrounding
+                // whitespace Director leaves untouched. Tokenizing and
+                // rejoining with single spaces (the old approach) collapses
+                // leading/interior whitespace — e.g. `delete word 1 of
+                // " text \"x\""` must yield " \"x\"" (leading space kept) so a
+                // following `delete char 1` can strip it. The MM custom scroll
+                // bar's findSprite relies on exactly this to recover a member
+                // name from a `"sprite N: type \"name\""` string.
+                let ranges = super::string::word_char_ranges(string);
+                let n = ranges.len();
+                if n == 0 {
                     return Ok(string.to_owned());
                 }
-
-                let mut new_chunks = chunk_list;
-                new_chunks.drain(start..end);
-                Ok(new_chunks.join(" "))
+                let (start, end) = Self::vm_range_to_host((chunk_expr.start, chunk_expr.end), n);
+                let start = start.min(n);
+                let end = end.min(n);
+                if start >= end {
+                    return Ok(string.to_owned());
+                }
+                // Director also removes one delimiter (a whitespace run): the
+                // following one if a word survives after the range, else the
+                // preceding one; if no other words exist, just the content.
+                let (char_start, char_end) = if end < n {
+                    (ranges[start].0, ranges[end].0)
+                } else if start > 0 {
+                    (ranges[start - 1].1, ranges[end - 1].1)
+                } else {
+                    (ranges[start].0, ranges[end - 1].1)
+                };
+                let (byte_start, byte_end) = char_range_to_byte_range(string, char_start, char_end);
+                let mut new_string = string.to_owned();
+                new_string.replace_range(byte_start..byte_end, "");
+                Ok(new_string)
             },
             StringChunkType::Line => {
                 let chunk_list = 
@@ -751,40 +772,14 @@ impl StringChunkHandlers {
         value_ref: &DatumRef,
     ) -> Result<(), ScriptError> {
         match prop {
-            "font" | "fontStyle" | "color" | "hyperlink" => {
+            // All per-run style props target ONLY the chunk's character range
+            // (via apply_styled_span_range). fontSize previously set the whole
+            // member + every span, so `member.line[2].fontSize = 18` blew the
+            // size up for the entire member — spectral-wizard's help_text set
+            // its body to 14 then only line 2 (the "> Story" header) to 18, but
+            // the whole body rendered at 18.
+            "font" | "fontStyle" | "color" | "hyperlink" | "fontSize" => {
                 return Self::set_chunk_style_prop(player, datum_ref, prop, value_ref);
-            }
-            "fontSize" => {
-                let new_val = player.get_datum(value_ref).int_value()?;
-                let datum = player.get_datum(datum_ref).clone();
-                if let Datum::StringChunk(source, _, _) = datum {
-                    let mut current_source = source;
-                    loop {
-                        match current_source {
-                            StringChunkSource::Member(member_ref) => {
-                                if let Some(member) = player.movie.cast_manager.find_member_by_ref_mut(&member_ref) {
-                                    if let CastMemberType::Text(ref mut text) = member.member_type {
-                                        text.font_size = new_val as u16;
-                                        for span in text.html_styled_spans.iter_mut() {
-                                            span.style.font_size = Some(new_val);
-                                        }
-                                    } else if let CastMemberType::Field(ref mut field) = member.member_type {
-                                        field.font_size = new_val as u16;
-                                    }
-                                }
-                                break;
-                            }
-                            StringChunkSource::Datum(ref source_datum_ref) => {
-                                let source_datum = player.get_datum(source_datum_ref).clone();
-                                if let Datum::StringChunk(inner_source, _, _) = source_datum {
-                                    current_source = inner_source;
-                                } else {
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                }
             }
             "charSpacing" => {
                 // Update the source member's char_spacing
@@ -849,6 +844,7 @@ impl StringChunkHandlers {
         // Build the style modifier from the incoming value.
         enum StyleChange {
             Font(String),
+            FontSize(i32),
             FontStyle { bold: bool, italic: bool, underline: bool },
             Color(u32),
             /// Director chapter 15 `hyperlink` — per-character link target
@@ -858,6 +854,7 @@ impl StringChunkHandlers {
         let value_datum = player.get_datum(value_ref).clone();
         let change = match prop {
             "font" => StyleChange::Font(value_datum.string_value()?),
+            "fontSize" => StyleChange::FontSize(value_datum.int_value()?),
             "hyperlink" => StyleChange::Hyperlink(value_datum.string_value().unwrap_or_default()),
             "fontStyle" => {
                 // Director accepts either a single symbol (#bold) or a list
@@ -942,6 +939,7 @@ impl StringChunkHandlers {
                     default_style,
                     |style| match &change {
                         StyleChange::Font(f) => style.font_face = Some(f.clone()),
+                        StyleChange::FontSize(sz) => style.font_size = Some(*sz),
                         StyleChange::FontStyle { bold, italic, underline } => {
                             style.bold = *bold;
                             style.italic = *italic;
@@ -963,6 +961,10 @@ impl StringChunkHandlers {
                 // styled runs.
                 match &change {
                     StyleChange::Font(f) => field.font = f.clone(),
+                    // FieldMember has a single member-wide font size (no per-run
+                    // styled spans), so a chunk fontSize write falls back to the
+                    // whole member — matches Director's field behaviour.
+                    StyleChange::FontSize(sz) => field.font_size = (*sz).max(0) as u16,
                     StyleChange::FontStyle { bold, italic, underline } => {
                         let mut parts: Vec<&str> = Vec::new();
                         if *bold { parts.push("bold"); }
@@ -1232,5 +1234,40 @@ fn resolve_word_char_range(text: &str, start: i32, end: i32) -> (usize, usize) {
         (range_start, range_start)
     } else {
         (range_start, range_end)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::director::lingo::datum::{StringChunkExpr, StringChunkType};
+
+    fn del_word(s: &str, start: i32, end: i32) -> String {
+        let expr = StringChunkExpr {
+            chunk_type: StringChunkType::Word,
+            start,
+            end,
+            item_delimiter: ',',
+        };
+        StringChunkUtils::string_by_deleting_chunk(s, &expr).unwrap()
+    }
+
+    #[test]
+    fn delete_word_preserves_leading_whitespace() {
+        // The MM custom scroll bar findSprite parse: ` text "name"` →
+        // delete word 1 must keep the leading space so the next delete char 1
+        // removes the space (not the opening quote).
+        assert_eq!(del_word(" text \"name\"", 1, 0), " \"name\"");
+    }
+
+    #[test]
+    fn delete_word_basic_and_delimiters() {
+        // Removes word + the following whitespace run.
+        assert_eq!(del_word("a b c", 1, 0), "b c");
+        assert_eq!(del_word("a b c", 2, 0), "a c");
+        // Last word: removes the preceding whitespace too.
+        assert_eq!(del_word("a b c", 3, 0), "a b");
+        // Interior runs of whitespace: only the deleted gap goes.
+        assert_eq!(del_word("a   b   c", 2, 0), "a   c");
     }
 }

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1410,6 +1410,10 @@ impl BuiltInHandlerManager {
             "max" => TypeHandlers::max(args),
             "sort" => TypeHandlers::sort(args),
             "intersect" => TypeHandlers::intersect(args),
+            "inflate" => TypeHandlers::inflate(args),
+            "pointtochar" => TypeHandlers::point_to_char(args),
+            "scrollbyline" => TypeHandlers::scroll_by_line(args),
+            "scrollbypage" => TypeHandlers::scroll_by_page(args),
             "rollover" => MovieHandlers::rollover(args),
             "getpropat" => TypeHandlers::get_prop_at(args),
             "puppetsound" => MovieHandlers::puppet_sound(args),
@@ -1760,7 +1764,17 @@ impl BuiltInHandlerManager {
                         } else {
                             line_idx as i32
                         };
-                        let y = top_spacing as i32 + visual_line * line_step;
+                        // See branch B: a trailing newline's location is the line
+                        // it creates, so charPosToLoc(char.count) on text ending
+                        // in \r gives the full height for GetMaxScroll. Gated to
+                        // the last char + a newline so letter-terminated text
+                        // returns the char's line top (Coke Studios' shrink loop
+                        // requires charPosToLoc(1).locV == charPosToLoc(len).locV
+                        // for single-line text — see branch B note).
+                        let trailing_nl_a = index + 1 >= text.chars().count()
+                            && matches!(text.chars().nth(index), Some('\r') | Some('\n'));
+                        let y = top_spacing as i32
+                            + (visual_line + if trailing_nl_a { 1 } else { 0 }) * line_step;
 
                         Ok(player.alloc_datum(Datum::Point([width as f64, y as f64], 0)))
                     } else {
@@ -1911,7 +1925,22 @@ impl BuiltInHandlerManager {
                             // get_text_char_pos (which handles char-level
                             // x correctly). y: from visual_idx * line_step.
                             let (x_pos, _y_unused) = crate::player::font::get_text_char_pos(&text, &params, index);
-                            let y_pos = top_spacing.saturating_add(visual_idx as i16 * line_step);
+                            // A trailing newline's location is the line it
+                            // CREATES (the next one), not the line it ends — so
+                            // charPosToLoc(char.count) on text ending in \r gives
+                            // the full height for GetMaxScroll (spectral-wizard's
+                            // help-story scroll). Gated to the last char AND a
+                            // newline: charPosToLoc(textLength) on letter-
+                            // terminated text must return that char's line TOP so
+                            // it equals charPosToLoc(1).locV for single-line text.
+                            // Coke Studios' window shrink-to-one-line loop spins
+                            // `while charPosToLoc(m,1).locV <> charPosToLoc(m,len).locV`
+                            // — a non-newline-gated bump never converged → freeze.
+                            let trailing_nl_b = index + 1 >= text.chars().count()
+                                && matches!(text.chars().nth(index), Some('\r') | Some('\n'));
+                            let y_pos = top_spacing.saturating_add(
+                                (visual_idx as i16 + if trailing_nl_b { 1 } else { 0 }) * line_step,
+                            );
                             (x_pos, y_pos)
                         };
 
@@ -2056,9 +2085,52 @@ impl BuiltInHandlerManager {
         reserve_player_mut(|player| {
             let arg_datum = player.get_datum(&args[0]);
 
+            // An INTEGER argument is a direct key code (this is how games store
+            // their configurable keys — spectral-wizard's `settingsKeys` uses
+            // SW codes like #jump:7 (X), #attack:6 (Z), #down:125). Handle it
+            // BEFORE the string path: `Datum::Int(7).string_value()` is "7",
+            // which the length-1 branch below would misread as the *character*
+            // '7' and look up the digit-7 key — so keyPressed(7) checked the
+            // wrong key and jump/attack never fired. Single-/double-digit codes
+            // were the visible failures; multi-digit ones (arrows) happened to
+            // round-trip through the number-parse branch.
+            if let crate::director::lingo::datum::Datum::Int(code) = arg_datum {
+                let code = *code;
+                // An ASCII letter code (A-Z/a-z) maps through the char table;
+                // any other integer is used as the SW key code verbatim.
+                let key_code = if (65..=90).contains(&code) || (97..=122).contains(&code) {
+                    let ch = (code as u8 as char).to_lowercase().next().unwrap();
+                    *keyboard_map::get_char_to_keycode_map().get(&ch).unwrap_or(&(code as u16))
+                } else {
+                    code as u16
+                };
+                let is_pressed = player
+                    .keyboard_manager
+                    .down_keys
+                    .iter()
+                    .any(|key| key.code == key_code);
+                return Ok(player.alloc_datum(datum_bool(is_pressed)));
+            }
+
             let key_code = if let Ok(key_str) = arg_datum.string_value() {
-                // STRING: First check if it's a single character
-                if key_str.len() == 1 {
+                // Named key constants. Director's SPACE/RETURN/TAB/... are
+                // character constants, but movies pass them to keyPressed in a
+                // form that reaches us as the symbolic name (e.g. spectral-
+                // wizard's `keyPressed("SPACE")` from `keyPressed(SPACE)`).
+                // Map the common names to Mac virtual key codes.
+                if let Some(code) = match key_str.to_ascii_uppercase().as_str() {
+                    "SPACE" => Some(49u16),
+                    "RETURN" => Some(36),
+                    "ENTER" => Some(76),
+                    "TAB" => Some(48),
+                    "BACKSPACE" => Some(51),
+                    "ESCAPE" | "ESC" => Some(53),
+                    _ => None,
+                } {
+                    code
+                }
+                // STRING: check if it's a single character
+                else if key_str.len() == 1 {
                     // Single character - convert to Director key code
                     let ch = key_str
                         .chars()

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -1180,6 +1180,12 @@ impl TypeHandlers {
             let result = match value {
                 Datum::Int(i) => Datum::Int(i.abs()),
                 Datum::Float(f) => Datum::Float(f.abs()),
+                // Director coerces VOID to 0 in numeric contexts, so
+                // `abs(VOID)` is `abs(0)` = 0. Movies routinely read
+                // uninitialized properties (e.g. a player's vX/vY before the
+                // first physics step in spectral-wizard's colliPlayer) and
+                // pass them straight into abs(); Director tolerates this.
+                Datum::Void => Datum::Int(0),
                 _ => {
                     return Err(ScriptError::new(format!(
                         "Cannot get abs of type: {}",
@@ -1522,6 +1528,97 @@ impl TypeHandlers {
             let rect = IntRect { left: l, top: t, right: r, bottom: b };
 
             Ok(player.alloc_datum(rect.to_datum()))
+        })
+    }
+
+    /// `inflate(rect, widthChange, heightChange)` — expands (or, with
+    /// negatives, shrinks) a rect by `widthChange` on the left and right and
+    /// `heightChange` on the top and bottom: left/top decrease, right/bottom
+    /// increase, so total width grows by 2*widthChange. Returns a new rect.
+    ///
+    /// NOTE: `inflate` is NOT in the bundled Director 11.5 Scripting Dictionary
+    /// (verified via the director-reference skill — the dict documents only
+    /// `rect()`, `map()`, `union()`, `intersect()`). This is the standard
+    /// Director rect-inflate contract, inferred from documented behavior and
+    /// the MM custom scroll bar's InstallElement, which pads the dragger active
+    /// zone with `inflate(zone, 32, 32)` (an outward expansion).
+    pub fn inflate(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            if args.len() != 3 {
+                return Err(ScriptError::new(
+                    "inflate requires 3 arguments (rect, widthChange, heightChange)".to_string(),
+                ));
+            }
+            let (vals, _f) = player.get_datum(&args[0]).to_rect_inline()?;
+            let dw = player.get_datum(&args[1]).int_value()?;
+            let dh = player.get_datum(&args[2]).int_value()?;
+            let rect = IntRect {
+                left: vals[0] as i32 - dw,
+                top: vals[1] as i32 - dh,
+                right: vals[2] as i32 + dw,
+                bottom: vals[3] as i32 + dh,
+            };
+            Ok(player.alloc_datum(rect.to_datum()))
+        })
+    }
+
+    /// `pointToChar(spriteRef, point)` (also `sprite.pointToChar(point)`) —
+    /// Director 11.5 Scripting Dictionary: "returns an integer representing the
+    /// character position located within the text or field sprite at a
+    /// specified screen coordinate, or returns -1 if the point is not within
+    /// the text." 1-based. Shares the hit-test core with `the mouseChar`.
+    /// Used by the customHyperlink behavior to find the char under the mouse.
+    pub fn point_to_char(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            if args.len() != 2 {
+                return Err(ScriptError::new(
+                    "pointToChar requires 2 arguments (sprite, point)".to_string(),
+                ));
+            }
+            let sprite_num = player.get_datum(&args[0]).to_sprite_ref()?;
+            let (pt_vals, _f) = player.get_datum(&args[1]).to_point_inline()?;
+            let result =
+                crate::player::compute_char_at(player, sprite_num, pt_vals[0] as i32, pt_vals[1] as i32);
+            Ok(player.alloc_datum(Datum::Int(result)))
+        })
+    }
+
+    /// `scrollByLine(member, amount)` — global form of `member.scrollByLine()`
+    /// (Director 11.5 Scripting Dictionary p.618). Scrolls a field/text member
+    /// by `amount` lines (positive = down). The MM custom scroll bar calls this
+    /// global form from its `move`/`MoveBar` handlers.
+    pub fn scroll_by_line(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            if args.len() != 2 {
+                return Err(ScriptError::new(
+                    "scrollByLine requires 2 arguments (member, amount)".to_string(),
+                ));
+            }
+            let member_ref = player.get_datum(&args[0]).to_member_ref()?;
+            let amount = player.get_datum(&args[1]).to_float()?;
+            crate::player::handlers::datum_handlers::cast_member::text::scroll_member_by_lines(
+                player, &member_ref, amount,
+            );
+            Ok(DatumRef::Void)
+        })
+    }
+
+    /// `scrollByPage(member, amount)` — global form of `member.scrollByPage()`
+    /// (Director 11.5 Scripting Dictionary p.619). Scrolls a field/text member
+    /// by `amount` pages (a page = the lines visible in the member's box).
+    pub fn scroll_by_page(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            if args.len() != 2 {
+                return Err(ScriptError::new(
+                    "scrollByPage requires 2 arguments (member, amount)".to_string(),
+                ));
+            }
+            let member_ref = player.get_datum(&args[0]).to_member_ref()?;
+            let amount = player.get_datum(&args[1]).to_float()?;
+            crate::player::handlers::datum_handlers::cast_member::text::scroll_member_by_pages(
+                player, &member_ref, amount,
+            );
+            Ok(DatumRef::Void)
         })
     }
 

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -228,6 +228,17 @@ pub struct DirPlayer {
     pub title: String,
     pub bg_color: ColorRef,
     pub stage_draw_rect: Option<[f64; 4]>,
+    /// Persistent script-owned stage framebuffer for "imaging Lingo" movies
+    /// that draw directly into `(the stage).image` (e.g. spectral-wizard).
+    /// Created lazily on first `(the stage).image` access and returned as the
+    /// same BitmapRef every call, so a cached `theStage = (the stage).image`
+    /// keeps accumulating draws. `None` until first access.
+    pub stage_image: Option<bitmap::manager::BitmapRef>,
+    /// Set true once a draw op (copyPixels/fill/etc.) targets `stage_image`.
+    /// Only then does the renderer composite it over the sprite output —
+    /// this keeps read-only camera-capture movies (which never draw) on the
+    /// old per-call snapshot behavior.
+    pub stage_image_dirty: bool,
     pub center_stage: bool,
     pub keyboard_focus_sprite: i16,
     pub text_selection_start: u16,
@@ -467,6 +478,8 @@ impl DirPlayer {
             title: "".to_string(),
             bg_color: ColorRef::Rgb(0, 0, 0),
             stage_draw_rect: None,
+            stage_image: None,
+            stage_image_dirty: false,
             center_stage: true,
             keyboard_focus_sprite: -1, // Setting keyboardFocusSprite to -1 returns keyboard focus control to the Score, and setting it to 0 disables keyboard entry into any editable sprite.
             mouse_loc: (0, 0),
@@ -1005,6 +1018,19 @@ impl DirPlayer {
         // Always advance logic (scripts, behaviors)
         self.next_frame = None;
         self.movie.current_frame = next_frame;
+
+        // Leaving a frame drops the "imaging Lingo" stage overlay. An imaging
+        // engine (spectral-wizard) draws its game/menu/worldmap into
+        // `(the stage).image` on ONE looping frame (`go(the frame)` keeps the
+        // same frame → overlay persists). When it actually changes frames —
+        // e.g. Game Over does `go("highscore")` to a sprite-based frame — the
+        // stale game framebuffer would otherwise keep compositing over the new
+        // frame's sprites (a black screen). Clear the dirty flag on a real
+        // frame change; the next frame re-dirties it only if it draws into the
+        // stage image again.
+        if prev_frame != next_frame {
+            self.stage_image_dirty = false;
+        }
 
         // NOTE: Filmloop frames are advanced solely by update_filmloop_frames() in the main loop.
         // Do NOT call advance_filmloop_frames() here - it would cause double advancement since
@@ -3950,10 +3976,20 @@ pub async fn run_single_frame() -> (bool, bool) {
 fn compute_mouse_char(player: &mut DirPlayer) -> i32 {
     let (mx, my) = player.mouse_loc;
     let sprite_num = match score::get_sprite_at(player, mx, my, false) {
-        Some(n) => n,
+        Some(n) => n as i16,
         None => return -1,
     };
-    let sprite = match player.movie.score.get_sprite(sprite_num as i16) {
+    compute_char_at(player, sprite_num, mx, my)
+}
+
+/// Shared core for `the mouseChar` and the `pointToChar()` builtin. Returns the
+/// 1-based character index within `sprite_num`'s text/field member at the stage
+/// coordinate `(mx, my)`, or -1 if the sprite holds no text/field member, the
+/// point is outside the sprite's rect, or it falls past the end of the text.
+/// Matches the Director 11.5 Scripting Dictionary `pointToChar()` contract
+/// ("returns -1 if the point is not within the text").
+pub fn compute_char_at(player: &mut DirPlayer, sprite_num: i16, mx: i32, my: i32) -> i32 {
+    let sprite = match player.movie.score.get_sprite(sprite_num) {
         Some(s) => s,
         None => return -1,
     };
@@ -3973,13 +4009,13 @@ fn compute_mouse_char(player: &mut DirPlayer) -> i32 {
     // mean clicks were resolved against system Arial widths while the
     // renderer drew with the field's PFR Arial. The two layouts diverged
     // by enough to land Fugue No.4 clicks on the wrong underlined run.
-    let (text, line_spacing, top_spacing, wrap_width, scroll_top, word_wrap, font_name, font_size, formatting_runs) =
+    let (text, line_spacing, top_spacing, wrap_width, scroll_top, word_wrap, font_name, font_size, formatting_runs, is_text) =
         match &member.member_type {
             CastMemberType::Field(f) => (
                 f.text.clone(), f.fixed_line_space, f.top_spacing,
                 f.width as i32, f.scroll_top as i32, f.word_wrap,
                 f.font.clone(), f.font_size,
-                f.formatting_runs.clone(),
+                f.formatting_runs.clone(), false,
             ),
             CastMemberType::Text(t) => (
                 t.text.clone(), t.fixed_line_space, t.top_spacing,
@@ -3987,7 +4023,7 @@ fn compute_mouse_char(player: &mut DirPlayer) -> i32 {
                 t.info.as_ref().map(|i| i.scroll_top as i32).unwrap_or(0),
                 t.word_wrap,
                 t.font.clone(), t.font_size,
-                Vec::new(),
+                Vec::new(), true,
             ),
             _ => return -1,
         };
@@ -4004,7 +4040,7 @@ fn compute_mouse_char(player: &mut DirPlayer) -> i32 {
     // through `member`) before we touch `player.font_manager` /
     // `player.bitmap_manager` mutably below.
     drop(member);
-    let rect = score::get_sprite_rect_in_context(player, sprite_num as i16);
+    let rect = score::get_sprite_rect_in_context(player, sprite_num);
     let local_x = mx - rect.0 as i32;
     let local_y = my - rect.1 as i32;
     if local_x < 0 || local_y < 0
@@ -4220,10 +4256,31 @@ fn compute_mouse_char(player: &mut DirPlayer) -> i32 {
         }
         chosen_idx
     } else {
+        // Text members render via the native (Canvas2D) path, where the line
+        // STEP is `fixedLineSpace` itself when set (see
+        // render_native_text_to_bitmap: `effective_line_height = fixed_line_space`),
+        // NOT `font_size + fixedLineSpace`. Passing line_spacing on top of the
+        // font-derived line height (as fields/bitmap path want) double-counts
+        // and makes the y→line mapping drift by a full item per few lines —
+        // e.g. spectral-wizard's help_menu mapped a bottom-of-list hover to a
+        // mid-list link. So for text members override line_height to the native
+        // value and zero the extra spacing.
+        let (line_height_override, eff_line_spacing) = if is_text {
+            let lh: u16 = if line_spacing > 0 {
+                line_spacing
+            } else if font.font_size > 0 {
+                font.font_size
+            } else {
+                font.char_height
+            };
+            (Some(lh), 0u16)
+        } else {
+            (None, line_spacing)
+        };
         let params = crate::player::font::DrawTextParams {
             font: &font,
-            line_height: None,
-            line_spacing,
+            line_height: line_height_override,
+            line_spacing: eff_line_spacing,
             top_spacing,
             char_spacing: 0,
             member_width: if word_wrap && wrap_width > 0 { Some(wrap_width as i16) } else { None },

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -209,8 +209,20 @@ impl Movie {
             },
             "rightMouseDown" => Ok(datum_bool(self.right_mouse_down)),
             "rightMouseUp" => Ok(datum_bool(!self.right_mouse_down)),
-            "traceScript" => Ok(datum_bool(self.trace_script)),
+            // `the trace` toggles the same Lingo-tracing facility as the Trace
+            // button / `the traceScript` (Director 11.5 Scripting Dictionary).
+            "trace" | "traceScript" => Ok(datum_bool(self.trace_script)),
             "activeWindow" => Ok(Datum::Stage),
+            // `the windowList` is the Player property listing all open
+            // movie-in-a-window (MIAW) windows (Director 11.5 Scripting
+            // Dictionary). dirplayer has no MIAW support, so it's always empty —
+            // `count(the windowList)` is then 0, matching a player with only the
+            // Stage open.
+            "windowList" => Ok(Datum::List(
+                crate::director::lingo::datum::DatumType::List,
+                VecDeque::new(),
+                false,
+            )),
             "rollOver" => {
                 reserve_player_ref(|player| {
                     let sprite = super::score::get_sprite_at(player, player.mouse_loc.0, player.mouse_loc.1, false);
@@ -220,6 +232,11 @@ impl Movie {
             "randomSeed" => Ok(Datum::Int(self.random_seed.unwrap_or(0))),
             "maxInteger" => Ok(Datum::Int(i32::MAX)),
             "memorySize" => Ok(Datum::Int(256 * 1024 * 1024)), // 256 MB
+            // `_system.colorDepth` — monitor color depth (Director 11.5
+            // Scripting Dictionary, valid values 1/2/4/8/16/32). The web
+            // canvas is true-color, so report 32. Setting it is a no-op
+            // (see set_prop), matching a monitor that can't change depth.
+            "colorDepth" => Ok(Datum::Int(32)),
             "active3dRenderer" => Ok(Datum::String("#openGL".to_string())),
             "scriptExecutionStyle" => Ok(Datum::Int(9)),
             "xtraList" => {
@@ -334,7 +351,9 @@ impl Movie {
                     )),
                 }
             },
-            "traceScript" => {
+            // `the trace` is an alias for the Trace-button / `the traceScript`
+            // tracing toggle (Director 11.5 Scripting Dictionary).
+            "trace" | "traceScript" => {
                 self.trace_script = value.int_value()? != 0;
                 Ok(())
             },

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -577,20 +577,33 @@ impl Score {
                         // Just clear the exited flag so they remain active.
                         sprite.exited = false;
                         false
-                    } else {
-                        // Non-puppet sprites that EXITED their span are cleaned up
-                        // regardless of visibility. The previous `if sprite.visible`
-                        // gate left an invisible exited sprite with its stale
-                        // behavior instance + `entered`/`exited` flags, so on
-                        // re-entry its span never re-entered and beginSprite never
-                        // re-fired. spectral-wizard's Help scroll bar hides sprite
-                        // 15 (`sprite(15).visible = 0`) for short pages; on the
-                        // second visit that sprite kept its first-visit instance
-                        // (myState=#done), so its InstallElement was skipped and the
-                        // shared `ourMaxScroll` stayed empty → CustomScrollbar_SetScroll
-                        // crashed on `ourMaxScroll[1]`. Visibility is independent of
-                        // span membership, so an exited sprite must reset either way.
+                    } else if sprite.visible {
+                        // Visible non-puppet sprite leaving its span → full reset.
                         sprite.reset();
+                        true
+                    } else {
+                        // Invisible non-puppet exited sprite: clear ONLY the
+                        // behavior lifecycle (instances + entered/exited) so a
+                        // re-entered span re-creates the behavior and re-fires
+                        // beginSprite — but PRESERVE the visual state (visible,
+                        // member, loc). A full reset() forces `visible = true`
+                        // and drops the member, which is wrong here for two
+                        // reasons:
+                        //  - spectral-wizard's Help scroll bar hides sprite 15
+                        //    (`sprite(15).visible = 0`) for short pages; on the
+                        //    second visit its stale first-visit instance lingered
+                        //    (myState=#done), InstallElement was skipped, and the
+                        //    shared `ourMaxScroll` stayed empty → SetScroll crashed
+                        //    on `ourMaxScroll[1]`. It needs the lifecycle cleared.
+                        //  - Pinball keeps its flipper-frame sprites deliberately
+                        //    hidden until interaction; forcing them visible drew
+                        //    every animation frame at once. It needs `visible=0`
+                        //    preserved.
+                        // Clearing the lifecycle satisfies the first; preserving
+                        // the visual state satisfies the second.
+                        sprite.script_instance_list.clear();
+                        sprite.entered = false;
+                        sprite.exited = false;
                         true
                     }
                 };

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -577,11 +577,21 @@ impl Score {
                         // Just clear the exited flag so they remain active.
                         sprite.exited = false;
                         false
-                    } else if sprite.visible {
+                    } else {
+                        // Non-puppet sprites that EXITED their span are cleaned up
+                        // regardless of visibility. The previous `if sprite.visible`
+                        // gate left an invisible exited sprite with its stale
+                        // behavior instance + `entered`/`exited` flags, so on
+                        // re-entry its span never re-entered and beginSprite never
+                        // re-fired. spectral-wizard's Help scroll bar hides sprite
+                        // 15 (`sprite(15).visible = 0`) for short pages; on the
+                        // second visit that sprite kept its first-visit instance
+                        // (myState=#done), so its InstallElement was skipped and the
+                        // shared `ourMaxScroll` stayed empty → CustomScrollbar_SetScroll
+                        // crashed on `ourMaxScroll[1]`. Visibility is independent of
+                        // span membership, so an exited sprite must reset either way.
                         sprite.reset();
                         true
-                    } else {
-                        false
                     }
                 };
                 // Invalidate the cached scriptInstanceList so stale ScriptInstanceRefs

--- a/vm-rust/src/player/script.rs
+++ b/vm-rust/src/player/script.rs
@@ -468,6 +468,12 @@ pub async fn player_set_obj_prop(
             // TODO should we really pass a clone of the value here?
             CastMemberRefHandlers::set_prop(&member_ref, prop_name, value_clone)
         }
+        // `member.vertex[i].handle1 = point` etc. — write a sub-property of a
+        // vectorShape vertex reference straight back into the member.
+        Datum::VectorVertexRef(member_ref, index) => reserve_player_mut(|player| {
+            crate::player::handlers::datum_handlers::cast_member::vector_shape::VectorShapeMemberHandlers
+                ::set_vertex_ref_prop(player, &member_ref, index, prop_name, &value_clone)
+        }),
         Datum::Stage => reserve_player_mut(|player| set_stage_prop(player, &prop_name, value_ref)),
         Datum::BitmapRef(bitmap_ref) => reserve_player_mut(|player| {
             BitmapDatumHandlers::set_bitmap_ref_prop(player, bitmap_ref, prop_name, value_ref)
@@ -616,6 +622,13 @@ pub fn get_obj_prop(
         }
         Datum::CastMember(member_ref) => {
             let result = CastMemberRefHandlers::get_prop(player, &member_ref, prop_name)?;
+            Ok(player.alloc_datum(result))
+        }
+        // `member.vertex[i].handle1` etc. — read a sub-property of a
+        // vectorShape vertex reference (produced by getPropRef).
+        Datum::VectorVertexRef(member_ref, index) => {
+            let result = crate::player::handlers::datum_handlers::cast_member::vector_shape::VectorShapeMemberHandlers
+                ::get_vertex_ref_prop(player, &member_ref, index, prop_name)?;
             Ok(player.alloc_datum(result))
         }
         Datum::ScriptInstanceRef(script_instance_id) => {

--- a/vm-rust/src/player/stage.rs
+++ b/vm-rust/src/player/stage.rs
@@ -196,16 +196,41 @@ pub fn get_stage_prop(player: &mut DirPlayer, prop: &str) -> Result<Datum, Scrip
         }
         "bgColor" => Ok(Datum::ColorRef(player.bg_color.clone())),
         "image" => {
-            let mut captured_bitmap = None;
+            // `(the stage).image` is a *live, writable* handle to the stage
+            // framebuffer (Director 11.5 Scripting Dictionary — drawing into
+            // it via draw()/copyPixels()/fill() appears on screen). We back it
+            // with one persistent bitmap reused across calls, so a cached
+            // `theStage = (the stage).image` keeps accumulating draws (the
+            // "imaging Lingo" engine pattern used by spectral-wizard et al.).
+            //
+            // While no script has drawn into it (`stage_image_dirty == false`),
+            // we refresh its contents from the current render on every access
+            // — this preserves the read-only snapshot behavior camera-capture
+            // movies rely on. Once a draw marks it dirty, the renderer
+            // composites it over the sprite output and we leave its pixels
+            // alone here.
+            let has_clean_existing = match player.stage_image {
+                Some(existing) => {
+                    player.bitmap_manager.get_bitmap(existing).is_some()
+                        && player.stage_image_dirty
+                }
+                None => false,
+            };
+            // A dirty existing image is returned as-is; only build a fresh
+            // render snapshot when we need to create or refresh (clean) it.
+            // (capture_stage_bitmap runs a full draw_frame, so skip it when
+            // possible.)
+            if has_clean_existing {
+                return Ok(Datum::BitmapRef(player.stage_image.unwrap()));
+            }
+
+            let mut snapshot = None;
             with_renderer_mut(|renderer_opt| {
                 if let Some(renderer) = renderer_opt {
-                    captured_bitmap = Some(renderer.capture_stage_bitmap(player));
+                    snapshot = Some(renderer.capture_stage_bitmap(player));
                 }
             });
-
-            let new_bitmap = if let Some(bitmap) = captured_bitmap {
-                bitmap
-            } else {
+            let mut snapshot = snapshot.unwrap_or_else(|| {
                 let layout = stage_layout(player);
                 let w = layout.stage_rect[2] - layout.stage_rect[0];
                 let h = layout.stage_rect[3] - layout.stage_rect[1];
@@ -219,14 +244,34 @@ pub fn get_stage_prop(player: &mut DirPlayer, prop: &str) -> Result<Datum, Scrip
                 );
                 render_stage_to_bitmap(player, &mut bitmap, None);
                 bitmap
-            };
-            // Ephemeral: a fresh stage snapshot per call. Once no DatumRef
-            // wraps it (e.g. after the script's `(the stage).image` Lingo
-            // expression goes out of scope) the bitmap is freed. RemoteControl
-            // CameraScreen scripts call this every frame — without ephemeral
-            // tracking each call leaks ~movie_w*movie_h*4 bytes forever.
-            let bitmap_id = player.bitmap_manager.add_ephemeral_bitmap(new_bitmap);
-            Ok(Datum::BitmapRef(bitmap_id))
+            });
+            // The stage framebuffer is OPAQUE — Director's `(the stage).image`
+            // has no alpha channel. `capture_stage_bitmap` flags its result
+            // use_alpha=true, but if the persistent stage image keeps that
+            // flag, `copyPixels` of an alpha source onto it writes transparent
+            // pixels verbatim (as black) instead of skipping them — imaging-
+            // Lingo movies that blit an alpha bubble/dialog onto the stage
+            // (spectral-wizard: `theStage.copyPixels(talkBoxBuffer)`) then get
+            // a black box around the shape. Force opaque so the alpha source's
+            // transparent pixels are skipped and the scene shows through.
+            snapshot.use_alpha = false;
+
+            match player.stage_image {
+                Some(existing) if player.bitmap_manager.get_bitmap(existing).is_some() => {
+                    // Clean existing image — refresh from the live render so
+                    // camera-capture reads see current sprite content.
+                    if let Some(dst) = player.bitmap_manager.get_bitmap_mut(existing) {
+                        *dst = snapshot;
+                    }
+                    Ok(Datum::BitmapRef(existing))
+                }
+                _ => {
+                    let bitmap_id = player.bitmap_manager.add_bitmap(snapshot);
+                    player.stage_image = Some(bitmap_id);
+                    player.stage_image_dirty = false;
+                    Ok(Datum::BitmapRef(bitmap_id))
+                }
+            }
         }
         "name" => Ok(Datum::String("stage".to_string())),
         _ => return Err(ScriptError::new(format!("Invalid stage property {}", prop))),

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -3206,6 +3206,28 @@ impl PlayerCanvasRenderer {
         let bitmap = &mut self.bitmap;
         render_stage_to_bitmap(player, bitmap, self.debug_selected_channel_num);
 
+        // Composite the script-owned stage framebuffer over the sprite render
+        // for "imaging Lingo" movies that draw straight into `(the stage).image`
+        // (see stage.rs `image` getter). Only once a script has actually drawn
+        // into it (`stage_image_dirty`).
+        if player.stage_image_dirty {
+            if let Some(stage_ref) = player.stage_image {
+                if let Some(src) = player.bitmap_manager.get_bitmap(stage_ref) {
+                    let palettes = player.movie.cast_manager.palettes();
+                    let w = bitmap.width as i32;
+                    let h = bitmap.height as i32;
+                    bitmap.copy_pixels(
+                        &palettes,
+                        src,
+                        IntRect::from(0, 0, w, h),
+                        IntRect::from(0, 0, src.width as i32, src.height as i32),
+                        &HashMap::new(),
+                        None,
+                    );
+                }
+            }
+        }
+
         #[cfg(feature = "alloc-debug-overlay")]
         if let Some(font) = player.font_manager.get_system_font() {
             let font_bitmap = player.bitmap_manager.get_bitmap(font.bitmap_ref).unwrap();

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -101,6 +101,9 @@ pub struct WebGL2Renderer {
     trails_texture: Option<web_sys::WebGlTexture>,
     /// Size of the trails FBO texture
     trails_size: (u32, u32),
+    /// Reused texture for compositing the script-owned stage framebuffer
+    /// (`(the stage).image` imaging-Lingo overlay). Re-uploaded each frame.
+    stage_image_texture: Option<web_sys::WebGlTexture>,
     /// Shockwave 3D scene renderer
     scene3d: scene3d::Scene3dRenderer,
     native_cursor_cache: crate::cursor::NativeCursorCache,
@@ -179,6 +182,7 @@ impl WebGL2Renderer {
             trails_fbo: None,
             trails_texture: None,
             trails_size: (0, 0),
+            stage_image_texture: None,
             scene3d: scene3d::Scene3dRenderer::new(),
             native_cursor_cache: None,
         })
@@ -348,6 +352,83 @@ impl WebGL2Renderer {
         gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
     }
 
+    /// Composite the script-owned stage framebuffer (`(the stage).image`) as a
+    /// full-screen quad over the sprite render. No-op until a script has drawn
+    /// into it (`stage_image_dirty`). The bitmap is re-uploaded each frame
+    /// because its contents change as the movie redraws.
+    fn draw_stage_image_overlay(&mut self, player: &mut DirPlayer) {
+        if !player.stage_image_dirty {
+            return;
+        }
+        let stage_ref = match player.stage_image {
+            Some(r) => r,
+            None => return,
+        };
+        let (sw, sh, data) = match player.bitmap_manager.get_bitmap(stage_ref) {
+            Some(b) => (b.width as u32, b.height as u32, b.data.clone()),
+            None => return,
+        };
+        if sw == 0 || sh == 0 {
+            return;
+        }
+
+        // Lazily create the reused texture, then upload the current pixels.
+        if self.stage_image_texture.is_none() {
+            self.stage_image_texture = self.context.create_texture().ok();
+        }
+        let texture = match &self.stage_image_texture {
+            Some(t) => t.clone(),
+            None => return,
+        };
+        if self.context.upload_texture_rgba(&texture, sw, sh, &data).is_err() {
+            return;
+        }
+
+        let (width, height) = self.size;
+        let effective_ink = self.shader_manager.use_program(&self.context, InkMode::Copy);
+        let program = match self.shader_manager.get_program(effective_ink) {
+            Some(p) => p,
+            None => return,
+        };
+        self.context.set_blend_alpha();
+
+        let gl = self.context.gl();
+        self.quad.bind(gl);
+        gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+        gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&texture));
+        if let Some(ref loc) = program.u_texture {
+            gl.uniform1i(Some(loc), 0);
+        }
+        if let Some(ref loc) = program.u_sprite_rect {
+            gl.uniform4f(Some(loc), 0.0, 0.0, width as f32, height as f32);
+        }
+        if let Some(ref loc) = program.u_tex_rect {
+            gl.uniform4f(Some(loc), 0.0, 0.0, 1.0, 1.0);
+        }
+        if let Some(ref loc) = program.u_flip {
+            gl.uniform2f(Some(loc), 0.0, 0.0);
+        }
+        if let Some(ref loc) = program.u_rotation {
+            gl.uniform1f(Some(loc), 0.0);
+        }
+        if let Some(ref loc) = program.u_skew_flip {
+            gl.uniform1f(Some(loc), 0.0);
+        }
+        if let Some(ref loc) = program.u_skew {
+            gl.uniform1f(Some(loc), 0.0);
+        }
+        if let Some(ref loc) = program.u_rotation_center {
+            gl.uniform2f(Some(loc), 0.0, 0.0);
+        }
+        if let Some(ref loc) = program.u_blend {
+            gl.uniform1f(Some(loc), 1.0);
+        }
+
+        self.quad.draw(gl);
+        gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
+        self.quad.unbind(gl);
+    }
+
     /// Draw the current frame
     pub fn draw_frame(&mut self, player: &mut DirPlayer) {
         self.frame_count += 1;
@@ -467,6 +548,11 @@ impl WebGL2Renderer {
             // No trails sprites - clean up FBO
             self.destroy_trails_fbo();
         }
+
+        // Composite the script-owned stage framebuffer over the sprite render
+        // for "imaging Lingo" movies that draw into `(the stage).image`
+        // (see stage.rs `image` getter). Only once a script has drawn into it.
+        self.draw_stage_image_overlay(player);
 
         // Update native CSS cursor (no per-frame draw needed)
         self.update_native_cursor(player);
@@ -1852,6 +1938,46 @@ impl WebGL2Renderer {
                         }).collect())
                     };
 
+                    // Ink 4 (NotCopy): Director displays the inverse of the Copy
+                    // colors. The RenderedText path composites with the Copy
+                    // shader (white bg keyed to alpha), so the inversion can't
+                    // happen in-shader — bake it into the text colors instead.
+                    // spectral-wizard's HELP title stacks an ink-4 copy of the
+                    // cream `help_header` behind the cream one to form a black
+                    // drop shadow (FFFBF0 → ~00040F).
+                    let (styled_spans_with_defaults, text_fg_color) = if ink == 4 {
+                        let inv_spans = styled_spans_with_defaults.map(|spans| {
+                            spans.into_iter().map(|mut s| {
+                                if let Some(c) = s.style.color {
+                                    s.style.color = Some(!c & 0xFFFFFF);
+                                }
+                                s
+                            }).collect::<Vec<_>>()
+                        });
+                        let inv_fg = match &text_fg_color {
+                            ColorRef::Rgb(r, g, b) => ColorRef::Rgb(255 - r, 255 - g, 255 - b),
+                            other => other.clone(),
+                        };
+                        (inv_spans, inv_fg)
+                    } else {
+                        (styled_spans_with_defaults, text_fg_color)
+                    };
+
+                    // Apply `scrollTop` the same way the field path does: shift
+                    // the draw origin upward by scroll_top so a scrollable text
+                    // member shows the scrolled-to portion (the MM custom scroll
+                    // bar sets help_text to boxType #fixed and drives scrollTop).
+                    // Positive scroll_top → negative effective top_spacing → the
+                    // first lines clip above the box top. Folding it into
+                    // top_spacing (which the cache key hashes) re-rasterizes the
+                    // texture on every scroll. keep_authored_height is already
+                    // forced below for non-#adjust box types, so the bitmap stays
+                    // at the box height instead of growing with the content.
+                    let text_scroll_top =
+                        text_member.info.as_ref().map(|i| i.scroll_top as i32).unwrap_or(0);
+                    let effective_top_spacing = (text_member.top_spacing as i32 - text_scroll_top)
+                        .clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+
                     // Build cache key from the final styled spans that will actually be rendered.
                     let styled_spans_ref = styled_spans_with_defaults.as_ref().map(|s| s.as_slice());
                     let text_has_focus = player.keyboard_focus_sprite == channel_num;
@@ -1876,7 +2002,7 @@ impl WebGL2Renderer {
                         font_size,
                         font_style,
                         text_member.fixed_line_space,
-                        text_member.top_spacing,
+                        effective_top_spacing,
                     );
                     // For #fixed (and #limit/#scroll) text members the
                     // authored member.height is the rendering box; content
@@ -2008,7 +2134,7 @@ impl WebGL2Renderer {
                         font_style,
                         font_id: None,
                         line_spacing: text_member.fixed_line_space,
-                        top_spacing: text_member.top_spacing,
+                        top_spacing: effective_top_spacing,
                         bottom_spacing: text_member.bottom_spacing,
                         width,
                         height,
@@ -6122,23 +6248,24 @@ impl WebGL2Renderer {
             &PaletteRef::BuiltIn(get_system_default_palette()),
             8,
         );
-        // For transparency inks, NEVER fill the background.
-        // The text bitmap already has alpha=0 for background, alpha>0 for text.
-        // These inks rely on the alpha channel for transparency:
-        // - Ink 7 (Not Ghost): discards alpha=0 pixels via matte
-        // - Ink 8 (Matte): discards alpha<0.01 pixels in shader
-        // - Ink 9 (Mask): uses alpha as mask
-        // - Ink 36 (BgTransparent): composited with alpha blending
-        // Filling background with bg_color at alpha=255 would make the entire
-        // text area opaque, producing solid colored rectangles instead of text.
-        let is_transparency_ink = ink == 3 || ink == 7 || ink == 8 || ink == 9 || ink == 36;
+        // Only ink 0 (Copy) paints the member's opaque background. Every other
+        // ink lets the background fall through (relying on the text bitmap's
+        // alpha=0 background / alpha>0 glyphs), which is exactly what the
+        // comment below already documents: ink 0 = bg drawn, otherwise not.
+        //
+        // The previous `!is_transparency_ink` heuristic only excluded a small
+        // set (3,7,8,9,36) and so force-filled an opaque white box under every
+        // other ink — including ink 4 (NotCopy), which spectral-wizard's HELP
+        // title uses for its drop shadow: the same cream `help_header` member,
+        // NotCopy-inverted to black and offset behind the cream copy. The
+        // bogus white fill from the shadow sprite covered the whole title.
+        // (Transparent/Reverse/blend inks on text were similarly wrong.)
+        //
         // White bg fields use ink 36 (BgTransparent) when the author wants the
-        // bg to fall through (e.g. text/field members composited over a 3D
-        // scene). Under any non-transparent ink (e.g. ink 0 Copy on Coke
-        // Studios' `nav_vego_search_field` v-ego search box) the white bg has
-        // to be drawn — otherwise the field appears as transparent text on
-        // whatever's behind it. Don't second-guess the ink here.
-        let has_bg_fill = !is_transparency_ink;
+        // bg to fall through (e.g. text/field members over a 3D scene). Coke
+        // Studios' `nav_vego_search_field` v-ego search box uses ink 0 Copy and
+        // needs its white bg drawn — preserved here.
+        let has_bg_fill = ink == 0;
 
         // After drawing text, handle background pixels.
         // The bitmap was pre-filled with alpha=0 (transparent).


### PR DESCRIPTION
cb99f1f4 flash: queue setVariable before Ruffle instance is ready
b08d5d8f player: reset invisible exited sprites on frame re-entry, text hit-test core
d49f36fd render: webgl2 text bg-fill/NotCopy/scrollTop, stage image, render loop
911a14d3 lingo: inflate/pointToChar/scrollByLine/charPosToLoc builtins, movie props, keyPressed, rgb() whitespace
e0326917 text/field: hyperlinks, per-run styling (color/size/font), scrolling, word-chunk delete
64b75782 bitmap: alpha compositing (ink0 blend, quad blit), copyPixels fill shapes
a9dd7d6d vectorshape: FLSH parser, Lingo getters/setters, vertex/handle refs

fixes #189 