### PR TITLE
supporting spongebob squarepants jellyfishing game

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,3 +8,6 @@
 [submodule "xtras/bobba-xtra"]
 	path = xtras/bobba-xtra
 	url = https://github.com/chameleonxxl/bobba-xtra.git
+[submodule "xtras/groove-xtra"]
+	path = xtras/groove-xtra
+	url = https://github.com/chameleonxxl/groove-xtra.git

--- a/cors-proxy.cjs
+++ b/cors-proxy.cjs
@@ -94,6 +94,15 @@ function proxyRequest(targetUrl, clientReq, res, bodyChunks, redirectsLeft) {
       for (const [k, v] of Object.entries(up.headers)) {
         if (!STRIP_RES_HEADERS.has(k.toLowerCase())) outHeaders[k] = v;
       }
+      // Preserve Content-Length when the body is identity-encoded. We strip
+      // `accept-encoding` from the request (so upstream returns identity) and
+      // pipe the body unchanged, so the upstream length is accurate. Without it
+      // Director's getStreamStatus(netID)[#bytestotal] is 0, so preloadNetThing
+      // progress (percentloaded) sits at 0% forever and DGS loading bars never
+      // advance. Only skipped if upstream actually sent a content-encoding.
+      if (!up.headers["content-encoding"] && up.headers["content-length"]) {
+        outHeaders["content-length"] = up.headers["content-length"];
+      }
       res.writeHead(status, outHeaders);
       up.pipe(res);
     }

--- a/cors-proxy.cjs
+++ b/cors-proxy.cjs
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+// Generic dev CORS proxy for DirPlayer "loader mode".
+//
+// Lets the localhost dev UI fetch a Shockwave game (its loader page, the
+// .dcr, external casts, images, sounds, and high-score POSTs) from a live
+// site that doesn't send CORS headers. It fetches the target server-side and
+// re-serves it with permissive CORS, forwarding method / body / most headers.
+//
+//   GET  /cors?url=<encoded absolute url>
+//   POST /cors?url=<encoded absolute url>   (body forwarded)
+//
+// This is a DEV-ONLY tool: it will proxy any URL, so run it only on localhost.
+// It is entirely separate from ws-tcp-proxy-all.cjs and is opt-in — the dev UI
+// only routes through it when loader mode is active.
+//
+//   node cors-proxy.cjs            # listens on 127.0.0.1:3099
+//   PORT=4000 node cors-proxy.cjs  # custom port
+
+const http = require("http");
+const https = require("https");
+const { URL } = require("url");
+
+const PORT = parseInt(process.env.PORT || "3099", 10);
+const HOST = process.env.HOST || "127.0.0.1";
+const MAX_REDIRECTS = 8;
+
+// Hop-by-hop headers must not be forwarded, plus a few that break re-serving.
+const STRIP_REQ_HEADERS = new Set([
+  "host", "origin", "referer", "connection", "keep-alive",
+  "proxy-authenticate", "proxy-authorization", "te", "trailer",
+  "transfer-encoding", "upgrade", "accept-encoding", // let node negotiate/pass-through identity
+]);
+const STRIP_RES_HEADERS = new Set([
+  "connection", "keep-alive", "transfer-encoding", "content-encoding",
+  "content-length", "content-security-policy", "content-security-policy-report-only",
+  "x-frame-options", "cross-origin-opener-policy", "cross-origin-embedder-policy",
+  "cross-origin-resource-policy", "set-cookie", // set-cookie can't cross origin usefully anyway
+]);
+
+function corsHeaders(reqHeaders) {
+  return {
+    "access-control-allow-origin": reqHeaders.origin || "*",
+    "access-control-allow-methods": "GET, POST, PUT, DELETE, OPTIONS, HEAD",
+    "access-control-allow-headers":
+      reqHeaders["access-control-request-headers"] || "*",
+    "access-control-allow-credentials": "true",
+    "access-control-expose-headers": "*",
+    "access-control-max-age": "86400",
+  };
+}
+
+function fail(res, reqHeaders, code, msg) {
+  res.writeHead(code, { "content-type": "text/plain", ...corsHeaders(reqHeaders) });
+  res.end(msg);
+}
+
+function proxyRequest(targetUrl, clientReq, res, bodyChunks, redirectsLeft) {
+  let target;
+  try {
+    target = new URL(targetUrl);
+  } catch {
+    return fail(res, clientReq.headers, 400, `Bad target url: ${targetUrl}`);
+  }
+  if (target.protocol !== "http:" && target.protocol !== "https:") {
+    return fail(res, clientReq.headers, 400, `Unsupported protocol: ${target.protocol}`);
+  }
+
+  const headers = {};
+  for (const [k, v] of Object.entries(clientReq.headers)) {
+    if (!STRIP_REQ_HEADERS.has(k.toLowerCase())) headers[k] = v;
+  }
+  headers["host"] = target.host;
+  // Present as a normal same-site request to the target.
+  headers["referer"] = target.origin + "/";
+  headers["origin"] = target.origin;
+
+  const lib = target.protocol === "https:" ? https : http;
+  const upstream = lib.request(
+    target,
+    { method: clientReq.method, headers },
+    (up) => {
+      const status = up.statusCode || 502;
+      // Follow redirects server-side so the browser never sees a cross-origin 3xx.
+      if (
+        status >= 300 && status < 400 && up.headers.location &&
+        redirectsLeft > 0
+      ) {
+        up.resume(); // drain
+        const next = new URL(up.headers.location, target).toString();
+        return proxyRequest(next, clientReq, res, bodyChunks, redirectsLeft - 1);
+      }
+
+      const outHeaders = { ...corsHeaders(clientReq.headers) };
+      for (const [k, v] of Object.entries(up.headers)) {
+        if (!STRIP_RES_HEADERS.has(k.toLowerCase())) outHeaders[k] = v;
+      }
+      res.writeHead(status, outHeaders);
+      up.pipe(res);
+    }
+  );
+
+  upstream.on("error", (err) => {
+    fail(res, clientReq.headers, 502, `Upstream error: ${err.message}`);
+  });
+
+  if (bodyChunks && bodyChunks.length) upstream.end(Buffer.concat(bodyChunks));
+  else upstream.end();
+}
+
+const server = http.createServer((req, res) => {
+  // CORS preflight.
+  if (req.method === "OPTIONS") {
+    res.writeHead(204, corsHeaders(req.headers));
+    return res.end();
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(req.url, `http://${HOST}:${PORT}`);
+  } catch {
+    return fail(res, req.headers, 400, "Bad request url");
+  }
+
+  if (parsed.pathname === "/" || parsed.pathname === "/health") {
+    res.writeHead(200, { "content-type": "text/plain", ...corsHeaders(req.headers) });
+    return res.end("DirPlayer CORS proxy. Use /cors?url=<encoded absolute url>\n");
+  }
+
+  if (parsed.pathname !== "/cors") {
+    return fail(res, req.headers, 404, "Not found. Use /cors?url=<encoded absolute url>");
+  }
+
+  const target = parsed.searchParams.get("url");
+  if (!target) {
+    return fail(res, req.headers, 400, "Missing ?url= parameter");
+  }
+
+  const chunks = [];
+  req.on("data", (c) => chunks.push(c));
+  req.on("end", () => proxyRequest(target, req, res, chunks, MAX_REDIRECTS));
+  req.on("error", () => fail(res, req.headers, 400, "Request stream error"));
+});
+
+server.listen(PORT, HOST, () => {
+  console.log(`[cors-proxy] listening on http://${HOST}:${PORT}/cors?url=<encoded url>`);
+});

--- a/dirplayer-js-api/index.d.ts
+++ b/dirplayer-js-api/index.d.ts
@@ -52,7 +52,7 @@ type TVmCallbacks = {
   onChannelChanged: (channelNumber: number, channelData: ScoreSpriteSnapshot) => void,
   onChannelDisplayNameChanged: (channelNumber: number, displayName: string) => void,
   onExternalEvent?: (event: string) => void,
-  onFlashMemberLoaded?: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean) => void,
+  onFlashMemberLoaded?: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean, assertedFrame: number) => void,
   onFlashMemberUnloaded?: (spriteNum: number) => void,
   onStageSizeChanged?: (width: number, height: number, center: boolean) => void,
 }

--- a/dirplayer-js-api/index.d.ts
+++ b/dirplayer-js-api/index.d.ts
@@ -54,6 +54,7 @@ type TVmCallbacks = {
   onExternalEvent?: (event: string) => void,
   onFlashMemberLoaded?: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean, assertedFrame: number) => void,
   onFlashMemberUnloaded?: (spriteNum: number) => void,
+  onFlashResetAll?: () => void,
   onStageSizeChanged?: (width: number, height: number, center: boolean) => void,
 }
 declare let vmCallbacks: TVmCallbacks | undefined;

--- a/dirplayer-js-api/index.js
+++ b/dirplayer-js-api/index.js
@@ -140,6 +140,12 @@ export function onFlashMemberUnloaded(spriteNum) {
   }
 }
 
+export function onFlashResetAll() {
+  if (vmCallbacks?.onFlashResetAll) {
+    vmCallbacks.onFlashResetAll();
+  }
+}
+
 export function onStageSizeChanged(width, height, center) {
   if (vmCallbacks?.onStageSizeChanged) {
     vmCallbacks.onStageSizeChanged(width, height, center);

--- a/dirplayer-js-api/index.js
+++ b/dirplayer-js-api/index.js
@@ -124,11 +124,11 @@ export function onExternalEvent(event) {
   }
 }
 
-export function onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart) {
+export function onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart, assertedFrame) {
   if (vmCallbacks?.onFlashMemberLoaded) {
-    vmCallbacks.onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart);
+    vmCallbacks.onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart, assertedFrame);
   } else {
-    console.log('Flash member loaded:', 'sprite#' + spriteNum, castLib, castMember, width, height, swfData.length, 'bytes', 'pausedAtStart=' + pausedAtStart);
+    console.log('Flash member loaded:', 'sprite#' + spriteNum, castLib, castMember, width, height, swfData.length, 'bytes', 'pausedAtStart=' + pausedAtStart, 'assertedFrame=' + assertedFrame);
   }
 }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -23,7 +23,7 @@
     }
   ],
   "host_permissions": ["<all_urls>"],
-  "permissions": ["scripting"],
+  "permissions": ["scripting", "declarativeNetRequest"],
   "background": {
     "service_worker": "extension/src/background.ts",
     "type": "module"

--- a/extension/src/background.ts
+++ b/extension/src/background.ts
@@ -104,11 +104,104 @@ async function ensureRegistered(): Promise<void> {
   }
 }
 
-chrome.runtime.onInstalled.addListener(() => { void ensureRegistered(); });
-chrome.runtime.onStartup.addListener(() => { void ensureRegistered(); });
+// Cross-origin fetch proxy for the isolated-world content script. In MV3 a
+// content-script `fetch()` is page-privileged (subject to the page's CORS), so
+// `host_permissions` does NOT let it read cross-origin responses — but the
+// service worker (with host_permissions <all_urls>) can. Neopets' DGS loads its
+// game SWF (ml_maraqua.swf) and other assets from cross-origin neopets hosts;
+// flashPlayerManager's fetch shim routes those here. Bytes are base64-framed
+// because chrome.runtime messaging JSON-serializes payloads.
+interface CorsFetchRequest {
+  type: 'dirplayer-cors-fetch';
+  url: string;
+  method?: string;
+  headers?: Record<string, string>;
+  body?: string; // base64
+}
+
+chrome.runtime.onMessage.addListener((msg: CorsFetchRequest, _sender, sendResponse) => {
+  if (!msg || msg.type !== 'dirplayer-cors-fetch') return; // not ours — let others handle
+  (async () => {
+    try {
+      const body = msg.body
+        ? Uint8Array.from(atob(msg.body), (c) => c.charCodeAt(0))
+        : undefined;
+      const res = await fetch(msg.url, {
+        method: msg.method || 'GET',
+        headers: msg.headers,
+        body,
+        credentials: 'omit',
+      });
+      const buf = new Uint8Array(await res.arrayBuffer());
+      let bin = '';
+      const CHUNK = 0x8000;
+      for (let i = 0; i < buf.length; i += CHUNK) {
+        bin += String.fromCharCode.apply(
+          null,
+          buf.subarray(i, i + CHUNK) as unknown as number[],
+        );
+      }
+      sendResponse({
+        ok: res.ok,
+        status: res.status,
+        statusText: res.statusText,
+        contentType: res.headers.get('content-type') || '',
+        bodyBase64: btoa(bin),
+      });
+    } catch (e) {
+      sendResponse({ ok: false, status: 0, error: String((e as Error)?.message || e) });
+    }
+  })();
+  return true; // keep the message channel open for the async sendResponse
+});
+
+// CORS relaxation for Ruffle's MAIN-world SWF loads. Ruffle runs in the page's
+// main world (no extension privileges), so its cross-origin asset fetches
+// (Neopets' swf.neopets.com dgs_include_v2.swf / game SWFs) are CORS-blocked.
+// Rather than monkey-patching the page's window.fetch (which reads as page
+// tampering to store reviewers), add the CORS response header declaratively via
+// declarativeNetRequest — an inspectable, Google-endorsed API. The rule is
+// scoped to the media/plugin/fetch resource types an emulator actually loads,
+// not arbitrary API traffic. Content-script (isolated-world) fetches keep going
+// through the background message proxy above; this rule is what unblocks the
+// main-world Ruffle player. `Access-Control-Allow-Origin: *` is safe here
+// because these are un-credentialed asset GETs.
+const CORS_DNR_RULE_ID = 2001;
+
+async function ensureCorsRules(): Promise<void> {
+  const dnr = (chrome as unknown as { declarativeNetRequest?: {
+    updateDynamicRules?: (opts: unknown) => Promise<void>;
+  } }).declarativeNetRequest;
+  if (!dnr?.updateDynamicRules) return;
+  try {
+    await dnr.updateDynamicRules({
+      removeRuleIds: [CORS_DNR_RULE_ID],
+      addRules: [{
+        id: CORS_DNR_RULE_ID,
+        priority: 1,
+        action: {
+          type: 'modifyHeaders',
+          responseHeaders: [
+            { header: 'Access-Control-Allow-Origin', operation: 'set', value: '*' },
+          ],
+        },
+        condition: {
+          urlFilter: '*',
+          resourceTypes: ['media', 'object', 'xmlhttprequest', 'other', 'sub_frame'],
+        },
+      }],
+    });
+  } catch (e) {
+    console.warn('[DirPlayer] failed to install CORS DNR rule:', e);
+  }
+}
+
+chrome.runtime.onInstalled.addListener(() => { void ensureRegistered(); void ensureCorsRules(); });
+chrome.runtime.onStartup.addListener(() => { void ensureRegistered(); void ensureCorsRules(); });
 // Also register on service-worker activation in case the listeners above
 // missed (e.g. extension was loaded mid-session via reload).
 void ensureRegistered();
+void ensureCorsRules();
 
 // Note: the chrome-extension URL needed by Ruffle's chunk loader gets
 // stamped onto `<html data-dirplayer-ruffle-url="...">` by an isolated-

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "proxy": "node ws-tcp-proxy-all.cjs",
+    "cors-proxy": "node cors-proxy.cjs",
     "electron-dev": "mkdir -p build && cp public/electron.cjs build/electron.cjs && concurrently \"BROWSER=none npm run start\" \"wait-on http://localhost:3000 && electron .\"",
     "electron-pack": "electron-builder",
     "preelectron-pack": "npm run build"

--- a/public/dirplayer-ruffle-bridge-host.js
+++ b/public/dirplayer-ruffle-bridge-host.js
@@ -66,6 +66,21 @@
   var RES_EVENT = 'dirplayer-ruffle-bridge-response';
   var EVT_EVENT = 'dirplayer-ruffle-bridge-event';
 
+  // dirplayer LocalConnection.send bridge (main world → isolated). The Ruffle
+  // fork runs HERE (main world) and calls window.dirplayer_localConnectionSend
+  // when a SWF does LocalConnection.send; dirplayer's WASM export that dispatches
+  // the Lingo setCallback handler lives in the ISOLATED world. Re-fire it there
+  // as a DOM event (shared document, wombat-safe). Fire-and-forget — the fork
+  // ignores the return. dirplayer_-namespaced so it never collides with stock.
+  window.dirplayer_localConnectionSend = function (name, method, argsJson) {
+    try {
+      window.dispatchEvent(new CustomEvent('dirplayer-lc-send', {
+        detail: { name: name, method: method, argsJson: argsJson },
+      }));
+    } catch (e) { /* ignore */ }
+    return false;
+  };
+
   function respond(requestId, payload, error) {
     window.dispatchEvent(new CustomEvent(RES_EVENT, {
       detail: {
@@ -115,9 +130,69 @@
     }
   }
 
+  // Shared, dirplayer-namespaced node for the SYNCHRONOUS request/response path
+  // (GetVariable / SetVariable / CallFunction). Lingo consumes these inline, and
+  // the async Promise transport below can't answer synchronously — so the sync
+  // handler runs DURING the isolated world's dispatchEvent and writes the result
+  // here before dispatch returns. Plain DOM text crosses worlds, is untouched by
+  // wombat, and is invisible to stock Ruffle.
+  var SYNC_NODE_ID = '__dirplayer_ruffle_sync_channel';
+
+  function writeSyncResult(syncId, result, error) {
+    var el = document.getElementById(SYNC_NODE_ID);
+    if (!el) return; // client creates it before dispatch; nothing to write to otherwise
+    el.textContent = JSON.stringify({
+      syncId: syncId,
+      result: error == null ? result : undefined,
+      error: error == null ? null : ((error && error.message) || String(error)),
+    });
+  }
+
+  // Synchronous handler for the inline Lingo reads. MUST stay non-async and
+  // fully synchronous so the result node is populated before the isolated
+  // world's dispatchEvent returns. Ruffle's GetVariable/SetVariable/CallFunction
+  // all return synchronously, so this is safe (unlike `load`, which is async and
+  // stays on the Promise transport below).
+  window.addEventListener(REQ_EVENT, function (ev) {
+    var m = ev.detail;
+    if (!m || !m.sync) return;
+    var syncId = m.syncId;
+    try {
+      var player = players.get(m.playerId);
+      if (!player) throw new Error('player not registered: ' + m.playerId);
+      var args = m.args || [];
+      var result;
+      switch (m.method) {
+        case 'getVariableSync':
+          result = player.GetVariable(args[0]);
+          break;
+        case 'setVariableSync':
+          result = player.SetVariable(args[0], args[1]);
+          if (result === undefined) result = true;
+          break;
+        case 'callFunctionSync':
+          result = player.CallFunction(args[0], args[1] || []);
+          break;
+        case 'callMethodSync': {
+          // Generic sync method call: args = [methodName, methodArgs].
+          var fn = player[args[0]];
+          result = (typeof fn === 'function') ? fn.apply(player, args[1] || []) : undefined;
+          break;
+        }
+        default:
+          throw new Error('unknown sync bridge method: ' + m.method);
+      }
+      writeSyncResult(syncId, result == null ? null : result, null);
+    } catch (e) {
+      writeSyncResult(syncId, undefined, e);
+    }
+  });
+
   window.addEventListener(REQ_EVENT, async (ev) => {
     const m = ev.detail;
     if (!m) return;
+    // Sync requests are handled by the synchronous listener above.
+    if (m.sync) return;
 
     const { requestId, method, playerId, methodName, propName, args } = m;
     try {
@@ -184,6 +259,35 @@
           const player = players.get(playerId);
           if (!player) throw new Error('player not registered: ' + playerId);
           player[propName] = m.value;
+          respond(requestId, null);
+          break;
+        }
+        case 'registerCallbackForwarders': {
+          // Flash->Director callbacks (getURL "event:"/"lingo:" and fscommand)
+          // are functions, which can't cross the world boundary. Register
+          // host-side handlers that forward each invocation to the isolated
+          // world as a bridge event. The open-URL handler must decide
+          // SYNCHRONOUSLY whether it claims the navigation — it does so for our
+          // lingo:/event: schemes (mirroring the isolated-world logic) and
+          // forwards the body for the actual Lingo dispatch there.
+          const player = players.get(playerId);
+          if (!player) throw new Error('player not registered: ' + playerId);
+          if (typeof player.dirplayer_addOpenUrlHandler === 'function') {
+            player.dirplayer_addOpenUrlHandler(function (url, target) {
+              if (typeof url === 'string'
+                && (url.indexOf('lingo:') === 0 || url.indexOf('event:') === 0)) {
+                announceEvent(playerId, 'openUrl', { url: url, target: target });
+                return true; // claimed — suppress navigation
+              }
+              return false; // not ours — let Ruffle's openUrlMode decide
+            });
+          }
+          var fsReg = player.dirplayer_addFSCommandHandler || player.addFSCommandHandler;
+          if (typeof fsReg === 'function') {
+            fsReg.call(player, function (command, args) {
+              announceEvent(playerId, 'fsCommand', { command: command, args: args });
+            });
+          }
           respond(requestId, null);
           break;
         }

--- a/public/xtra-registry.json
+++ b/public/xtra-registry.json
@@ -1,3 +1,4 @@
 {
-  "BobbaXtra.x32": "~/bobba_xtra.wasm"
+  "BobbaXtra.x32": "~/bobba_xtra.wasm",
+  "Groove": "~/groove_xtra.wasm"
 }

--- a/scripts/run-browser-tests.mjs
+++ b/scripts/run-browser-tests.mjs
@@ -165,7 +165,10 @@ const template = fs.readFileSync(
 const html = template
   .replaceAll("$WASM_JS_FILE", jsBasename)
   .replaceAll("$TEST_ENV_JSON", testEnvJson)
-  .replaceAll("$DEBUG_MODE", keepOpen ? "true" : "false");
+  .replaceAll("$DEBUG_MODE", keepOpen ? "true" : "false")
+  // Optional substring filter: `E2E_FILTER=lore npm run e2e-test-browser`
+  // runs only test_* functions whose name contains the string.
+  .replaceAll("$TEST_FILTER", (loadedEnv.E2E_FILTER || "").replace(/"/g, ""));
 fs.writeFileSync(path.join(RUNNER_DIR, "index.html"), html);
 
 // 7. Link the asset directory into the runner. Use a junction on Windows so

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -936,8 +936,12 @@ function translateLevel0(path: string): string {
 function getVariable(spriteNum: number, path: string): string | null {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
-  if (!instance) {
-    // Expected during lazy load: the SWF instance hasn't been created yet.
+  if (!instance || !instance.ready) {
+    // Not ready: either the SWF instance hasn't been created yet, or it has
+    // loaded but its ActionScript hasn't finished initializing (so the objects
+    // a caller wants — e.g. Coke Studios' `_level0.oLoginServlet` — don't exist
+    // yet). `getVariable` must gate on `.ready` like setVariable/callFunction do;
+    // reading a not-fully-initialized SWF hands back undefined/garbage.
     // We can't hand a value back to an already-returned synchronous Lingo
     // call, but this isn't lost data for the common case — the Rust
     // getVariable(sprite, path, 0) handler falls back to a lazy
@@ -1766,6 +1770,27 @@ export function initFlashBridge(): void {
   // in flight. Those sprites are never scripted, so blocking for them is pure
   // lost time; they just pop in when their background load finishes.
   win.dirplayer_isFlashLoading = () => flashAccessBeforeReady;
+
+  // Per-sprite readiness, used by the WASM side to BLOCK an individual Flash
+  // interop call (getVariable / setVariable / callFunction / setCallback) until
+  // that sprite's Ruffle instance has loaded AND finished AS init — so a
+  // one-shot Lingo init (Coke Studios' SF gateway reading _level0.oLoginServlet
+  // etc.) gets live objects instead of null. Unlike dirplayer_isFlashLoading
+  // this is scoped to one sprite, so it never stalls unrelated display-only
+  // Flash sprites. Returns true (proceed) when the instance is ready OR when no
+  // instance exists and nothing is loading (so the caller can't hang forever on
+  // a sprite that will never get an instance).
+  win.dirplayer_isFlashInstanceReady = (spriteNum: number): boolean => {
+    const inst = instances.get(instanceKey(spriteNum));
+    // Only "ready" once the instance exists AND has finished AS init. A missing
+    // instance is NOT ready: the sprite's SWF is (or is about to be) loading, so
+    // the WASM-side wait must keep polling until it lands — otherwise a very
+    // early one-shot call (Coke Studios' SESSION_createSession, made before the
+    // instance dispatches) gets deferred and returns null, killing the session.
+    // The WASM wait is bounded, so a sprite that never gets an instance can't
+    // hang forever.
+    return !!(inst && inst.ready);
+  };
 
   // Hand-fired test entry for Flash `event: …` dispatch — lets you prove
   // the WASM dispatch chain end-to-end from DevTools without waiting for

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -6,7 +6,7 @@
  * can be composited with Director sprites (Director sprites can layer on top).
  */ 
 
-import { update_flash_frame, trigger_lingo_callback_on_script, dispatch_flash_event } from 'vm-rust';
+import { update_flash_frame, trigger_lingo_callback_on_script, dispatch_flash_event, dispatch_flash_lingo } from 'vm-rust';
 import {
   isBridgeRequired,
   waitForBridge,
@@ -230,6 +230,25 @@ export function dispatchFlashEvent(castLib: number, castMember: number, body: st
 }
 
 /**
+ * Run a Flash `getURL("lingo: …")` navigation body as a Lingo command.
+ *
+ * Director's Flash Asset Xtra interprets a `getURL` whose URL uses the
+ * `lingo:` scheme by evaluating the remainder as a Lingo command in the
+ * movie's global handler context (like `do "…"`). Pengapop's titleScreen
+ * SWF drives every button this way: Play → `lingo:startGameTimed`, hover
+ * SFX → `lingo:bdPlaySound(#generalSound,"s_mouseOver")`, etc. The body is
+ * everything after the `lingo:` prefix.
+ */
+export function dispatchFlashLingo(body: string): boolean {
+  try {
+    return dispatch_flash_lingo(body);
+  } catch (e) {
+    console.warn('[Flash] dispatchFlashLingo error:', e);
+    return false;
+  }
+}
+
+/**
  * Register an open-URL handler on a Ruffle player so `getURL("event: …")`
  * is routed into Director instead of being denied. Requires the dirplayer
  * Ruffle fork's `dirplayer_addOpenUrlHandler` patch; until it lands the
@@ -245,7 +264,24 @@ function registerEventUrlHandler(player: any, castLib: number, castMember: numbe
     return;
   }
   player.dirplayer_addOpenUrlHandler((url: string, _target: string): boolean => {
-    if (typeof url !== 'string' || !url.startsWith('event:')) {
+    if (typeof url !== 'string') {
+      return false;
+    }
+    // Director's Flash Asset `lingo:` scheme — run the URL body as a Lingo
+    // command (`do "…"` semantics). Pengapop's titleScreen buttons use this
+    // for everything (Play → `lingo:startGameTimed`, hover SFX →
+    // `lingo:bdPlaySound(...)`). Swallow the navigation either way.
+    if (url.startsWith('lingo:')) {
+      const body = url.slice('lingo:'.length).trim();
+      const handled = dispatchFlashLingo(body);
+      if (!handled) {
+        console.warn(
+          `[Flash] ${castLib}:${castMember}: empty/failed lingo URL body: ${JSON.stringify(body)}`
+        );
+      }
+      return true;
+    }
+    if (!url.startsWith('event:')) {
       return false; // not ours — let Ruffle's openUrlMode decide
     }
     const body = url.slice('event:'.length).trim();
@@ -730,7 +766,16 @@ function getVariable(spriteNum: number, path: string): string | null {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) {
-    console.warn(`ruffleGetVariable: no instance for sprite#${spriteNum}`);
+    // Expected during lazy load: the SWF instance hasn't been created yet.
+    // We can't hand a value back to an already-returned synchronous Lingo
+    // call, but this isn't lost data for the common case — the Rust
+    // getVariable(sprite, path, 0) handler falls back to a lazy
+    // FlashObjectRef that re-resolves the sprite when the handle is actually
+    // used (by which point the instance is ready). Setting
+    // flashAccessBeforeReady makes the frame loop wait for the pending
+    // instance before running more scripts. Log at debug to avoid spamming
+    // the console for a benign, self-healing condition.
+    console.debug(`ruffleGetVariable: no instance yet for sprite#${spriteNum} (path=${path}); deferring via lazy handle`);
     flashAccessBeforeReady = true;
     return null;
   }
@@ -790,7 +835,8 @@ type PendingOp =
   | { kind: 'play' }
   | { kind: 'stop' }
   | { kind: 'rewind' }
-  | { kind: 'setVariable'; path: string; value: string };
+  | { kind: 'setVariable'; path: string; value: string }
+  | { kind: 'callFunction'; path: string; argsXml: string };
 const pendingOps = new Map<number, PendingOp[]>();
 
 /**
@@ -971,6 +1017,21 @@ function flushPendingGoto(spriteNum: number): void {
         case 'setVariable':
           instance.rufflePlayer.SetVariable(translateLevel0(op.path), op.value);
           break;
+        case 'callFunction': {
+          // Replay a pre-ready callFunction. Decode args exactly like the
+          // live callFunction path (null → undefined, `__ruffle_path:` →
+          // AS object handle) so the replayed call matches what Lingo asked
+          // for. The return value is discarded — the original Lingo call
+          // already returned VOID; only the side effect is reproduced.
+          const rawArgs: any[] = op.argsXml ? JSON.parse(op.argsXml) : [];
+          const args: any[] = rawArgs.map(arg => {
+            if (arg === null) return undefined;
+            if (typeof arg === 'string' && arg.startsWith('__ruffle_path:')) return { __ruffle_path: arg.substring('__ruffle_path:'.length) };
+            return arg;
+          });
+          instance.rufflePlayer.CallFunction(translateLevel0(op.path), args);
+          break;
+        }
       }
     } catch (e) {
       console.warn(`[Flash flush] sprite#${spriteNum} op ${op.kind} error:`, e);
@@ -1047,8 +1108,17 @@ function goToFrameAndStop(spriteNum: number, frameOrLabel: string): void {
 function callFunction(spriteNum: number, path: string, argsXml: string): string | null {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
-  if (!instance) {
-    console.warn(`ruffleCallFunction: no instance for sprite#${spriteNum}`);
+  // Instance not created / AS-init not finished yet: a beginSprite (or a
+  // puppet/mid-frame) script can call into the SWF before the renderer has
+  // lazily created the Ruffle player. A synchronous Lingo call can't be made
+  // to block for the ~3s AS-init, and it can't be handed a return value after
+  // it has already returned — but the *side effect* of the call can still be
+  // replayed. Queue it (in frame order with goto/play/setVariable) and fire it
+  // once the instance is ready; return null now, matching Director's own
+  // "flash not ready → VOID" result for the immediate call. See setVariable
+  // for the same pre-instance pattern.
+  if (!instance || !instance.ready) {
+    queueOp(spriteNum, { kind: 'callFunction', path, argsXml });
     flashAccessBeforeReady = true;
     return null;
   }

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -587,7 +587,13 @@ export async function createFlashInstance(
     // queue-flush `play` heuristic below.
     autoplay: 'on',
     unmuteOverlay: 'hidden',
-    logLevel: 'info',
+    // Ruffle logs to console at this level. `info` (the old hardcoded value)
+    // emits every AS `trace()` and unsupported-feature notice — for a busy SWF
+    // that's console output every frame, and the browser RETAINS each console
+    // entry (plus its arguments), so RAM climbs steadily over a long run. Honour
+    // the host's configured level (`__dirplayerFlashConfig.logLevel`) and default
+    // to `error` so the frame-capture loop doesn't flood the console.
+    logLevel: ((window as any).__dirplayerFlashConfig?.logLevel as string) ?? 'error',
     splashScreen: false,
     // Transparent stage so SWFs that layer over other Director sprites
     // (mello's fire/marshmello/stick) composite correctly. The downside:

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -117,6 +117,23 @@ function maybeCorsProxy(urlStr: string): string | null {
 }
 
 const origFetch = window.fetch;
+// Count outstanding browser fetches so dirplayer's Rust frame loop can lengthen
+// its per-frame yield while any request is in flight — including Ruffle-side
+// requests (LoadVars/URLLoader/XML) that dirplayer's own net_manager never sees.
+// The DGS loader spins a tight high-tempo frame loop (puppetTempo(999)) waiting
+// on `preloaderTranslationSuccess`, which is only set once the preloader's
+// `LoadVars` POST to gettranslationxml.phtml (1-3 s) completes; without a yield
+// the loop starves that fetch's completion callback and the login links never
+// resolve. Tracked as a window global (read from Rust via Reflect).
+let pendingNetCount = 0;
+function trackFetch(p: Promise<Response>): Promise<Response> {
+  pendingNetCount += 1;
+  (window as any).__dirplayerPendingNetCount = pendingNetCount;
+  return p.finally(() => {
+    pendingNetCount -= 1;
+    (window as any).__dirplayerPendingNetCount = pendingNetCount;
+  });
+}
 window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   if (typeof input === 'string') {
     try {
@@ -134,7 +151,7 @@ window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<R
       const newUrl = applyFetchRewrite(url) ? url.toString() : maybeCorsProxy(url.toString());
       if (newUrl) {
         const req = input;
-        return req.arrayBuffer().then(bodyBuf => {
+        return trackFetch(req.arrayBuffer().then(bodyBuf => {
           const newInit: RequestInit = {
             method: req.method,
             headers: req.headers,
@@ -143,11 +160,11 @@ window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<R
             credentials: 'omit' as RequestCredentials,
           };
           return origFetch.call(window, newUrl, newInit);
-        });
+        }));
       }
     } catch (e) { console.error('[fetch-intercept] Error:', e); }
   }
-  return origFetch.call(window, input, init);
+  return trackFetch(origFetch.call(window, input, init));
 };
 
 // Monkey-patch HTMLCanvasElement.getContext to force preserveDrawingBuffer: true
@@ -197,6 +214,17 @@ function instanceKey(spriteNum: number): string {
   return `${spriteNum}`;
 }
 
+// Publish the count of live Ruffle instances so dirplayer's Rust frame loop can
+// floor its per-frame yield while any Flash sprite is on stage. The offscreen
+// Ruffle instances self-tick via requestAnimationFrame; a tight high-tempo
+// Director loop (DGS puppetTempo(999) guest-gate poll) otherwise hogs the main
+// thread and starves those RAF ticks, so a text field whose htmlText was just
+// updated (the preloader login links) never re-renders. Only affects movies
+// running faster than ~60fps — see the yield logic in player/mod.rs.
+function syncActiveFlashCount(): void {
+  (window as any).__dirplayerActiveFlashCount = instances.size;
+}
+
 /**
  * Forward a Director sprite mouse event into a Ruffle player so the SWF's
  * own AS1 button handlers (`on (press)` / `on (release)`) actually run.
@@ -243,7 +271,8 @@ function dispatchMouseEvent(
       `bridgeId=${inst.bridgeId}, player keys=`, player ? Object.keys(player as object) : 'no player');
     return false;
   }
-  return !!player.dirplayer_dispatchPointer(type, canvasX, canvasY);
+  const handled = !!player.dirplayer_dispatchPointer(type, canvasX, canvasY);
+  return handled;
 }
 
 /**
@@ -604,6 +633,7 @@ export async function createFlashInstance(
   };
 
   instances.set(key, instance);
+  syncActiveFlashCount();
 
   // Copy data out of WASM memory immediately — the underlying ArrayBuffer
   // can be detached/invalidated when WASM memory grows
@@ -880,6 +910,7 @@ export function destroyFlashInstance(spriteNum: number): void {
 
   instance.container.remove();
   instances.delete(key);
+  syncActiveFlashCount();
 }
 
 /**
@@ -921,7 +952,8 @@ function getVariable(spriteNum: number, path: string): string | null {
   }
 
   try {
-    return instance.rufflePlayer.GetVariable(translateLevel0(path));
+    const val = instance.rufflePlayer.GetVariable(translateLevel0(path));
+    return val;
   } catch (e) {
     console.warn(`ruffleGetVariable error:`, e);
     return null;
@@ -1780,6 +1812,7 @@ export function destroyAllFlashInstances(): void {
     instance.container.remove();
   });
   instances.clear();
+  syncActiveFlashCount();
 }
 
 /**

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -40,6 +40,14 @@ interface FlashInstance {
   /// actually start the SWF. When false, autoplay covers it and the
   /// queued `play` op is a redundant restart we skip.
   pausedAtStart: boolean;
+  /// Director-intent "is this sprite's Flash movie stopped?" flag. We stop a
+  /// Flash sprite by halting its root TIMELINE (not by suspending the whole
+  /// Ruffle player — that would kill the render loop and strand later
+  /// GotoFrame calls on a stale canvas). Because the player keeps running,
+  /// its own `isPlaying` no longer reflects the movie's stopped state, so we
+  /// track it here for `sprite.playing`. Set true by stop/rewind/frame-setter,
+  /// false by play/gotoFrame.
+  stopped?: boolean;
 }
 
 // Per-sprite Flash instance map. Each Flash sprite gets its own Ruffle
@@ -543,7 +551,16 @@ export async function createFlashInstance(
     // takes over those responsibilities on the dirplayer side; this
     // wmode just makes the Ruffle canvas itself transparent-where-empty.
     wmode: 'transparent',
-    renderer: 'canvas',  // Force Canvas2D so we can read pixels back
+    // Force the Canvas2D backend. Ruffle's config key is `preferredRenderer`
+    // (see load-options.ts RenderBackend); the old `renderer: 'canvas'` was an
+    // UNKNOWN key that Ruffle silently ignored, so every instance defaulted to
+    // the wgpu-webgl backend and allocated its own WebGL context. Games with
+    // many simultaneous Flash sprites (bogey_nights' boogyflash/spitflash
+    // "superstar" splashes) then blew past the browser's ~16 WebGL-context cap
+    // ("Too many active WebGL contexts"). Canvas2D uses no WebGL context and
+    // makes the getImageData frame-capture readback cheaper — which is the
+    // whole reason we wanted the canvas backend in the first place.
+    preferredRenderer: 'canvas',
     socketProxy: getSocketProxyConfig(),
   };
   if (bridgeId) {
@@ -937,6 +954,10 @@ function applyGotoLabelAndPin(instance: FlashInstance, label: string): void {
   queueMicrotask(() => {
     try {
       player.CallFunction!('_root.stop', []);
+      // Resume the player so the seeked label frame paints — see schedulePin
+      // for the full rationale (a movie pinning the sprite via per-frame
+      // stop()/hold keeps the player suspended, so the goto never repaints).
+      (instance.rufflePlayer as { play?: () => void }).play?.();
     } catch (e) {
       console.warn(`[Flash gotoLabel] pin-step error:`, e);
     }
@@ -966,6 +987,22 @@ function schedulePin(instance: FlashInstance, frame: number): void {
     pinTarget.delete(instance.spriteNum);
     try {
       instance.rufflePlayer.GotoFrame(frame, true);
+      // Resume the PLAYER (not the clip) so the seeked frame actually paints
+      // to the canvas. Ruffle's `goto_frame` only rebuilds the display list;
+      // the paint happens on a player tick, which is skipped while the player
+      // is SUSPENDED. A movie that pins a Flash sprite by calling
+      // `stop(sprite N)` / `hold` every frame keeps the player suspended, so
+      // without this the model advances to `frame` but dirplayer keeps
+      // capturing the STALE previous frame (bogey_nights' intro: clicking
+      // Instructions sets `sprite(1).frame = 113` but the menu stayed on
+      // screen). The clip itself is stopped by the gotoAndStop above, so
+      // resuming the player renders `frame` once and it stays put; the
+      // movie's next per-frame stop() re-suspends. For sprites that were
+      // never paused (poster-frame tiles) the player is already playing and
+      // this is a harmless no-op. Runs in the microtask (after the current
+      // synchronous Lingo dispatch) so a same-frame stop() can't re-suspend
+      // before the paint lands.
+      instance.rufflePlayer.play?.();
     } catch (e) {
       console.warn(`[Flash goto] pin-step error:`, e);
     }
@@ -1007,11 +1044,28 @@ function flushPendingGoto(spriteNum: number): void {
           pinTarget.delete(spriteNum);
           break;
         case 'stop':
+          // Mirror the live stopFlash: halt the root TIMELINE, don't suspend
+          // the whole player. A queued `stop` replaying `pause()` here was the
+          // bug behind bogey_nights' end screen — "flash bhv" beginSprite runs
+          // `sprite(3).frame = 116` then `sprite(3).stop()`; when sprite 3's
+          // instance was (re)loading, both ops queued, and the queued stop
+          // paused the player so the frame-116 seek never painted (stale frame
+          // on screen even though `sprite(3).frame` read 116). Keeping the
+          // player alive lets the seeked frame render.
           pinTarget.delete(spriteNum);
-          instance.rufflePlayer.pause();
+          instance.stopped = true;
+          {
+            const p = instance.rufflePlayer as {
+              CallFunction?: (path: string, args: unknown[]) => unknown;
+              pause?: () => void;
+            };
+            if (typeof p.CallFunction === 'function') p.CallFunction('_root.stop', []);
+            else p.pause?.();
+          }
           break;
         case 'rewind':
           pinTarget.delete(spriteNum);
+          instance.stopped = true;
           instance.rufflePlayer.GotoFrame(1, true);
           break;
         case 'setVariable':
@@ -1066,6 +1120,7 @@ function goToFrame(spriteNum: number, frameOrLabel: string): void {
     }
     return;
   }
+  instance.stopped = false; // gotoFrame is gotoAndPlay-semantic → keep playing
   if (isNumeric) {
     applyGotoPlay(instance, parseInt(trimmed, 10));
   } else {
@@ -1094,6 +1149,7 @@ function goToFrameAndStop(spriteNum: number, frameOrLabel: string): void {
     }
     return;
   }
+  instance.stopped = true; // frame setter is gotoAndStop-semantic → stopped
   if (isNumeric) {
     applyGotoAndPin(instance, parseInt(trimmed, 10));
   } else {
@@ -1149,8 +1205,28 @@ function stopFlash(spriteNum: number): void {
     return;
   }
   pinTarget.delete(spriteNum);
+  instance.stopped = true;
   try {
-    instance.rufflePlayer.pause();
+    // Stop the root TIMELINE, not the whole player. `player.pause()` suspends
+    // the entire Ruffle player, which halts its render loop — so any later
+    // GotoFrame updates the SWF model but never repaints, and dirplayer
+    // captures a stale canvas. bogey_nights' intro calls `stop(sprite 1)`
+    // every frame; with pause() the menu stayed frozen on screen even after
+    // `sprite(1).frame = 113` moved the model to the Instructions frame
+    // (confirmed: overriding ruffleStop to a no-op made Instructions appear).
+    // Halting only the root MovieClip freezes the timeline in place while
+    // leaving the player alive to paint frame changes. `sprite.playing` reads
+    // `instance.stopped` since the player itself keeps running.
+    const player = instance.rufflePlayer as {
+      CallFunction?: (path: string, args: unknown[]) => unknown;
+      pause?: () => void;
+    };
+    if (typeof player.CallFunction === 'function') {
+      player.CallFunction('_root.stop', []);
+    } else {
+      // Bridge mode / no CallFunction: fall back to the old full-player pause.
+      player.pause?.();
+    }
   } catch (e) {
     console.warn(`ruffleStop error:`, e);
   }
@@ -1178,6 +1254,7 @@ function playFlash(spriteNum: number): void {
   // in this same Lingo dispatch — otherwise the scheduled RAF stop
   // would undo our play() a frame later (BS69 shrink animation).
   pinTarget.delete(spriteNum);
+  instance.stopped = false;
   try {
     instance.rufflePlayer.play();
     const cur = parseInt(
@@ -1200,6 +1277,7 @@ function rewindFlash(spriteNum: number): void {
     return;
   }
   pinTarget.delete(spriteNum);
+  instance.stopped = true;
   try {
     instance.rufflePlayer.GotoFrame(1, true);
   } catch (e) {
@@ -1214,6 +1292,11 @@ function isPlaying(spriteNum: number): boolean {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return false;
+  // The player's render loop stays alive even when a sprite is "stopped" (we
+  // halt the root timeline, not the player — see stopFlash), so the
+  // player-level isPlaying is no longer a reliable proxy for the movie's
+  // stopped state. Honour the tracked intent first.
+  if (instance.stopped) return false;
   try {
     return instance.rufflePlayer.isPlaying ?? false;
   } catch (e) {
@@ -1504,10 +1587,20 @@ export function initFlashBridge(): void {
     }
   };
 
-  // Expose flash loading state for WASM frame loop to check.
-  // Also returns true if scripts tried to access a Flash instance that doesn't exist yet
-  // (the rendering loop will dispatch it shortly).
-  win.dirplayer_isFlashLoading = () => flashLoadingCount > 0 || flashAccessBeforeReady;
+  // Expose flash loading state for the WASM frame loop to check. The loop
+  // BLOCKS (up to 15s) while this is true, so it must only be true when the
+  // game genuinely can't proceed without a Flash instance — i.e. when a script
+  // actually tried to read a not-yet-ready Flash sprite (getVariable /
+  // callFunction / setVariable set `flashAccessBeforeReady`).
+  //
+  // It must NOT block merely because some instance is still loading
+  // (`flashLoadingCount > 0`). Games that spawn many transient, display-only
+  // Flash sprites (bogey_nights turns every "superstar" splash into a
+  // boogyflash/spitflash SWF) would otherwise stall the ENTIRE game — including
+  // player input — for ~3s per spawn, perpetually, since there's always a load
+  // in flight. Those sprites are never scripted, so blocking for them is pure
+  // lost time; they just pop in when their background load finishes.
+  win.dirplayer_isFlashLoading = () => flashAccessBeforeReady;
 
   // Hand-fired test entry for Flash `event: …` dispatch — lets you prove
   // the WASM dispatch chain end-to-end from DevTools without waiting for

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -114,11 +114,18 @@ window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<R
 };
 
 // Monkey-patch HTMLCanvasElement.getContext to force preserveDrawingBuffer: true
-// for all WebGL contexts. This is needed so we can read pixels back from Ruffle's
+// for WebGL contexts. This is needed so we can read pixels back from Ruffle's
 // wgpu-webgl canvas after the frame is presented.
+//
+// EXCEPTION: dirplayer's own stage canvas is marked with `data-dp-stage` (set in
+// Rust before it requests its WebGL2 context). preserveDrawingBuffer keeps a full
+// extra drawing buffer alive — pointless for the stage (we never read it back via
+// this path) and it raises GPU memory, which makes the browser more likely to
+// drop the stage context when the tab is backgrounded. So skip the stage canvas.
 const origGetContext = HTMLCanvasElement.prototype.getContext;
 (HTMLCanvasElement.prototype as any).getContext = function(type: string, attrs?: any) {
-  if (type === 'webgl' || type === 'webgl2') {
+  const isStage = (this as HTMLElement)?.getAttribute?.('data-dp-stage') === '1';
+  if ((type === 'webgl' || type === 'webgl2') && !isStage) {
     attrs = { ...(attrs || {}), preserveDrawingBuffer: true };
   }
   return origGetContext.call(this, type, attrs);
@@ -612,28 +619,56 @@ function startFrameCapture(key: string): void {
   const instance = instances.get(key);
   if (!instance) return;
 
+  // Off-screen Flash members used as 3D textures use a NEGATIVE synthetic
+  // sprite number (dispatched by the Rust newTexture path). These are STATIC
+  // textures, so capturing every frame would run one expensive getImageData
+  // GPU→CPU readback per texture per frame — with ~10 of them (frog01's
+  // environment + wheels) that tanks the frame rate. Instead, capture a few
+  // throttled frames to let the SWF paint, then STOP the readback loop and
+  // pause the player. The last captured frame stays in the GPU texture.
+  const isOffscreenTexture = instance.spriteNum < 0;
+  let rafCount = 0;
+  let textureCaptures = 0;
+  const TEX_CAPTURE_INTERVAL = 10; // every Nth RAF
+  const TEX_CAPTURE_LIMIT = 10;    // ~10 captures (~1.7s) then stop
+
   function captureFrame() {
     const inst = instances.get(key);
     if (!inst || !inst.canvas) return;
 
-    try {
-      const canvas = inst.canvas;
-      const width = canvas.width;
-      const height = canvas.height;
+    rafCount++;
+    // On-stage sprites capture every frame (they animate). Off-screen
+    // textures only capture on the throttled interval.
+    const doCapture = !isOffscreenTexture || (rafCount % TEX_CAPTURE_INTERVAL === 0);
 
-      if (width > 0 && height > 0) {
-        const offscreen = document.createElement('canvas');
-        offscreen.width = width;
-        offscreen.height = height;
-        const offCtx = offscreen.getContext('2d');
-        if (offCtx) {
-          offCtx.drawImage(canvas, 0, 0);
-          const imageData = offCtx.getImageData(0, 0, width, height);
-          update_flash_frame(inst.spriteNum, width, height, new Uint8Array(imageData.data.buffer));
+    if (doCapture) {
+      try {
+        const canvas = inst.canvas;
+        const width = canvas.width;
+        const height = canvas.height;
+
+        if (width > 0 && height > 0) {
+          const offscreen = document.createElement('canvas');
+          offscreen.width = width;
+          offscreen.height = height;
+          const offCtx = offscreen.getContext('2d');
+          if (offCtx) {
+            offCtx.drawImage(canvas, 0, 0);
+            const imageData = offCtx.getImageData(0, 0, width, height);
+            update_flash_frame(inst.spriteNum, width, height, new Uint8Array(imageData.data.buffer));
+          }
         }
+      } catch (e) {
+        // Silently ignore frame capture errors
       }
-    } catch (e) {
-      // Silently ignore frame capture errors
+
+      if (isOffscreenTexture && ++textureCaptures >= TEX_CAPTURE_LIMIT) {
+        // Static texture fully captured — stop the readback loop and pause
+        // the player so it stops consuming CPU every frame.
+        inst.animFrameId = null;
+        try { inst.rufflePlayer.pause?.(); } catch { /* bridge mode / no pause */ }
+        return;
+      }
     }
 
     inst.animFrameId = requestAnimationFrame(captureFrame);
@@ -678,17 +713,6 @@ export function destroyFlashInstance(spriteNum: number): void {
 function translateLevel0(path: string): string {
   if (path.startsWith('_level0')) {
     return '_root' + path.substring('_level0'.length);
-  }
-  // Director's getVariable/setVariable/callFunction accept bare names
-  // and resolve them as `_root.<name>`. Ruffle's GetVariable is strict
-  // — a bare path returns Void. Rewrite bare names (no path
-  // separator, no leading `_root`/`_level0`/`this`/`super`) into the
-  // `/:<name>` form Ruffle handles, so e.g. JunkbotUndercover's
-  // `getVariable(sprite(15), "sceneNumber")` actually reads the SWF's
-  // `_root.sceneNumber`.
-  const isBareName = !/[\/:.]/.test(path) && !/^_?(root|level\d+|this|super|parent)\b/i.test(path);
-  if (isBareName && path.length > 0) {
-    return '/:' + path;
   }
   return path;
 }
@@ -1188,19 +1212,41 @@ function findLabel(spriteNum: number, _label: string): number {
 }
 
 /**
- * Perform a hit test on a Ruffle instance.
- * Returns true if the point (in Flash coordinates) hits content.
+ * Classify what's under a sprite-local point, mirroring Director's Flash
+ * `sprite.hitTest(point)` return values — and the signal behind
+ * `sprite.mouseOverButton`. Coordinates are sprite-local pixels (origin at the
+ * sprite's top-left), the same space `dispatchMouseEvent` takes; we rebase them
+ * to canvas pixels and hand them to the fork's `dirplayer_hitTest`, which
+ * injects a synthetic MouseMove to refresh hover state then reads the resolved
+ * cursor + a stage shape pick.
+ *
+ * Returns: 0 = #background, 1 = #normal, 2 = #button, 3 = #editText
+ * (0 when no instance / the fork method is unavailable).
  */
-function hitTest(spriteNum: number, x: number, y: number): boolean {
-  const key = instanceKey(spriteNum);
-  const instance = instances.get(key);
-  if (!instance) return false;
+function hitTest(spriteNum: number, localX: number, localY: number): number {
+  const inst = instances.get(instanceKey(spriteNum));
+  if (!inst) return 0;
+
+  let canvasX = localX;
+  let canvasY = localY;
+  if (inst.canvas) {
+    const rect = inst.canvas.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      canvasX = (localX / rect.width) * inst.canvas.width;
+      canvasY = (localY / rect.height) * inst.canvas.height;
+    }
+  }
+
+  const player = inst.rufflePlayer as
+    | { dirplayer_hitTest?: (x: number, y: number) => number }
+    | undefined;
+  if (typeof player?.dirplayer_hitTest !== 'function') {
+    return 0;
+  }
   try {
-    // Use CallFunction to invoke _root.hitTest(x, y, true)
-    const result = instance.rufflePlayer.CallFunction("_root.hitTest", [x, y, true]);
-    return result === true || result === "true" || result === 1;
+    return player.dirplayer_hitTest(canvasX, canvasY) | 0;
   } catch (e) {
-    return false;
+    return 0;
   }
 }
 

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -92,6 +92,30 @@ function applyFetchRewrite(url: URL): boolean {
   return false;
 }
 
+// Generic CORS proxy for "loader mode" (debugging a Shockwave game from its live
+// site). When `__dirplayerFlashConfig.corsProxy` is set to a base like
+// "http://127.0.0.1:3099/cors?url=", any CROSS-ORIGIN http(s) fetch is rewritten
+// to `<base><encoded url>` so the dev CORS proxy (cors-proxy.cjs) can fetch it
+// server-side and re-serve it with CORS. Opt-in: with no corsProxy configured
+// this returns null and fetch behaves exactly as before. Same-origin requests
+// (the dev app's own assets/xtras) and already-proxied URLs are left untouched.
+function getCorsProxyBase(): string | null {
+  const base = (window as any).__dirplayerFlashConfig?.corsProxy;
+  return typeof base === 'string' && base ? base : null;
+}
+
+function maybeCorsProxy(urlStr: string): string | null {
+  const base = getCorsProxyBase();
+  if (!base) return null;
+  let u: URL;
+  try { u = new URL(urlStr, window.location.origin); } catch { return null; }
+  if (u.protocol !== 'http:' && u.protocol !== 'https:') return null;
+  if (u.origin === window.location.origin) return null; // same-origin: leave alone
+  if (urlStr.startsWith(base)) return null;              // already proxied
+  try { if (new URL(base, window.location.origin).host === u.host) return null; } catch { /* */ }
+  return base + encodeURIComponent(u.toString());
+}
+
 const origFetch = window.fetch;
 window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<Response> {
   if (typeof input === 'string') {
@@ -99,13 +123,16 @@ window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<R
       const url = new URL(input, window.location.origin);
       if (applyFetchRewrite(url)) {
         input = url.toString();
+      } else {
+        const proxied = maybeCorsProxy(url.toString());
+        if (proxied) input = proxied;
       }
     } catch { /* ignore parse errors */ }
   } else if (input instanceof Request) {
     try {
       const url = new URL(input.url);
-      if (applyFetchRewrite(url)) {
-        const newUrl = url.toString();
+      const newUrl = applyFetchRewrite(url) ? url.toString() : maybeCorsProxy(url.toString());
+      if (newUrl) {
         const req = input;
         return req.arrayBuffer().then(bodyBuf => {
           const newInit: RequestInit = {
@@ -304,6 +331,44 @@ function registerEventUrlHandler(player: any, castLib: number, castMember: numbe
     // Always swallow the navigation: even an unrecognised event:URL must
     // not open a popup. Director silently ignores malformed event: bodies.
     return true;
+  });
+}
+
+/**
+ * Register an fscommand handler on a Ruffle player so a SWF's
+ * `fscommand("handler", "args")` reaches Director's Lingo, matching the Flash
+ * Asset Xtra's Flash→Director bridge. This is the classic channel Director
+ * Flash movies use to call back into Lingo (distinct from `getURL("event:…")`).
+ *
+ * Neopets' DGS include movie (`objMain`) signals init readiness this way:
+ * `fscommand("FlashLoaderLoaded")` → Director's movie handler
+ * `on FlashLoaderLoaded` → `gMainObject.flashLoaderIsReady()`. Without this,
+ * the fscommand is dropped and the DGS loader stalls at load_state 6.
+ *
+ * The reference (Director 11.5 Scripting Dictionary) doesn't document the
+ * Xtra's fscommand→handler mapping, so this mirrors the observed contract:
+ * the command name is the handler; any args string is appended so
+ * dispatch_flash_event tokenises trailing args.
+ */
+function registerFSCommandHandler(player: any, castLib: number, castMember: number): void {
+  if (typeof player?.addFSCommandHandler !== 'function') {
+    console.warn(
+      `[Flash] ${castLib}:${castMember}: addFSCommandHandler missing on Ruffle player — ` +
+      `fscommand() calls from the SWF will be dropped.`
+    );
+    return;
+  }
+  player.addFSCommandHandler((command: string, args: string): void => {
+    if (typeof command !== 'string' || !command.trim()) return;
+    const body = (typeof args === 'string' && args.trim())
+      ? `${command.trim()} ${args.trim()}`
+      : command.trim();
+    const handled = dispatchFlashEvent(castLib, castMember, body);
+    if (!handled) {
+      console.warn(
+        `[Flash] ${castLib}:${castMember}: unhandled fscommand: ${JSON.stringify(command)} ${JSON.stringify(args)}`
+      );
+    }
   });
 }
 
@@ -661,6 +726,10 @@ export async function createFlashInstance(
   // `event:` get routed into dispatch_flash_event and the real open is
   // suppressed. Otherwise it's a safe no-op.
   registerEventUrlHandler(player, castLib, castMember);
+
+  // The other Flash→Director channel: `fscommand("handler", "args")`. DGS's
+  // include movie (objMain) uses this to fire `on FlashLoaderLoaded`.
+  registerFSCommandHandler(player, castLib, castMember);
 
   // Find the internal canvas element that Ruffle renders to
   await new Promise<void>((resolve) => {

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -24,8 +24,10 @@ interface FlashInstance {
   bridgeId: string | null; // Set when this instance is driven by the main-world bridge
   container: HTMLDivElement;
   canvas: HTMLCanvasElement | null;
-  width: number;
+  width: number;   // current render (canvas) width in px; tracked by setFlashSize
   height: number;
+  nativeW: number; // SWF native stage size (detail floor for resizes); 0 if unknown
+  nativeH: number;
   animFrameId: number | null;
   /// Becomes true only after the SWF has loaded AND the 3s AS init wait
   /// has elapsed AND the inheritance/queue replay has finished. Lingo
@@ -353,6 +355,73 @@ function isFlashDisabled(): boolean {
 }
 
 /**
+ * Parse the SWF header's stage size (width, height) in pixels from the movie
+ * bytes. Only uncompressed FWS is handled (returns null for CWS/ZWS). Used to
+ * pick a high-resolution render canvas so a Flash sprite that is scaled UP on
+ * stage (bogey_nights' boogyflash/spitflash splashes GROW as they absorb
+ * others; the bogeyman arm swaps member dims) stays sharp: Ruffle renders the
+ * vector at high res and dirplayer DOWNSCALES to the sprite rect, instead of
+ * upscaling a tiny creation-time capture (which pixelates).
+ */
+function parseSwfStageSize(data: Uint8Array): { w: number; h: number } | null {
+  if (data.length < 9 || data[0] !== 0x46 || data[1] !== 0x57 || data[2] !== 0x53) {
+    return null; // not "FWS"
+  }
+  const nbits = data[8] >> 3;
+  const readBits = (bitPos: number, n: number): number => {
+    let v = 0;
+    for (let i = 0; i < n; i++) {
+      const byteIdx = (bitPos + i) >> 3;
+      const bitIdx = 7 - ((bitPos + i) & 7);
+      if ((data[byteIdx] >> bitIdx) & 1) v |= 1 << (n - 1 - i);
+    }
+    return v;
+  };
+  let p = 8 * 8 + 5; // byte 8, past the 5-bit nbits field
+  const xMin = readBits(p, nbits); p += nbits;
+  const xMax = readBits(p, nbits); p += nbits;
+  const yMin = readBits(p, nbits); p += nbits;
+  const yMax = readBits(p, nbits);
+  const w = Math.round((xMax - xMin) / 20);
+  const h = Math.round((yMax - yMin) / 20);
+  if (w <= 0 || h <= 0) return null;
+  return { w, h };
+}
+
+/**
+ * Resize a live Ruffle instance to match the sprite's current on-stage size so
+ * the vector re-renders sharp at the new scale (bogey_nights' splashes grow,
+ * the bogeyman arm swaps member dims). Keeps the render ~1:1 with what dirplayer
+ * draws — no blur from up-render + downscale, and no pixelation from upscaling a
+ * stale small capture. Never shrinks below the SWF's native size (detail floor)
+ * and no-ops for tiny changes / off-screen 3D-texture instances.
+ */
+function setFlashSize(spriteNum: number, w: number, h: number): void {
+  if (spriteNum < 0) return; // off-screen 3D texture: fixed size
+  const inst = instances.get(instanceKey(spriteNum));
+  if (!inst) return;
+  let tw = Math.max(1, Math.round(w));
+  let th = Math.max(1, Math.round(h));
+  if (inst.nativeW && inst.nativeH) {
+    tw = Math.max(tw, inst.nativeW);
+    th = Math.max(th, inst.nativeH);
+  }
+  // Skip sub-2px churn so a slowly-growing splash doesn't reflow Ruffle every
+  // single frame.
+  if (Math.abs(tw - inst.width) < 2 && Math.abs(th - inst.height) < 2) return;
+  inst.width = tw;
+  inst.height = th;
+  try {
+    inst.container.style.width = `${tw}px`;
+    inst.container.style.height = `${th}px`;
+    inst.rufflePlayer.style.width = `${tw}px`;
+    inst.rufflePlayer.style.height = `${th}px`;
+  } catch (e) {
+    /* bridge mode / detached element */
+  }
+}
+
+/**
  * Create a Ruffle player instance for a specific Flash sprite.
  * Each sprite gets its own player so multiple sprites that share a single
  * Flash cast member can display different frames simultaneously.
@@ -365,6 +434,7 @@ export async function createFlashInstance(
   width: number,
   height: number,
   pausedAtStart: boolean = false,
+  assertedFrame: number = -1,
 ): Promise<void> {
   const key = instanceKey(spriteNum);
 
@@ -379,57 +449,15 @@ export async function createFlashInstance(
     return;
   }
 
-  // Capture the about-to-die instance's current frame BEFORE destroy so
-  // we can carry it across a member change. storyscramble does
-  // `gotoFrame(sprite 2, 31)` in BS38 while sprite 2 holds member 1:31;
-  // when the scene change swaps sprite 2 to member 1:45 (bubble) we
-  // destroy the old instance and have no record of frame 31. Stash it
-  // here keyed by sprite number, then check below after sibling
-  // inheritance. Mimics Director's per-sprite frame property which
-  // survives member swaps.
-  const priorIntendedFrame: number | null = (() => {
-    const prior = instances.get(key);
-    if (!prior) return null;
-    try {
-      const f = parseInt(prior.rufflePlayer.GetVariable?.('/:_currentframe') || '0', 10);
-      return f >= 1 ? f : null;
-    } catch { return null; }
-  })();
-
   // Destroy existing instance for this sprite if any.
   destroyFlashInstance(spriteNum);
 
-  // Playhead inheritance — preserve Director's "Flash member state is
-  // shared across sprites using that member" semantic the old cast-keyed
-  // architecture used to give us for free. With per-sprite instances,
-  // sprite 2 in storyscramble's main scene would spin up a fresh Ruffle
-  // player and autoplay the bubble SWF (1:45) from frame 1→11, hiding
-  // the frame-21 state sprite 17 already advanced it to. Scan live
-  // siblings here for the same member and capture their current frame;
-  // we'll seed the new instance to that frame in the finally block
-  // below, after the SWF has loaded and AS initialisation finishes.
-  let inheritedFrame: number | null = null;
-  const siblings = Array.from(instances.values());
-  for (const sibling of siblings) {
-    if (sibling.castLib === castLib && sibling.castMember === castMember) {
-      try {
-        const cur = parseInt(
-          sibling.rufflePlayer.GetVariable?.('/:_currentframe') || '0', 10
-        );
-        if (cur >= 1) {
-          inheritedFrame = cur;
-          break;
-        }
-      } catch { /* getVariable failed (bridge mode etc.) — fall through to autoplay */ }
-    }
-  }
-
-  // Per-sprite intent wins over sibling inheritance: if BS38 set this
-  // sprite to frame N before the member changed, the new member should
-  // also land at frame N (Director's per-sprite frame attribute).
-  if (priorIntendedFrame !== null) {
-    inheritedFrame = priorIntendedFrame;
-  }
+  // Per-sprite frame intent is now owned by the Rust sprite
+  // (`flash_asserted_frame`) and threaded in as `assertedFrame`, which we pin
+  // below. The old cross-sprite "sibling frame inheritance" is gone: it seeded
+  // a new instance from ANOTHER sprite sharing the member, which for
+  // shared-member sets (StoryScramble's 3 story tiles) gave them all the SAME
+  // frame — clobbering each tile's unique poster.
 
   flashLoadingCount++;
   console.log(`[Flash] Instance ${key} creation started (pending: ${flashLoadingCount})`);
@@ -446,13 +474,30 @@ export async function createFlashInstance(
   let player: any;
   let bridgeId: string | null = null;
 
+  // Render resolution = the sprite's current on-stage size, so the captured
+  // frame is ~1:1 with what dirplayer draws (crisp; no bilinear softening from
+  // an up-render + downscale roundtrip). As the sprite is scaled on stage
+  // (bogey_nights' splashes GROW, the arm swaps dims), `setFlashSize` resizes
+  // the player so Ruffle re-renders the vector sharp at the new size — matching
+  // Director's vector rendering at any scale. Never render below the SWF's
+  // native size, so a sprite briefly created tiny (splash at ~10px) still has
+  // detail until the first resize. Off-screen 3D-texture members (negative
+  // sprite number) keep their exact requested size.
+  let renderW = Math.max(1, Math.round(width));
+  let renderH = Math.max(1, Math.round(height));
+  const native = spriteNum >= 0 ? parseSwfStageSize(swfData) : null;
+  if (native) {
+    renderW = Math.max(renderW, native.w);
+    renderH = Math.max(renderH, native.h);
+  }
+
   // Hidden container for Ruffle - pixels are read back and composited into dirplayer's canvas
   const container = document.createElement('div');
   container.style.position = 'absolute';
   container.style.left = '-9999px';
   container.style.top = '-9999px';
-  container.style.width = `${width}px`;
-  container.style.height = `${height}px`;
+  container.style.width = `${renderW}px`;
+  container.style.height = `${renderH}px`;
   container.style.overflow = 'hidden';
   document.body.appendChild(container);
 
@@ -464,15 +509,15 @@ export async function createFlashInstance(
     const elem = bridgeFindElement(bridgeId);
     if (!elem) throw new Error('bridge created player but DOM element not found: ' + bridgeId);
     player = elem;
-    player.style.width = `${width}px`;
-    player.style.height = `${height}px`;
+    player.style.width = `${renderW}px`;
+    player.style.height = `${renderH}px`;
     container.appendChild(player);
   } else {
     // Direct mode (page-loaded polyfill, same world as Ruffle).
     const ruffle = await loadRuffle();
     player = ruffle.createPlayer();
-    player.style.width = `${width}px`;
-    player.style.height = `${height}px`;
+    player.style.width = `${renderW}px`;
+    player.style.height = `${renderH}px`;
     container.appendChild(player);
   }
 
@@ -484,8 +529,10 @@ export async function createFlashInstance(
     bridgeId,
     container,
     canvas: null,
-    width,
-    height,
+    width: renderW,
+    height: renderH,
+    nativeW: native ? native.w : 0,
+    nativeH: native ? native.h : 0,
     animFrameId: null,
     ready: false,
     pausedAtStart,
@@ -579,17 +626,25 @@ export async function createFlashInstance(
   // MovieClip at frame 1 (rendered + stopped) so it doesn't visibly
   // cycle during the 3-second AS-init wait below. Subsequent Lingo
   // `mySprite.play()` (via playFlash) unsticks it normally.
-  if (pausedAtStart) {
+  // Pin the initial frame BEFORE autoplay runs and before frame-capture starts,
+  // so the very first captured frame is already correct. A Lingo-asserted frame
+  // (`sprite.frame = N`, threaded from Rust as `assertedFrame` — it lives on the
+  // SPRITE so it's correct even though this JS instance was just (re)created and
+  // never saw the `frame =` op) takes PRECEDENCE over `pausedAtStart`'s frame-1:
+  // StoryScramble's 3 story tiles share cast 2:1 but each must show its own
+  // poster; pinning them all to frame 1 (pausedAtStart) shows the SAME picture.
+  const initialPin = assertedFrame >= 0 ? assertedFrame : (pausedAtStart ? 1 : -1);
+  if (initialPin >= 0) {
     try {
-      // Two-step pin: gotoAndPlay so Ruffle paints frame 1, wait one
-      // browser RAF so the paint lands on the canvas, then gotoAndStop
-      // to halt the MovieClip. Mirrors applyGotoAndPin's strategy
-      // (Ruffle skips paint for already-stopped MovieClips).
-      player.GotoFrame(1, false);
+      // Two-step: gotoAndPlay so Ruffle paints the frame (it skips paint for an
+      // already-stopped MovieClip), wait one RAF so the paint lands, then
+      // gotoAndStop to halt there.
+      player.GotoFrame(initialPin, false);
       await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-      player.GotoFrame(1, true);
+      player.GotoFrame(initialPin, true);
+      instance.stopped = true;
     } catch (e) {
-      console.warn(`[Flash] Instance ${key} pausedAtStart pin failed:`, e);
+      console.warn(`[Flash] Instance ${key} initial-frame pin (${initialPin}) failed:`, e);
     }
   }
 
@@ -629,39 +684,32 @@ export async function createFlashInstance(
     flashAccessBeforeReady = false;
     console.log(`[Flash] Instance ${key} fully ready (pending: ${flashLoadingCount})`);
 
-    // Seed the new instance with the frame captured from a sibling
-    // sprite using the same member (see scan above). Bubbles in
-    // storyscramble's main scene rely on this — sprite 2 picks up
-    // sprite 17's frame-21 state instead of autoplaying back to 11.
-    //
-    // By the time this runs (3s after instance creation), the SWF has
-    // already autoplayed 1→11 and AS `stop()` has parked the MovieClip.
-    // A bare `GotoFrame(N, false)` against an AS-stopped MovieClip
-    // doesn't reliably seek — we have to mirror the playFlash
-    // workaround: call `play()` first to flip the player-level paused
-    // flag, THEN `GotoFrame(N, false)` to hit MovieClip's goto_frame
-    // (which seeks AND clears the stopped flag). Frame N's own AS
-    // `stop()` then re-parks the playhead at N.
     const live = instances.get(key);
-    // Mark ready BEFORE the seed and queue replay so the internal
+    // Mark ready BEFORE the queue replay so the internal
     // `live.rufflePlayer.GotoFrame(...)` calls aren't seen as targeting
-    // a not-yet-ready instance (they're the seed itself). After this
-    // point any Lingo goTo/play/stop calls bypass the queue.
+    // a not-yet-ready instance. After this point any Lingo goTo/play/stop
+    // calls bypass the queue.
     if (live) live.ready = true;
-    if (inheritedFrame !== null && live) {
-      try {
-        live.rufflePlayer.play();
-        live.rufflePlayer.GotoFrame(inheritedFrame, false);
-      } catch (e) {
-        console.warn(`[Flash] inherit seed failed for ${key}:`, e);
-      }
-    }
 
     // Replay any beginSprite-time `gotoFrame(sprite,N)` / `play(sprite)` /
-    // `stop(sprite)` Lingo calls that arrived before this instance was
-    // created. Runs AFTER the inheritance seed so an explicit
-    // `gotoFrame(31)` from BS38 wins over an inherited frame 21.
+    // `stop(sprite)` Lingo calls that arrived before this instance was created.
     flushPendingGoto(spriteNum);
+
+    // Finally, re-assert the sprite's authoritative frame (from Rust). The
+    // early pin above set it before autoplay, but the 3s AS-init window +
+    // flushPendingGoto may have moved the playhead; re-pinning here guarantees
+    // the poster survives to `ready` (StoryScramble tiles). Skipped if a queued
+    // `play`/`gotoFrame` already resumed the sprite (the flush's stopped flag
+    // reflects that).
+    if (assertedFrame >= 0 && live && live.stopped) {
+      try {
+        live.rufflePlayer.GotoFrame(assertedFrame, false);
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
+        live.rufflePlayer.GotoFrame(assertedFrame, true);
+      } catch (e) {
+        console.warn(`[Flash] asserted-frame re-pin failed for ${key}:`, e);
+      }
+    }
   }
 }
 
@@ -1031,17 +1079,26 @@ function flushPendingGoto(spriteNum: number): void {
           applyGotoLabelAndPin(instance, op.label);
           break;
         case 'play':
-          // Queued `play` ops fire only on instances we just created —
-          // at which point autoplay has already started the SWF. Re-
-          // firing play() / GotoFrame(_currentframe, false) here is
-          // redundant AND visually disruptive: it seeks back to the
-          // queued goto target and makes the bubble grow animation
-          // restart from frame 1 after autoplay already played it.
-          //
-          // All we need to do is cancel any pending pin from a queued
-          // goto earlier in the same queue so the deferred stop
-          // doesn't undo the implicit play.
+          // Cancel any deferred gotoAndStop pin from a queued goto earlier in
+          // this queue, THEN actually resume playback from the current frame.
+          // A preceding queued `stop`/gotoAndStop (very common: the bogeyman's
+          // `#pickit` does `sprite(16).frame = 1` then `play(sprite 16)` on a
+          // just-swapped straw/longarm instance) leaves the clip PARKED — with a
+          // no-op here it stays at frame 1, so `#rollit`'s frame poll never
+          // advances, the grab never completes, and the sprite is stuck showing
+          // "straw". Playing from `_currentframe` (not a hardcoded 1) means an
+          // already-autoplayed clip isn't restarted.
           pinTarget.delete(spriteNum);
+          instance.stopped = false;
+          try {
+            instance.rufflePlayer.play();
+            const cur = parseInt(
+              instance.rufflePlayer.GetVariable?.('/:_currentframe') || '1', 10
+            ) || 1;
+            instance.rufflePlayer.GotoFrame(cur, false);
+          } catch (e) {
+            console.warn(`[Flash flush] sprite#${spriteNum} play resume error:`, e);
+          }
           break;
         case 'stop':
           // Mirror the live stopFlash: halt the root TIMELINE, don't suspend
@@ -1552,6 +1609,7 @@ export function initFlashBridge(): void {
   win.dirplayer_ruffleStop = stopFlash;
   win.dirplayer_rufflePlay = playFlash;
   win.dirplayer_ruffleRewind = rewindFlash;
+  win.dirplayer_ruffleSetSize = setFlashSize;
   win.dirplayer_ruffleIsPlaying = isPlaying;
   win.dirplayer_ruffleGetFrameCount = getFrameCount;
   win.dirplayer_ruffleGetCurrentFrame = getCurrentFrame;

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -6,7 +6,7 @@
  * can be composited with Director sprites (Director sprites can layer on top).
  */ 
 
-import { update_flash_frame, trigger_lingo_callback_on_script, dispatch_flash_event, dispatch_flash_lingo } from 'vm-rust';
+import { update_flash_frame, trigger_lingo_callback_on_script, dispatch_flash_event, dispatch_flash_lingo, local_connection_send } from 'vm-rust';
 import {
   isBridgeRequired,
   waitForBridge,
@@ -14,6 +14,12 @@ import {
   bridgeFindElement,
   bridgeCallMethod,
   bridgeDestroyPlayer,
+  bridgeGetVariableSync,
+  bridgeSetVariableSync,
+  bridgeCallFunctionSync,
+  bridgeCallMethodSync,
+  bridgeOnEvent,
+  bridgeRegisterCallbackForwarders,
 } from './ruffleBridgeClient';
 
 interface FlashInstance {
@@ -116,6 +122,130 @@ function maybeCorsProxy(urlStr: string): string | null {
   return base + encodeURIComponent(u.toString());
 }
 
+// Mixed Content upgrade: a Director movie served over HTTPS (Neopets' DGS loader
+// at https://www.neopets.com/games/dgs/play_shockwave.phtml) still fetches its
+// game data over a hardcoded http:// URL
+// (http://www.neopets.com/games/dgs/dgs_get_game_data.phtml). Chrome blocks
+// active mixed content outright, so the fetch never completes and the loader
+// loops retrying. The resource is served over https on the same host, so upgrade
+// the scheme. Never touch localhost/127.0.0.1 — the dev proxies are deliberately
+// http and are matched by applyFetchRewrite/maybeCorsProxy by hostname regardless
+// of scheme. Returns true if the URL was changed. No-op when the page itself is
+// http (no mixed-content restriction) or the request is already https.
+function upgradeInsecureUrl(url: URL): boolean {
+  if (
+    window.location.protocol === 'https:' &&
+    url.protocol === 'http:' &&
+    url.hostname !== 'localhost' &&
+    url.hostname !== '127.0.0.1'
+  ) {
+    url.protocol = 'https:';
+    return true;
+  }
+  return false;
+}
+
+// Cross-origin fetch proxy (MV3 extension). A content-script `fetch()` is
+// page-privileged, so a cross-origin request (Neopets' game SWF lives on
+// swf.neopets.com while the loader page is www.neopets.com) is CORS-blocked even
+// though the extension has host_permissions. The service worker CAN read those
+// responses, so we relay cross-origin requests through it. Standalone/electron
+// (no chrome.runtime) and same-origin / localhost-proxy requests stay direct.
+// `chrome` isn't in the app's TS lib; access it structurally.
+const extChrome = (globalThis as unknown as {
+  chrome?: { runtime?: { id?: string; sendMessage?: (msg: unknown) => Promise<unknown> } };
+}).chrome;
+
+function isExtensionContext(): boolean {
+  return !!extChrome?.runtime?.id;
+}
+
+function shouldProxyCrossOrigin(url: URL): boolean {
+  if (!isExtensionContext()) return false;
+  try {
+    if (url.origin === window.location.origin) return false; // same-origin: no CORS
+  } catch {
+    return false;
+  }
+  if (url.hostname === 'localhost' || url.hostname === '127.0.0.1') return false; // dev proxy handles its own CORS
+  return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    bin += String.fromCharCode.apply(null, bytes.subarray(i, i + CHUNK) as unknown as number[]);
+  }
+  return btoa(bin);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+function bodyInitToBytes(body: BodyInit): Uint8Array | undefined {
+  if (typeof body === 'string') return new TextEncoder().encode(body);
+  if (body instanceof Uint8Array) return body;
+  if (body instanceof ArrayBuffer) return new Uint8Array(body);
+  if (ArrayBuffer.isView(body)) return new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+  return undefined; // Blob / FormData / URLSearchParams — not used by our asset fetches
+}
+
+function headersToObject(h?: HeadersInit): Record<string, string> | undefined {
+  if (!h) return undefined;
+  const out: Record<string, string> = {};
+  if (h instanceof Headers) h.forEach((v, k) => { out[k] = v; });
+  else if (Array.isArray(h)) h.forEach(([k, v]) => { out[k] = v; });
+  else Object.assign(out, h);
+  return out;
+}
+
+interface BgFetchResult {
+  ok?: boolean;
+  status?: number;
+  statusText?: string;
+  contentType?: string;
+  bodyBase64?: string;
+  error?: string;
+}
+
+async function corsFetchRawViaBackground(
+  url: string,
+  method: string,
+  headers?: Record<string, string>,
+  bodyBytes?: Uint8Array,
+): Promise<BgFetchResult> {
+  const resp = await extChrome!.runtime!.sendMessage!({
+    type: 'dirplayer-cors-fetch',
+    url,
+    method,
+    headers,
+    body: bodyBytes && bodyBytes.byteLength ? bytesToBase64(bodyBytes) : undefined,
+  }) as BgFetchResult | undefined;
+  return resp || { error: 'no response from background' };
+}
+
+async function corsFetchViaBackground(
+  url: string,
+  method: string,
+  headers?: Record<string, string>,
+  bodyBytes?: Uint8Array,
+): Promise<Response> {
+  const resp = await corsFetchRawViaBackground(url, method, headers, bodyBytes);
+  if (resp.error) throw new Error('cors-fetch: ' + resp.error);
+  const bytes = base64ToBytes(resp.bodyBase64 || '');
+  const status = resp.status && resp.status >= 200 ? resp.status : 200;
+  return new Response(bytes as unknown as BodyInit, {
+    status,
+    statusText: resp.statusText || '',
+    headers: resp.contentType ? { 'content-type': resp.contentType } : undefined,
+  });
+}
+
 const origFetch = window.fetch;
 // Count outstanding browser fetches so dirplayer's Rust frame loop can lengthen
 // its per-frame yield while any request is in flight — including Ruffle-side
@@ -138,20 +268,44 @@ window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<R
   if (typeof input === 'string') {
     try {
       const url = new URL(input, window.location.origin);
+      const upgraded = upgradeInsecureUrl(url);
       if (applyFetchRewrite(url)) {
         input = url.toString();
       } else {
         const proxied = maybeCorsProxy(url.toString());
         if (proxied) input = proxied;
+        else if (upgraded) input = url.toString();
+      }
+      // Cross-origin in the MV3 extension: relay through the service worker,
+      // which (unlike this page-privileged content script) can read the
+      // response. swf.neopets.com game SWFs hit this from www.neopets.com.
+      const finalUrl = new URL(input as string, window.location.origin);
+      if (shouldProxyCrossOrigin(finalUrl)) {
+        const method = (init?.method || 'GET').toUpperCase();
+        const bodyBytes = init?.body ? bodyInitToBytes(init.body) : undefined;
+        return trackFetch(corsFetchViaBackground(
+          finalUrl.toString(), method, headersToObject(init?.headers), bodyBytes,
+        ));
       }
     } catch { /* ignore parse errors */ }
   } else if (input instanceof Request) {
     try {
       const url = new URL(input.url);
-      const newUrl = applyFetchRewrite(url) ? url.toString() : maybeCorsProxy(url.toString());
-      if (newUrl) {
+      const upgraded = upgradeInsecureUrl(url);
+      const rewritten = applyFetchRewrite(url)
+        ? url.toString()
+        : (maybeCorsProxy(url.toString()) || (upgraded ? url.toString() : null));
+      const finalUrl = rewritten || url.toString();
+      const crossOrigin = shouldProxyCrossOrigin(new URL(finalUrl, window.location.origin));
+      if (rewritten || crossOrigin) {
         const req = input;
         return trackFetch(req.arrayBuffer().then(bodyBuf => {
+          if (crossOrigin) {
+            const bodyBytes = bodyBuf.byteLength > 0 ? new Uint8Array(bodyBuf) : undefined;
+            return corsFetchViaBackground(
+              finalUrl, req.method, headersToObject(req.headers), bodyBytes,
+            );
+          }
           const newInit: RequestInit = {
             method: req.method,
             headers: req.headers,
@@ -159,7 +313,7 @@ window.fetch = function(input: RequestInfo | URL, init?: RequestInit): Promise<R
             mode: 'cors' as RequestMode,
             credentials: 'omit' as RequestCredentials,
           };
-          return origFetch.call(window, newUrl, newInit);
+          return origFetch.call(window, finalUrl, newInit);
         }));
       }
     } catch (e) { console.error('[fetch-intercept] Error:', e); }
@@ -248,8 +402,8 @@ function dispatchMouseEvent(
 ): boolean {
   const inst = instances.get(instanceKey(spriteNum));
   if (!inst) {
-    console.warn(`[Flash mouse] no instance for sprite#${spriteNum}; known=`,
-      Array.from(instances.keys()));
+    // No Flash instance for this sprite (e.g. a click on a non-Flash sprite, or
+    // before the SWF instance is created) — nothing to forward.
     return false;
   }
 
@@ -263,12 +417,20 @@ function dispatchMouseEvent(
     }
   }
 
+  // Bridge mode (MV3 extension): dirplayer_dispatchPointer lives on the
+  // main-world player element, invisible on the isolated-world stub. Forward it
+  // through the bridge — fire-and-forget (a click's "handled" return isn't
+  // consumed synchronously). Without this, Director-side clicks never reach the
+  // offscreen Ruffle preloader, so DGS's "Play" button never flips `playGame`.
+  if (inst.bridgeId) {
+    void bridgeCallMethod(inst.bridgeId, 'dirplayer_dispatchPointer', [type, canvasX, canvasY]);
+    return true;
+  }
+
   const player = inst.rufflePlayer as
     | { dirplayer_dispatchPointer?: (t: string, x: number, y: number) => boolean }
     | undefined;
   if (typeof player?.dirplayer_dispatchPointer !== 'function') {
-    console.warn(`[Flash mouse] sprite#${spriteNum} player has no dirplayer_dispatchPointer; ` +
-      `bridgeId=${inst.bridgeId}, player keys=`, player ? Object.keys(player as object) : 'no player');
     return false;
   }
   const handled = !!player.dirplayer_dispatchPointer(type, canvasX, canvasY);
@@ -380,14 +542,18 @@ function registerEventUrlHandler(player: any, castLib: number, castMember: numbe
  * dispatch_flash_event tokenises trailing args.
  */
 function registerFSCommandHandler(player: any, castLib: number, castMember: number): void {
-  if (typeof player?.addFSCommandHandler !== 'function') {
+  // Prefer the fork's namespaced `dirplayer_addFSCommandHandler` (binds only to
+  // our player, never a stock Ruffle sharing the page); fall back to the stock
+  // `addFSCommandHandler` if an older bundle is loaded.
+  const reg = player?.dirplayer_addFSCommandHandler || player?.addFSCommandHandler;
+  if (typeof reg !== 'function') {
     console.warn(
-      `[Flash] ${castLib}:${castMember}: addFSCommandHandler missing on Ruffle player — ` +
+      `[Flash] ${castLib}:${castMember}: dirplayer_addFSCommandHandler missing on Ruffle player — ` +
       `fscommand() calls from the SWF will be dropped.`
     );
     return;
   }
-  player.addFSCommandHandler((command: string, args: string): void => {
+  reg.call(player, (command: string, args: string): void => {
     if (typeof command !== 'string' || !command.trim()) return;
     const body = (typeof args === 'string' && args.trim())
       ? `${command.trim()} ${args.trim()}`
@@ -399,6 +565,41 @@ function registerFSCommandHandler(player: any, castLib: number, castMember: numb
       );
     }
   });
+}
+
+/**
+ * Bridge-mode counterpart to registerEventUrlHandler + registerFSCommandHandler.
+ * The Flash→Director callbacks (getURL("event:"/"lingo:") and fscommand) are
+ * functions, which can't cross the isolated↔main world boundary. So the
+ * main-world host registers its OWN handlers on the player — it decides
+ * synchronously whether to claim an open-URL (for our lingo:/event: schemes) and
+ * forwards the body back here via the bridge event channel, where the actual
+ * Lingo dispatch runs. Neopets' DGS include movie fires `fscommand("FlashLoader
+ * Loaded")` this way; without it the loader stalls at load_state 6.
+ */
+function registerBridgeCallbacks(bridgeId: string, castLib: number, castMember: number): void {
+  bridgeOnEvent(bridgeId, (name, detail) => {
+    const d = detail as { url?: string; target?: string; command?: string; args?: string } | undefined;
+    if (!d) return;
+    if (name === 'openUrl') {
+      const url = d.url;
+      if (typeof url !== 'string') return;
+      if (url.startsWith('lingo:')) {
+        dispatchFlashLingo(url.slice('lingo:'.length).trim());
+      } else if (url.startsWith('event:')) {
+        dispatchFlashEvent(castLib, castMember, url.slice('event:'.length).trim());
+      }
+    } else if (name === 'fsCommand') {
+      const command = d.command;
+      const args = d.args;
+      if (typeof command !== 'string' || !command.trim()) return;
+      const body = (typeof args === 'string' && args.trim())
+        ? `${command.trim()} ${args.trim()}`
+        : command.trim();
+      dispatchFlashEvent(castLib, castMember, body);
+    }
+  });
+  void bridgeRegisterCallbackForwarders(bridgeId);
 }
 
 /**
@@ -740,9 +941,9 @@ export async function createFlashInstance(
       // Two-step: gotoAndPlay so Ruffle paints the frame (it skips paint for an
       // already-stopped MovieClip), wait one RAF so the paint lands, then
       // gotoAndStop to halt there.
-      player.GotoFrame(initialPin, false);
+      playerExec(instance, 'GotoFrame', [initialPin, false]);
       await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-      player.GotoFrame(initialPin, true);
+      playerExec(instance, 'GotoFrame', [initialPin, true]);
       instance.stopped = true;
     } catch (e) {
       console.warn(`[Flash] Instance ${key} initial-frame pin (${initialPin}) failed:`, e);
@@ -755,11 +956,18 @@ export async function createFlashInstance(
   // the Ruffle-fork patch is present, navigations whose URL starts with
   // `event:` get routed into dispatch_flash_event and the real open is
   // suppressed. Otherwise it's a safe no-op.
-  registerEventUrlHandler(player, castLib, castMember);
-
   // The other Flash→Director channel: `fscommand("handler", "args")`. DGS's
   // include movie (objMain) uses this to fire `on FlashLoaderLoaded`.
-  registerFSCommandHandler(player, castLib, castMember);
+  if (bridgeId) {
+    // Bridge mode (MV3 extension): the player + its handlers live in the main
+    // world, and callback functions can't cross worlds — so the host registers
+    // its own forwarders and posts each event/fscommand back here. Handles both
+    // the event:/lingo: URL channel and fscommand in one call.
+    registerBridgeCallbacks(bridgeId, castLib, castMember);
+  } else {
+    registerEventUrlHandler(player, castLib, castMember);
+    registerFSCommandHandler(player, castLib, castMember);
+  }
 
   // Find the internal canvas element that Ruffle renders to
   await new Promise<void>((resolve) => {
@@ -808,9 +1016,9 @@ export async function createFlashInstance(
     // reflects that).
     if (assertedFrame >= 0 && live && live.stopped) {
       try {
-        live.rufflePlayer.GotoFrame(assertedFrame, false);
+        playerExec(live, 'GotoFrame', [assertedFrame, false]);
         await new Promise<void>(resolve => requestAnimationFrame(() => resolve()));
-        live.rufflePlayer.GotoFrame(assertedFrame, true);
+        playerExec(live, 'GotoFrame', [assertedFrame, true]);
       } catch (e) {
         console.warn(`[Flash] asserted-frame re-pin failed for ${key}:`, e);
       }
@@ -956,6 +1164,12 @@ function getVariable(spriteNum: number, path: string): string | null {
   }
 
   try {
+    // Bridge mode (MV3 extension): the real player lives in the main world, so
+    // its GetVariable method isn't visible on the isolated-world element — route
+    // the read through the synchronous bridge instead.
+    if (instance.bridgeId) {
+      return bridgeGetVariableSync(instance.bridgeId, translateLevel0(path));
+    }
     const val = instance.rufflePlayer.GetVariable(translateLevel0(path));
     return val;
   } catch (e) {
@@ -982,6 +1196,10 @@ function setVariable(spriteNum: number, path: string, value: string): boolean {
   }
 
   try {
+    // Bridge mode: route through the synchronous bridge (see getVariable).
+    if (instance.bridgeId) {
+      return bridgeSetVariableSync(instance.bridgeId, translateLevel0(path), value);
+    }
     return instance.rufflePlayer.SetVariable(translateLevel0(path), value);
   } catch (e) {
     console.warn(`ruffleSetVariable error:`, e);
@@ -1031,6 +1249,30 @@ const pendingOps = new Map<number, PendingOp[]>();
  */
 const pinTarget = new Map<number, number>();
 
+// Fire-and-forget Ruffle player method. In the MV3 extension the player lives in
+// the main world, so its methods are invisible on the isolated-world stub —
+// route through the bridge; direct otherwise. Used for playback control
+// (GotoFrame / play / pause / CallFunction-as-command).
+function playerExec(instance: FlashInstance, method: string, args: unknown[] = []): void {
+  if (instance.bridgeId) {
+    void bridgeCallMethod(instance.bridgeId, method, args);
+    return;
+  }
+  const p = instance.rufflePlayer as Record<string, ((...a: unknown[]) => unknown) | undefined> | undefined;
+  const fn = p?.[method];
+  if (typeof fn === 'function') {
+    try { fn.apply(p, args); } catch (e) { console.warn(`[Flash ${method}] error:`, e); }
+  }
+}
+
+// Synchronous GetVariable that also works in bridge mode (frameCount /
+// currentFrame / findLabel / getFlashProperty need the value immediately).
+function playerGetVar(instance: FlashInstance, path: string): string | null {
+  if (instance.bridgeId) return bridgeGetVariableSync(instance.bridgeId, path);
+  const v = (instance.rufflePlayer as { GetVariable?: (p: string) => string | null } | undefined)?.GetVariable?.(path);
+  return v ?? null;
+}
+
 /**
  * Numeric seek that LEAVES THE PLAYHEAD RUNNING — matches Director's
  * `sprite(N).gotoFrame(frame)` method semantic (the Flash Asset Xtra's
@@ -1040,11 +1282,7 @@ const pinTarget = new Map<number, number>();
  * each label points to an animated frame range that must keep playing.
  */
 function applyGotoPlay(instance: FlashInstance, frame: number): void {
-  try {
-    instance.rufflePlayer.GotoFrame(frame, false);
-  } catch (e) {
-    console.warn(`[Flash gotoPlay] error:`, e);
-  }
+  playerExec(instance, 'GotoFrame', [frame, false]);
   // Cancel any pending pin from a previous gotoAndStop on this sprite —
   // play-mode wins over a stale pin target.
   pinTarget.delete(instance.spriteNum);
@@ -1056,18 +1294,7 @@ function applyGotoPlay(instance: FlashInstance, frame: number): void {
  * `_root.gotoAndPlay(label)` via CallFunction.
  */
 function applyGotoLabelPlay(instance: FlashInstance, label: string): void {
-  const player = instance.rufflePlayer as unknown as {
-    CallFunction?: (path: string, args: unknown[]) => unknown;
-  };
-  if (typeof player.CallFunction !== 'function') {
-    console.warn(`[Flash gotoLabelPlay] sprite#${instance.spriteNum} player has no CallFunction`);
-    return;
-  }
-  try {
-    player.CallFunction('_root.gotoAndPlay', [label]);
-  } catch (e) {
-    console.warn(`[Flash gotoLabelPlay] error:`, e);
-  }
+  playerExec(instance, 'CallFunction', ['_root.gotoAndPlay', [label]]);
 }
 
 /**
@@ -1078,16 +1305,10 @@ function applyGotoLabelPlay(instance: FlashInstance, label: string): void {
  * a render race against Ruffle's RAF; see schedulePin for the rationale.
  */
 function applyGotoAndPin(instance: FlashInstance, frame: number): void {
-  try {
-    // Goto+play first forces Ruffle to render frame N synchronously
-    // (Ruffle skips paint for already-stopped MovieClips, so a bare
-    // gotoAndStop wouldn't show frame N until something else triggered
-    // a repaint).
-    instance.rufflePlayer.GotoFrame(frame, false);
-  } catch (e) {
-    console.warn(`[Flash goto] play-step error:`, e);
-    return;
-  }
+  // Goto+play first forces Ruffle to render frame N synchronously (Ruffle skips
+  // paint for already-stopped MovieClips, so a bare gotoAndStop wouldn't show
+  // frame N until something else triggered a repaint).
+  playerExec(instance, 'GotoFrame', [frame, false]);
   pinTarget.set(instance.spriteNum, frame);
   schedulePin(instance, frame);
 }
@@ -1097,29 +1318,13 @@ function applyGotoAndPin(instance: FlashInstance, frame: number): void {
  * AS1 CallFunction.
  */
 function applyGotoLabelAndPin(instance: FlashInstance, label: string): void {
-  const player = instance.rufflePlayer as unknown as {
-    CallFunction?: (path: string, args: unknown[]) => unknown;
-  };
-  if (typeof player.CallFunction !== 'function') {
-    console.warn(`[Flash gotoLabel] sprite#${instance.spriteNum} player has no CallFunction`);
-    return;
-  }
-  try {
-    player.CallFunction('_root.gotoAndPlay', [label]);
-  } catch (e) {
-    console.warn(`[Flash gotoLabel] play-step error:`, e);
-    return;
-  }
+  playerExec(instance, 'CallFunction', ['_root.gotoAndPlay', [label]]);
   queueMicrotask(() => {
-    try {
-      player.CallFunction!('_root.stop', []);
-      // Resume the player so the seeked label frame paints — see schedulePin
-      // for the full rationale (a movie pinning the sprite via per-frame
-      // stop()/hold keeps the player suspended, so the goto never repaints).
-      (instance.rufflePlayer as { play?: () => void }).play?.();
-    } catch (e) {
-      console.warn(`[Flash gotoLabel] pin-step error:`, e);
-    }
+    playerExec(instance, 'CallFunction', ['_root.stop', []]);
+    // Resume the player so the seeked label frame paints — see schedulePin
+    // for the full rationale (a movie pinning the sprite via per-frame
+    // stop()/hold keeps the player suspended, so the goto never repaints).
+    playerExec(instance, 'play', []);
   });
 }
 
@@ -1144,6 +1349,12 @@ function schedulePin(instance: FlashInstance, frame: number): void {
     // different frame) cleared / overwrote our target in the meantime.
     if (pinTarget.get(instance.spriteNum) !== frame) return;
     pinTarget.delete(instance.spriteNum);
+    if (instance.bridgeId) {
+      // Bridge mode: fire-and-forget goto+play through the bridge.
+      playerExec(instance, 'GotoFrame', [frame, true]);
+      playerExec(instance, 'play', []);
+      return;
+    }
     try {
       instance.rufflePlayer.GotoFrame(frame, true);
       // Resume the PLAYER (not the clip) so the seeked frame actually paints
@@ -1201,14 +1412,10 @@ function flushPendingGoto(spriteNum: number): void {
           // already-autoplayed clip isn't restarted.
           pinTarget.delete(spriteNum);
           instance.stopped = false;
-          try {
-            instance.rufflePlayer.play();
-            const cur = parseInt(
-              instance.rufflePlayer.GetVariable?.('/:_currentframe') || '1', 10
-            ) || 1;
-            instance.rufflePlayer.GotoFrame(cur, false);
-          } catch (e) {
-            console.warn(`[Flash flush] sprite#${spriteNum} play resume error:`, e);
+          {
+            playerExec(instance, 'play');
+            const cur = parseInt(playerGetVar(instance, '/:_currentframe') || '1', 10) || 1;
+            playerExec(instance, 'GotoFrame', [cur, false]);
           }
           break;
         case 'stop':
@@ -1222,22 +1429,15 @@ function flushPendingGoto(spriteNum: number): void {
           // player alive lets the seeked frame render.
           pinTarget.delete(spriteNum);
           instance.stopped = true;
-          {
-            const p = instance.rufflePlayer as {
-              CallFunction?: (path: string, args: unknown[]) => unknown;
-              pause?: () => void;
-            };
-            if (typeof p.CallFunction === 'function') p.CallFunction('_root.stop', []);
-            else p.pause?.();
-          }
+          playerExec(instance, 'CallFunction', ['_root.stop', []]);
           break;
         case 'rewind':
           pinTarget.delete(spriteNum);
           instance.stopped = true;
-          instance.rufflePlayer.GotoFrame(1, true);
+          playerExec(instance, 'GotoFrame', [1, true]);
           break;
         case 'setVariable':
-          instance.rufflePlayer.SetVariable(translateLevel0(op.path), op.value);
+          playerExec(instance, 'SetVariable', [translateLevel0(op.path), op.value]);
           break;
         case 'callFunction': {
           // Replay a pre-ready callFunction. Decode args exactly like the
@@ -1251,7 +1451,7 @@ function flushPendingGoto(spriteNum: number): void {
             if (typeof arg === 'string' && arg.startsWith('__ruffle_path:')) return { __ruffle_path: arg.substring('__ruffle_path:'.length) };
             return arg;
           });
-          instance.rufflePlayer.CallFunction(translateLevel0(op.path), args);
+          playerExec(instance, 'CallFunction', [translateLevel0(op.path), args]);
           break;
         }
       }
@@ -1329,7 +1529,11 @@ function goToFrameAndStop(spriteNum: number, frameOrLabel: string): void {
  * Call a Flash function on a Ruffle instance.
  * Called from WASM via window.dirplayer_ruffleCallFunction.
  */
-function callFunction(spriteNum: number, path: string, argsXml: string): string | null {
+// Returns the RAW Ruffle value (boolean/number/string/object/null), not just a
+// string — the WASM `ruffle_call_function` extern receives it as a JsValue and
+// type-branches (bool → Int(1/0), object → FlashObjectRef, …). Stringifying here
+// broke DGS's `includeIsLoaded() = 1` (AS true → "true" ≠ 1).
+function callFunction(spriteNum: number, path: string, argsXml: string): unknown {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   // Instance not created / AS-init not finished yet: a beginSprite (or a
@@ -1355,6 +1559,10 @@ function callFunction(spriteNum: number, path: string, argsXml: string): string 
       if (typeof arg === 'string' && arg.startsWith('__ruffle_path:')) return { __ruffle_path: arg.substring('__ruffle_path:'.length) };
       return arg;
     });
+    // Bridge mode: route through the synchronous bridge (see getVariable).
+    if (instance.bridgeId) {
+      return bridgeCallFunctionSync(instance.bridgeId, translateLevel0(path), args);
+    }
     return instance.rufflePlayer.CallFunction(translateLevel0(path), args);
   } catch (e) {
     console.warn(`ruffleCallFunction error:`, e);
@@ -1385,16 +1593,8 @@ function stopFlash(spriteNum: number): void {
     // Halting only the root MovieClip freezes the timeline in place while
     // leaving the player alive to paint frame changes. `sprite.playing` reads
     // `instance.stopped` since the player itself keeps running.
-    const player = instance.rufflePlayer as {
-      CallFunction?: (path: string, args: unknown[]) => unknown;
-      pause?: () => void;
-    };
-    if (typeof player.CallFunction === 'function') {
-      player.CallFunction('_root.stop', []);
-    } else {
-      // Bridge mode / no CallFunction: fall back to the old full-player pause.
-      player.pause?.();
-    }
+    // Bridge mode routes CallFunction through the main-world player.
+    playerExec(instance, 'CallFunction', ['_root.stop', []]);
   } catch (e) {
     console.warn(`ruffleStop error:`, e);
   }
@@ -1423,15 +1623,9 @@ function playFlash(spriteNum: number): void {
   // would undo our play() a frame later (BS69 shrink animation).
   pinTarget.delete(spriteNum);
   instance.stopped = false;
-  try {
-    instance.rufflePlayer.play();
-    const cur = parseInt(
-      instance.rufflePlayer.GetVariable?.('/:_currentframe') || '1', 10
-    ) || 1;
-    instance.rufflePlayer.GotoFrame(cur, false);
-  } catch (e) {
-    console.warn(`rufflePlay error:`, e);
-  }
+  playerExec(instance, 'play');
+  const cur = parseInt(playerGetVar(instance, '/:_currentframe') || '1', 10) || 1;
+  playerExec(instance, 'GotoFrame', [cur, false]);
 }
 
 /**
@@ -1446,11 +1640,7 @@ function rewindFlash(spriteNum: number): void {
   }
   pinTarget.delete(spriteNum);
   instance.stopped = true;
-  try {
-    instance.rufflePlayer.GotoFrame(1, true);
-  } catch (e) {
-    console.warn(`ruffleRewind error:`, e);
-  }
+  playerExec(instance, 'GotoFrame', [1, true]);
 }
 
 /**
@@ -1465,6 +1655,9 @@ function isPlaying(spriteNum: number): boolean {
   // player-level isPlaying is no longer a reliable proxy for the movie's
   // stopped state. Honour the tracked intent first.
   if (instance.stopped) return false;
+  // Bridge mode: the isPlaying property isn't on the isolated-world stub; past
+  // the `stopped` gate the intent is "playing".
+  if (instance.bridgeId) return true;
   try {
     return instance.rufflePlayer.isPlaying ?? false;
   } catch (e) {
@@ -1480,8 +1673,7 @@ function getFrameCount(spriteNum: number): number {
   const instance = instances.get(key);
   if (!instance) return 0;
   try {
-    // Use GetVariable to read _totalframes
-    return parseInt(instance.rufflePlayer.GetVariable("/:_totalframes") || "0", 10);
+    return parseInt(playerGetVar(instance, "/:_totalframes") || "0", 10);
   } catch (e) {
     return 0;
   }
@@ -1495,7 +1687,7 @@ function getCurrentFrame(spriteNum: number): number {
   const instance = instances.get(key);
   if (!instance) return 0;
   try {
-    return parseInt(instance.rufflePlayer.GetVariable("/:_currentframe") || "0", 10);
+    return parseInt(playerGetVar(instance, "/:_currentframe") || "0", 10);
   } catch (e) {
     return 0;
   }
@@ -1510,13 +1702,9 @@ function callFrame(spriteNum: number, frame: number): void {
   const key = instanceKey(spriteNum);
   const instance = instances.get(key);
   if (!instance) return;
-  try {
-    // callFrame in Director executes the actions on a given frame
-    // Best approximation: go to that frame (which runs its scripts) and stop
-    instance.rufflePlayer.GotoFrame(frame, true);
-  } catch (e) {
-    console.warn(`ruffleCallFrame error:`, e);
-  }
+  // callFrame in Director executes the actions on a given frame.
+  // Best approximation: go to that frame (which runs its scripts) and stop.
+  playerExec(instance, 'GotoFrame', [frame, true]);
 }
 
 /**
@@ -1558,6 +1746,12 @@ function hitTest(spriteNum: number, localX: number, localY: number): number {
     }
   }
 
+  // Bridge mode: dirplayer_hitTest lives on the main-world player; call it
+  // synchronously (the classification 0–3 must return to Lingo inline).
+  if (inst.bridgeId) {
+    const r = bridgeCallMethodSync(inst.bridgeId, 'dirplayer_hitTest', [canvasX, canvasY]);
+    return (typeof r === 'number' ? r : 0) | 0;
+  }
   const player = inst.rufflePlayer as
     | { dirplayer_hitTest?: (x: number, y: number) => number }
     | undefined;
@@ -1595,7 +1789,7 @@ function getFlashProperty(spriteNum: number, target: string, propNum: number): s
 
   try {
     const path = target ? `${target}:${propName}` : `/:${propName}`;
-    return instance.rufflePlayer.GetVariable(path)?.toString() ?? null;
+    return playerGetVar(instance, path)?.toString() ?? null;
   } catch (e) {
     return null;
   }
@@ -1620,7 +1814,7 @@ function setFlashProperty(spriteNum: number, target: string, propNum: number, va
 
   try {
     const path = target ? `${target}:${propName}` : `/:${propName}`;
-    instance.rufflePlayer.SetVariable(path, value);
+    playerExec(instance, 'SetVariable', [path, value]);
   } catch (e) {
     console.warn(`ruffleSetFlashProperty error:`, e);
   }
@@ -1637,7 +1831,7 @@ function tellTarget(spriteNum: number, target: string, action: string): void {
   try {
     // tellTarget + action: best effort via SetVariable/CallFunction
     if (action === "play") {
-      instance.rufflePlayer.SetVariable(`${target}:_visible`, "1");
+      playerExec(instance, 'SetVariable', [`${target}:_visible`, "1"]);
       // Can't directly play a sub-timeline from JS, use CallFunction
     } else if (action === "stop") {
       // Similar limitation
@@ -1711,6 +1905,23 @@ function registerLingoCallback(
  */
 export function initFlashBridge(): void {
   const win = window as any;
+  // Flash LocalConnection.send bridge (Neopets DGS score/protocol). The Ruffle
+  // fork calls dirplayer_localConnectionSend(connName, method, argsJson); route
+  // it into the WASM export that dispatches the Lingo setCallback handler.
+  // Direct in dev (fork + this run in one world); in the MV3 extension the fork
+  // is main-world, so the bridge host re-fires it here as a `dirplayer-lc-send`
+  // DOM event (below).
+  win.dirplayer_localConnectionSend = (name: string, method: string, argsJson: string): boolean => {
+    try { return !!local_connection_send(name, method, argsJson); } catch { return false; }
+  };
+  if (isExtensionContext()) {
+    window.addEventListener('dirplayer-lc-send', (ev) => {
+      const d = (ev as CustomEvent).detail as
+        { name?: string; method?: string; argsJson?: string } | undefined;
+      if (!d || typeof d.name !== 'string') return;
+      try { local_connection_send(d.name, d.method || '', d.argsJson || '[]'); } catch { /* ignore */ }
+    });
+  }
   win.dirplayer_ruffleGetVariable = getVariable;
   win.dirplayer_flashInstances = instances;
   win.dirplayer_ruffleSetVariable = setVariable;

--- a/src/services/flashPlayerManager.ts
+++ b/src/services/flashPlayerManager.ts
@@ -399,6 +399,8 @@ function dispatchMouseEvent(
   type: 'down' | 'up' | 'move',
   localX: number,
   localY: number,
+  spriteW?: number,
+  spriteH?: number,
 ): boolean {
   const inst = instances.get(instanceKey(spriteNum));
   if (!inst) {
@@ -407,9 +409,17 @@ function dispatchMouseEvent(
     return false;
   }
 
+  // `localX/localY` are in the sprite's DISPLAY space (0..spriteW). The SWF renders
+  // at its own native size (`canvas.width/height`), which the sprite may scale — so
+  // map sprite-space → canvas internal space by the sprite dimensions (NOT the canvas
+  // DOM rect, which equals the native size and would be a no-op). A 626x468 SWF shown
+  // in a 600x320 sprite: local 288 → 288/600*626 ≈ 300.
   let canvasX = localX;
   let canvasY = localY;
-  if (inst.canvas) {
+  if (inst.canvas && spriteW && spriteH && spriteW > 0 && spriteH > 0) {
+    canvasX = (localX / spriteW) * inst.canvas.width;
+    canvasY = (localY / spriteH) * inst.canvas.height;
+  } else if (inst.canvas) {
     const rect = inst.canvas.getBoundingClientRect();
     if (rect.width > 0 && rect.height > 0) {
       canvasX = (localX / rect.width) * inst.canvas.width;

--- a/src/services/ruffleBridgeClient.ts
+++ b/src/services/ruffleBridgeClient.ts
@@ -120,6 +120,122 @@ export function bridgeDestroyPlayer(playerId: string): Promise<void> {
 }
 
 /**
+ * Ask the main-world host to register its own Flash→Director callback handlers
+ * (getURL "event:"/"lingo:" and fscommand) on the player and forward each
+ * invocation back as a bridge event (subscribe via bridgeOnEvent). Needed
+ * because the callback functions themselves can't cross the world boundary.
+ */
+export function bridgeRegisterCallbackForwarders(playerId: string): Promise<void> {
+  return bridgeCall({ method: 'registerCallbackForwarders', playerId });
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous bridge — for the handful of Ruffle calls Lingo consumes INLINE
+// (GetVariable / SetVariable / CallFunction). The Promise transport above can't
+// satisfy a synchronous Lingo read, but `dispatchEvent` runs listeners
+// synchronously, so the main-world host answers the request DURING dispatch and
+// writes the result onto a shared, `dirplayer_`-namespaced hidden DOM node. Plain
+// DOM text crosses the isolated↔main boundary, is untouched by wombat (which only
+// wraps navigation / postMessage), and is invisible to stock Ruffle (its own
+// surface is un-prefixed). We read the node back the instant `dispatchEvent`
+// returns. No new event name, no postMessage, no un-namespaced global.
+const SYNC_NODE_ID = '__dirplayer_ruffle_sync_channel';
+let syncNode: HTMLElement | null = null;
+let nextSyncId = 1;
+
+function ensureSyncNode(): HTMLElement {
+  if (syncNode && syncNode.isConnected) return syncNode;
+  let el = document.getElementById(SYNC_NODE_ID);
+  if (!el) {
+    el = document.createElement('div');
+    el.id = SYNC_NODE_ID;
+    el.style.display = 'none';
+    (document.documentElement || document.body).appendChild(el);
+  }
+  syncNode = el as HTMLElement;
+  return syncNode;
+}
+
+/**
+ * Synchronous bridge call. Dispatches the (already-namespaced) request event —
+ * whose listener the main-world host runs synchronously — and reads the result
+ * the host wrote to the shared node before `dispatchEvent` returned. Returns
+ * `undefined` if the host didn't answer (bridge not ready, method not sync),
+ * which callers treat like a null Flash read. Throws if the host reported an
+ * error for the call.
+ */
+function bridgeCallSync(payload: Record<string, unknown>): unknown {
+  const node = ensureSyncNode();
+  const syncId = nextSyncId++;
+  node.textContent = '';
+  window.dispatchEvent(new CustomEvent(REQ_EVENT, {
+    detail: { sync: true, syncId, ...payload },
+  }));
+  const raw = node.textContent;
+  if (!raw) return undefined;
+  let msg: { syncId?: number; result?: unknown; error?: string | null };
+  try {
+    msg = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!msg || msg.syncId !== syncId) return undefined;
+  if (msg.error) throw new Error(msg.error);
+  return msg.result;
+}
+
+export function bridgeGetVariableSync(
+  playerId: string,
+  path: string,
+): string | null {
+  const r = bridgeCallSync({ method: 'getVariableSync', playerId, args: [path] });
+  return r == null ? null : String(r);
+}
+
+export function bridgeSetVariableSync(
+  playerId: string,
+  path: string,
+  value: string,
+): boolean {
+  const r = bridgeCallSync({
+    method: 'setVariableSync',
+    playerId,
+    args: [path, value],
+  });
+  return !!r;
+}
+
+/**
+ * Synchronous generic method call on the main-world player (e.g.
+ * `dirplayer_hitTest`, which must return its classification immediately).
+ */
+export function bridgeCallMethodSync(
+  playerId: string,
+  method: string,
+  args: unknown[],
+): unknown {
+  return bridgeCallSync({ method: 'callMethodSync', playerId, args: [method, args] });
+}
+
+export function bridgeCallFunctionSync(
+  playerId: string,
+  path: string,
+  args: unknown[],
+): unknown {
+  // Return the RAW value (boolean / number / string / object / null), NOT a
+  // stringified form. dirplayer's ruffle_call_function extern receives this as a
+  // JsValue and branches on its type — AS `true` must stay a boolean so it maps
+  // to Lingo Int(1) (DGS `includeIsLoaded() = 1`); `String(true)` = "true" would
+  // become Datum::String and break the comparison. The bridge's JSON round-trip
+  // already preserves JSON types.
+  return bridgeCallSync({
+    method: 'callFunctionSync',
+    playerId,
+    args: [path, args],
+  });
+}
+
+/**
  * Find the DOM element corresponding to a bridge-managed player. The
  * main-world host stamps `data-dirplayer-bridge-id` on each player so
  * the isolated world can locate it via querySelector.

--- a/src/views/LoadMovie/index.tsx
+++ b/src/views/LoadMovie/index.tsx
@@ -17,6 +17,9 @@ type RecentMovie = {
   url: string;
   params: ExternalParam[];
   fakeMoviePath?: string;
+  // Whether this entry routes its cross-origin fetches through the CORS proxy.
+  // Opt-in per movie (advanced-options checkbox); undefined/false = direct.
+  useCorsProxy?: boolean;
   timestamp: number;
 };
 
@@ -116,9 +119,9 @@ function loadRecentMovies(): RecentMovie[] {
   }
 }
 
-function saveRecentMovie(url: string, params: ExternalParam[], fakeMoviePath?: string): RecentMovie[] {
+function saveRecentMovie(url: string, params: ExternalParam[], fakeMoviePath?: string, useCorsProxy?: boolean): RecentMovie[] {
   const existing = loadRecentMovies().filter(m => m.url !== url);
-  const updated = [{ url, params, fakeMoviePath, timestamp: Date.now() }, ...existing].slice(0, MAX_RECENT_MOVIES);
+  const updated = [{ url, params, fakeMoviePath, useCorsProxy, timestamp: Date.now() }, ...existing].slice(0, MAX_RECENT_MOVIES);
   window.localStorage.setItem(RECENT_MOVIES_KEY, JSON.stringify(updated));
   return updated;
 }
@@ -148,6 +151,8 @@ export default function LoadMovie() {
   const [paramsExpanded, setParamsExpanded] = useState(() => getEnvExternalParams().length > 0);
   const [loaderUrl, setLoaderUrl] = useState<string>('');
   const [corsProxy, setCorsProxy] = useState<string>(DEFAULT_CORS_PROXY);
+  // CORS proxy is OPT-IN per movie (default OFF); persisted per recent entry.
+  const [useCorsProxy, setUseCorsProxy] = useState<boolean>(false);
   const isInElectron = isElectron();
 
   const addParam = useCallback(() => {
@@ -163,20 +168,20 @@ export default function LoadMovie() {
     setExternalParams(prev => prev.map((p, i) => i === index ? { ...p, [field]: val } : p));
   }, []);
 
-  const loadMovieFile = useCallback(async (fullPath: string, params?: ExternalParam[], fakePath?: string) => {
+  const loadMovieFile = useCallback(async (fullPath: string, params?: ExternalParam[], fakePath?: string, useProxy?: boolean) => {
     try {
       setIsLoading(true);
       setHasError(false);
-      // The CORS-proxy field is the control: if it holds a base URL, route this
-      // movie's CROSS-ORIGIN http(s) fetches through it (e.g. Neopets DGS's
-      // `preloadNetThing("http://swf.neopets.com/...")`); if it's empty, route
-      // direct. maybeCorsProxy() only rewrites cross-origin requests, so a
-      // same-origin local movie is unaffected either way. We re-apply it on
-      // EVERY load — setting when non-empty, and CLEARING when empty — because
-      // `__dirplayerFlashConfig.corsProxy` is a persistent window global; without
-      // the clear, a proxy set by a prior load (or loader mode) leaked into
-      // later loads that shouldn't use it. Clear the field to disable.
-      const proxyBase = corsProxy.trim();
+      // The CORS proxy is OPT-IN per movie (advanced-options checkbox, persisted
+      // per recent entry). Only route this movie's CROSS-ORIGIN http(s) fetches
+      // through it when ENABLED and a base URL is set (e.g. Neopets DGS's
+      // `preloadNetThing("http://swf.neopets.com/...")`); otherwise route direct.
+      // We re-apply on EVERY load — setting when enabled, CLEARING otherwise —
+      // because `__dirplayerFlashConfig.corsProxy` is a persistent window global;
+      // without the clear, a proxy enabled for a PRIOR game leaked into later
+      // loads (incl. previously-added recent entries) that shouldn't use it.
+      const proxyEnabled = useProxy ?? useCorsProxy;
+      const proxyBase = proxyEnabled ? corsProxy.trim() : '';
       if (proxyBase) {
         (window as any).__dirplayerFlashConfig = {
           ...((window as any).__dirplayerFlashConfig || {}),
@@ -217,14 +222,14 @@ export default function LoadMovie() {
     } finally {
       setIsLoading(false);
     }
-  }, [autoPlay, dispatch, externalParams, fakeMoviePath, corsProxy]);
+  }, [autoPlay, dispatch, externalParams, fakeMoviePath, corsProxy, useCorsProxy]);
 
   const onLoadClick = useCallback(async () => {
     if (!movieUrl.trim()) { setHasError(true); return; }
-    const updated = saveRecentMovie(movieUrl, externalParams, fakeMoviePath);
+    const updated = saveRecentMovie(movieUrl, externalParams, fakeMoviePath, useCorsProxy);
     setRecentMovies(updated);
-    await loadMovieFile(movieUrl);
-  }, [movieUrl, externalParams, fakeMoviePath, loadMovieFile]);
+    await loadMovieFile(movieUrl, undefined, undefined, useCorsProxy);
+  }, [movieUrl, externalParams, fakeMoviePath, useCorsProxy, loadMovieFile]);
 
   // Loader mode: fetch a Shockwave loader page through the dev CORS proxy,
   // extract the Director embed (movie URL + sw* external params), enable proxy
@@ -254,8 +259,11 @@ export default function LoadMovie() {
       setMovieUrl(parsed.movieUrl);
       setExternalParams(parsed.params);
       if (parsed.params.length > 0) setParamsExpanded(true);
-      setRecentMovies(saveRecentMovie(parsed.movieUrl, parsed.params));
-      await loadMovieFile(parsed.movieUrl, parsed.params);
+      // Loader mode inherently requires the proxy (the game's own cross-origin
+      // fetches route through it), so force it on and persist that for the entry.
+      setUseCorsProxy(true);
+      setRecentMovies(saveRecentMovie(parsed.movieUrl, parsed.params, undefined, true));
+      await loadMovieFile(parsed.movieUrl, parsed.params, undefined, true);
     } catch (e) {
       console.error('[LoadMovie] Loader load failed', e);
       setHasError(true);
@@ -280,15 +288,19 @@ export default function LoadMovie() {
     setMovieUrl(movie.url);
     setExternalParams(movie.params);
     setFakeMoviePath(movie.fakeMoviePath ?? '');
-    const updated = saveRecentMovie(movie.url, movie.params, movie.fakeMoviePath);
+    // Honor the per-entry opt-in (default OFF for legacy entries with no flag).
+    const proxy = movie.useCorsProxy ?? false;
+    setUseCorsProxy(proxy);
+    const updated = saveRecentMovie(movie.url, movie.params, movie.fakeMoviePath, proxy);
     setRecentMovies(updated);
-    loadMovieFile(movie.url, movie.params, movie.fakeMoviePath);
+    loadMovieFile(movie.url, movie.params, movie.fakeMoviePath, proxy);
   }, [loadMovieFile]);
 
   const onEditRecent = useCallback((movie: RecentMovie) => {
     setMovieUrl(movie.url);
     setExternalParams(movie.params);
     setFakeMoviePath(movie.fakeMoviePath ?? '');
+    setUseCorsProxy(movie.useCorsProxy ?? false);
     if (movie.params.length > 0 || movie.fakeMoviePath) {
       setParamsExpanded(true);
     }
@@ -392,11 +404,23 @@ export default function LoadMovie() {
                     Fetch &amp; Load
                   </button>
                 </div>
+                <label
+                  style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 8, cursor: 'pointer' }}
+                  title="When off, this movie's cross-origin fetches go direct. Enable only for games that need the proxy (e.g. Neopets DGS). Saved per entry."
+                >
+                  <input
+                    type="checkbox"
+                    checked={useCorsProxy}
+                    onChange={e => setUseCorsProxy(e.currentTarget.checked)}
+                    disabled={isLoading}
+                  />
+                  Use CORS proxy for this movie
+                </label>
                 <div style={{ fontSize: '0.8em', color: '#888', marginTop: 4 }}>
-                  Fetches the loader page through the CORS proxy, extracts the
-                  Director embed + sw params, and loads it (the game's own
-                  cross-origin fetches then route through the proxy too). Start
-                  the proxy first: <code>node cors-proxy.cjs</code>.
+                  CORS proxy is <strong>opt-in per movie</strong> (default off) and
+                  saved with each recent entry. Enable it only for games whose
+                  cross-origin fetches need proxying. Fetch &amp; Load turns it on
+                  automatically. Start the proxy first: <code>node cors-proxy.cjs</code>.
                 </div>
               </div>
               <div className={styles.fieldContainer}>

--- a/src/views/LoadMovie/index.tsx
+++ b/src/views/LoadMovie/index.tsx
@@ -40,6 +40,73 @@ function paramsArrayToRecord(params: ExternalParam[]): Record<string, string> {
   return record;
 }
 
+const DEFAULT_CORS_PROXY = 'http://127.0.0.1:3099/cors?url=';
+
+function absolutize(src: string, base: string): string {
+  try { return new URL(src, base).toString(); } catch { return src; }
+}
+
+// Extract the Director movie URL + sw* external params from a Shockwave loader
+// page's HTML. Handles <embed type="application/x-director">, <object>/<param>,
+// and a raw fallback scan for JS-built embeds. Returns null if no Director
+// object is found.
+function parseShockwaveLoader(html: string, loaderUrl: string): { movieUrl: string; params: ExternalParam[] } | null {
+  const isDirector = (s: string | null) => !!s && /\.(dcr|dxr|dir)(\?|#|$)/i.test(s);
+  const params: ExternalParam[] = [];
+  let src = '';
+
+  try {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+
+    // 1) <embed type="application/x-director" src=... sw1=...>
+    const embed = Array.from(doc.querySelectorAll('embed')).find(e =>
+      (e.getAttribute('type') || '').toLowerCase().includes('director') ||
+      isDirector(e.getAttribute('src')));
+    if (embed) {
+      src = embed.getAttribute('src') || '';
+      for (const attr of Array.from(embed.attributes)) {
+        if (/^sw[0-9a-z]*$/i.test(attr.name) && attr.value) {
+          params.push({ key: attr.name.toLowerCase(), value: attr.value });
+        }
+      }
+    }
+
+    // 2) <object> with <param name="src"/"movie"/"sw1" ...>
+    if (!src) {
+      for (const obj of Array.from(doc.querySelectorAll('object'))) {
+        const pmap: Record<string, string> = {};
+        for (const p of Array.from(obj.querySelectorAll('param'))) {
+          const n = (p.getAttribute('name') || '').toLowerCase();
+          if (n) pmap[n] = p.getAttribute('value') || '';
+        }
+        const s = pmap['src'] || pmap['movie'] || obj.getAttribute('data') || '';
+        if (isDirector(s)) {
+          src = s;
+          for (const [n, v] of Object.entries(pmap)) {
+            if (/^sw[0-9a-z]*$/i.test(n) && v) params.push({ key: n, value: v });
+          }
+          break;
+        }
+      }
+    }
+  } catch { /* fall through to raw scan */ }
+
+  // 3) Raw fallback: scan for a .dcr url + sw1..sw9 string literals (JS-built).
+  if (!src) {
+    const m = html.match(/["']([^"']+\.(?:dcr|dxr|dir)(?:\?[^"']*)?)["']/i);
+    if (m) src = m[1];
+  }
+  if (params.length === 0) {
+    for (let i = 1; i <= 9; i++) {
+      const mm = html.match(new RegExp(`sw${i}\\s*[:=]\\s*["']([^"']*)["']`, 'i'));
+      if (mm) params.push({ key: `sw${i}`, value: mm[1] });
+    }
+  }
+
+  if (!src) return null;
+  return { movieUrl: absolutize(src, loaderUrl), params };
+}
+
 function loadRecentMovies(): RecentMovie[] {
   try {
     const raw = window.localStorage.getItem(RECENT_MOVIES_KEY);
@@ -79,6 +146,8 @@ export default function LoadMovie() {
   const [fakeMoviePath, setFakeMoviePath] = useState<string>('');
   const [recentMovies, setRecentMovies] = useState<RecentMovie[]>(() => loadRecentMovies());
   const [paramsExpanded, setParamsExpanded] = useState(() => getEnvExternalParams().length > 0);
+  const [loaderUrl, setLoaderUrl] = useState<string>('');
+  const [corsProxy, setCorsProxy] = useState<string>(DEFAULT_CORS_PROXY);
   const isInElectron = isElectron();
 
   const addParam = useCallback(() => {
@@ -98,6 +167,27 @@ export default function LoadMovie() {
     try {
       setIsLoading(true);
       setHasError(false);
+      // The CORS-proxy field is the control: if it holds a base URL, route this
+      // movie's CROSS-ORIGIN http(s) fetches through it (e.g. Neopets DGS's
+      // `preloadNetThing("http://swf.neopets.com/...")`); if it's empty, route
+      // direct. maybeCorsProxy() only rewrites cross-origin requests, so a
+      // same-origin local movie is unaffected either way. We re-apply it on
+      // EVERY load — setting when non-empty, and CLEARING when empty — because
+      // `__dirplayerFlashConfig.corsProxy` is a persistent window global; without
+      // the clear, a proxy set by a prior load (or loader mode) leaked into
+      // later loads that shouldn't use it. Clear the field to disable.
+      const proxyBase = corsProxy.trim();
+      if (proxyBase) {
+        (window as any).__dirplayerFlashConfig = {
+          ...((window as any).__dirplayerFlashConfig || {}),
+          corsProxy: proxyBase,
+        };
+      } else {
+        const cfg = (window as any).__dirplayerFlashConfig;
+        if (cfg && cfg.corsProxy) {
+          (window as any).__dirplayerFlashConfig = { ...cfg, corsProxy: null };
+        }
+      }
       dispatch(movieUnloaded());
       const moviePath = getBasePath(fullPath);
       set_base_path(moviePath);
@@ -127,7 +217,7 @@ export default function LoadMovie() {
     } finally {
       setIsLoading(false);
     }
-  }, [autoPlay, dispatch, externalParams, fakeMoviePath]);
+  }, [autoPlay, dispatch, externalParams, fakeMoviePath, corsProxy]);
 
   const onLoadClick = useCallback(async () => {
     if (!movieUrl.trim()) { setHasError(true); return; }
@@ -135,6 +225,44 @@ export default function LoadMovie() {
     setRecentMovies(updated);
     await loadMovieFile(movieUrl);
   }, [movieUrl, externalParams, fakeMoviePath, loadMovieFile]);
+
+  // Loader mode: fetch a Shockwave loader page through the dev CORS proxy,
+  // extract the Director embed (movie URL + sw* external params), enable proxy
+  // routing so the game's own cross-origin fetches also go through it, and load.
+  const onLoadLoader = useCallback(async () => {
+    const lu = loaderUrl.trim();
+    const proxyBase = corsProxy.trim();
+    if (!lu) { setHasError(true); return; }
+    if (!proxyBase) { console.error('[LoadMovie] loader mode needs a CORS proxy base'); setHasError(true); return; }
+    try {
+      setIsLoading(true);
+      setHasError(false);
+      // Turn on proxy routing for the fetch interceptor (loader page + game assets).
+      (window as any).__dirplayerFlashConfig = {
+        ...((window as any).__dirplayerFlashConfig || {}),
+        corsProxy: proxyBase,
+      };
+      const res = await fetch(proxyBase + encodeURIComponent(lu));
+      if (!res.ok) throw new Error(`loader fetch ${res.status}`);
+      const html = await res.text();
+      const parsed = parseShockwaveLoader(html, lu);
+      if (!parsed) {
+        console.error('[LoadMovie] No Director <embed>/<object> found in the loader page.');
+        setHasError(true);
+        return;
+      }
+      setMovieUrl(parsed.movieUrl);
+      setExternalParams(parsed.params);
+      if (parsed.params.length > 0) setParamsExpanded(true);
+      setRecentMovies(saveRecentMovie(parsed.movieUrl, parsed.params));
+      await loadMovieFile(parsed.movieUrl, parsed.params);
+    } catch (e) {
+      console.error('[LoadMovie] Loader load failed', e);
+      setHasError(true);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [loaderUrl, corsProxy, loadMovieFile]);
 
   const onBrowseClick = useCallback(async () => {
     if (!isInElectron) return;
@@ -232,6 +360,45 @@ export default function LoadMovie() {
           </button>
           {paramsExpanded && (
             <div className={styles.paramsList}>
+              <div className={styles.fieldContainer}>
+                <label className={styles.label} htmlFor="loaderUrl">
+                  Shockwave Loader URL (optional)
+                </label>
+                <input
+                  id="loaderUrl"
+                  type="text"
+                  className={styles.input}
+                  placeholder="https://www.neopets.com/games/dgs/play_shockwave.phtml?game_id=..."
+                  value={loaderUrl}
+                  onChange={e => setLoaderUrl(e.currentTarget.value)}
+                  disabled={isLoading}
+                />
+                <div style={{ display: 'flex', gap: 8, marginTop: 6 }}>
+                  <input
+                    type="text"
+                    className={styles.input}
+                    style={{ flex: 1 }}
+                    placeholder="CORS proxy base"
+                    value={corsProxy}
+                    onChange={e => setCorsProxy(e.currentTarget.value)}
+                    disabled={isLoading}
+                    title="Run: node cors-proxy.cjs"
+                  />
+                  <button
+                    className={styles.browseButton}
+                    onClick={onLoadLoader}
+                    disabled={isLoading}
+                  >
+                    Fetch &amp; Load
+                  </button>
+                </div>
+                <div style={{ fontSize: '0.8em', color: '#888', marginTop: 4 }}>
+                  Fetches the loader page through the CORS proxy, extracts the
+                  Director embed + sw params, and loads it (the game's own
+                  cross-origin fetches then route through the proxy too). Start
+                  the proxy first: <code>node cors-proxy.cjs</code>.
+                </div>
+              </div>
               <div className={styles.fieldContainer}>
                 <label className={styles.label} htmlFor="fakeMoviePath">
                   Fake Movie Path (optional)

--- a/src/views/MemberInspector/index.tsx
+++ b/src/views/MemberInspector/index.tsx
@@ -3,9 +3,9 @@ import { ICastMemberRef } from "dirplayer-js-api";
 import PreviewCanvas from "../../components/PreviewCanvas";
 import ScriptMemberPreview from "../../components/ScriptMemberPreview";
 import { useAppSelector, useMemberSnapshot } from "../../store/hooks";
-import { ICastMemberIdentifier, memberRefEqualsSafe } from "../../vm";
+import { ICastMemberIdentifier, ISoundMemberSnapshot, memberRefEqualsSafe } from "../../vm";
 import styles from "./styles.module.css";
-import { player_print_member_bitmap_hex } from 'vm-rust'
+import { player_print_member_bitmap_hex, player_play_member_sound, player_print_member_sound_hex } from 'vm-rust'
 import FilmLoopInspector from "../FilmLoopInspector";
 
 interface IMemberInspectorProps {
@@ -21,6 +21,46 @@ const normalizeLineEndings = (str: string, normalized = "\r\n") =>
 
 function TextMemberPreview({ text }: ITextMemberPreviewProps) {
   return <p className={styles.textPreview}>{normalizeLineEndings(text)}</p>;
+}
+
+function SoundMemberPreview({
+  memberId,
+  snapshot,
+}: {
+  memberId: ICastMemberIdentifier;
+  snapshot: ISoundMemberSnapshot;
+}) {
+  const durationSec = snapshot.duration ? (snapshot.duration / 1000).toFixed(2) : "?";
+  return (
+    <div>
+      <p>
+        {snapshot.sampleRate} Hz · {snapshot.channels} ch · {snapshot.bitsPerSample}-bit
+      </p>
+      <p>
+        Samples: {snapshot.sampleCount} · Duration: {durationSec}s · Loop:{" "}
+        {String(snapshot.loop)}
+      </p>
+      <p>
+        Codec: {snapshot.codec || "?"} · Data: {snapshot.dataSize} bytes
+      </p>
+      <div style={{ display: "flex", gap: 8, marginTop: 4 }}>
+        <button
+          onClick={() =>
+            player_play_member_sound(memberId.castNumber, memberId.memberNumber)
+          }
+        >
+          ▶ Play
+        </button>
+        <button
+          onClick={() =>
+            player_print_member_sound_hex(memberId.castNumber, memberId.memberNumber)
+          }
+        >
+          Print raw bytes
+        </button>
+      </div>
+    </div>
+  );
 }
 
 function FontPreview() {
@@ -90,6 +130,9 @@ export default function MemberInspector({ memberId }: IMemberInspectorProps) {
         )}
         {memberSnapshot?.type === "font" && (
           <FontPreview />
+        )}
+        {memberSnapshot?.type === "sound" && (
+          <SoundMemberPreview memberId={memberId} snapshot={memberSnapshot} />
         )}
         {memberSnapshot?.type === "flash" && (
           <div>

--- a/src/views/Stage/index.tsx
+++ b/src/views/Stage/index.tsx
@@ -761,7 +761,11 @@ export default function Stage({ showControls, enableGestures }: { showControls?:
         // every key — both here on bubble and from the input's handler.
         if (document.activeElement === hiddenInputRef.current) return;
         e.preventDefault();
-        if (e.repeat) return; // Skip browser key repeats; Lingo handles held keys via keyPressed()
+        // Pass browser key-repeats through: Director fires `on keyDown`
+        // repeatedly while a key is held (OS auto-repeat), and event-driven
+        // movies rely on that — e.g. Tetris soft-drops one row per repeated
+        // keyDown while the down arrow is held. Movies that instead poll
+        // `the keyPressed` in a loop are unaffected (they don't read keyDown).
         key_down(e.key, e.keyCode);
       }}
       onKeyUp={e => {

--- a/src/views/Stage/index.tsx
+++ b/src/views/Stage/index.tsx
@@ -39,6 +39,21 @@ import styles from "./styles.module.css";
 const MIN_SCALE = 0.1;
 const MAX_SCALE = 10;
 
+// setPointerCapture throws InvalidStateError while the Pointer Lock API owns the
+// pointer (FPS aim mode, e.g. Rasterwerks: the first click calls
+// requestPointerLock). Capture is also pointless once locked — pointer events
+// route to the locked element regardless. So skip it when locked, and keep the
+// call best-effort so a capture failure can never abort the rest of the handler
+// (the click that follows is what dispatches mouse_down → shooting to the VM).
+function safeSetPointerCapture(el: HTMLElement, pointerId: number) {
+  if (document.pointerLockElement) return;
+  try {
+    el.setPointerCapture(pointerId);
+  } catch {
+    /* non-essential: pointer capture is best-effort */
+  }
+}
+
 // Snap the CSS scale so that (cssScale × devicePixelRatio) is an integer,
 // guaranteeing one physical-pixel-wide columns/rows per canvas pixel.
 // At 125% Windows DPI (DPR=1.25), scale=1.0 would give 1.25 physical pixels
@@ -549,14 +564,14 @@ export default function Stage({ showControls, enableGestures }: { showControls?:
       e.preventDefault();
       const p = pointerOuterPos(e);
       middlePanRef.current = { startPointer: p, startPan: panRef.current };
-      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      safeSetPointerCapture(e.currentTarget as HTMLElement, e.pointerId);
       setIsMiddlePanning(true);
       return;
     }
 
     const p = pointerOuterPos(e);
     activePointersRef.current.set(e.pointerId, p);
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    safeSetPointerCapture(e.currentTarget as HTMLElement, e.pointerId);
 
     if (enableGestures && activePointersRef.current.size >= 2) {
       // Entering a multi-touch gesture. If a single-finger interaction was in

--- a/src/vm/callbacks.ts
+++ b/src/vm/callbacks.ts
@@ -181,11 +181,11 @@ export function initVmCallbacks() {
     onChannelDisplayNameChanged: (channelNumber: number, displayName: string) => {
       store.dispatch(channelDisplayNameChanged({ channelNumber, displayName }));
     },
-    onFlashMemberLoaded: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean) => {
+    onFlashMemberLoaded: (spriteNum: number, castLib: number, castMember: number, swfData: Uint8Array, width: number, height: number, pausedAtStart: boolean, assertedFrame: number) => {
       // Copy immediately - swfData is a view into WASM memory that may be invalidated
       const swfDataCopy = new Uint8Array(swfData);
-      console.log(`Flash member loaded: sprite#${spriteNum} ${castLib}:${castMember} ${width}x${height} (${swfDataCopy.length} bytes, first=[${Array.from(swfDataCopy.slice(0, 4)).join(',')}], pausedAtStart=${pausedAtStart})`);
-      createFlashInstance(spriteNum, castLib, castMember, swfDataCopy, width, height, pausedAtStart)
+      console.log(`Flash member loaded: sprite#${spriteNum} ${castLib}:${castMember} ${width}x${height} (${swfDataCopy.length} bytes, first=[${Array.from(swfDataCopy.slice(0, 4)).join(',')}], pausedAtStart=${pausedAtStart}, assertedFrame=${assertedFrame})`);
+      createFlashInstance(spriteNum, castLib, castMember, swfDataCopy, width, height, pausedAtStart, assertedFrame)
         .catch(e => console.error('Failed to create Flash instance:', e));
     },
     onFlashMemberUnloaded: (spriteNum: number) => {

--- a/src/vm/callbacks.ts
+++ b/src/vm/callbacks.ts
@@ -8,7 +8,7 @@ import {
   setXtraRegistry,
   getXtraRegistry,
 } from "dirplayer-js-api";
-import { createFlashInstance, destroyFlashInstance, initFlashBridge } from "../services/flashPlayerManager";
+import { createFlashInstance, destroyFlashInstance, destroyAllFlashInstances, initFlashBridge } from "../services/flashPlayerManager";
 import store from "../store";
 import { breakpointListChanged, castLibNameChanged, castListChanged, castMemberChanged, castMemberListChanged, channelChanged, channelDisplayNameChanged, datumSnapshot, debugContentAdded, debugMessageAdded, debugMessagesCleared, frameChanged, globalsChanged, movieLoaded, movieLoadFailed, onScriptError, removeTimeoutHandle, scopeListChanged, scoreChanged, scriptErrorCleared, scriptInstanceSnapshot, setTimeoutHandle } from "../store/vmSlice";
 import { OnMovieLoadedCallbackData, trigger_timeout, exportW3dObj, exportW3dRaw, listW3dMembers } from 'vm-rust'
@@ -190,6 +190,9 @@ export function initVmCallbacks() {
     },
     onFlashMemberUnloaded: (spriteNum: number) => {
       destroyFlashInstance(spriteNum);
+    },
+    onFlashResetAll: () => {
+      destroyAllFlashInstances();
     },
     onStageSizeChanged: (width: number, height: number, center: boolean) => {
       const inner = document.getElementById('stage_canvas_container');

--- a/src/vm/index.ts
+++ b/src/vm/index.ts
@@ -234,6 +234,18 @@ export interface IFontMemberSnapshot {
   type: 'font'
 }
 
+export interface ISoundMemberSnapshot {
+  type: 'sound'
+  sampleRate: number
+  channels: number
+  bitsPerSample: number
+  sampleCount: number
+  duration: number
+  loop: boolean
+  codec: string
+  dataSize: number
+}
+
 export interface IUnknownMemberSnapshot {
   type: 'unknown'
 }
@@ -289,4 +301,4 @@ export interface ScoreSnapshot {
   channelInitData?: IScoreChannelInitData[]
 }
 
-export type MemberSnapshot = IBaseMemberSnapshot & (IFieldMemberSnapshot | IScriptMemberSnapshot | IBitmapMemberSnapshot | IPaletteMemberSnapshot | IFontMemberSnapshot | IFlashMemberSnapshot | IShockwave3dMemberSnapshot | IUnknownMemberSnapshot | IFilmLoopMemberSnapshot)
+export type MemberSnapshot = IBaseMemberSnapshot & (IFieldMemberSnapshot | IScriptMemberSnapshot | IBitmapMemberSnapshot | IPaletteMemberSnapshot | IFontMemberSnapshot | ISoundMemberSnapshot | IFlashMemberSnapshot | IShockwave3dMemberSnapshot | IUnknownMemberSnapshot | IFilmLoopMemberSnapshot)

--- a/vm-rust/Cargo.lock
+++ b/vm-rust/Cargo.lock
@@ -583,6 +583,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools 0.11.0",
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,6 +2107,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "dotenvy",
+ "earcutr",
  "flate2",
  "futures",
  "fxhash",

--- a/vm-rust/Cargo.toml
+++ b/vm-rust/Cargo.toml
@@ -58,6 +58,10 @@ base64 = "0.22"
 toml = "0.8"
 dotenvy = "0.15"
 binary_rw = "4.1.0"
+# Polygon-with-holes triangulation (mapbox earcut port, pure Rust / WASM-safe).
+# Used for 3D-text (extrude3D) front/back cap tessellation so glyph holes
+# (O, A, 8, e ...) are filled correctly instead of the old triangle-fan.
+earcutr = "0.4"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.34"

--- a/vm-rust/lingo.pest
+++ b/vm-rust/lingo.pest
@@ -209,7 +209,17 @@ if_inline   =  { if_kw ~ expr ~ then_kw ~ command }
 pass_kw     = @{ ^"pass" ~ !(alpha | digit | "_") }
 pass_stmt   =  { pass_kw }
 
-command    = _{ if_inline | pass_stmt | set_statement | delete_statement | assignment | put_statement | go_inline | command_inline | expr }
+// Legacy `sound <verb> <args>` command form, e.g. `sound fadeIn 2, 60`,
+// `sound stop 3`, `sound playFile 1, "snd"`. Director treats the word after
+// `sound` as a verb keyword (not a variable); the evaluator turns it into the
+// #verb symbol so it dispatches through the same path as `sound(2).fadeIn(60)`.
+// `sound_kw` is atomic-with-word-boundary so `soundLevel` / `sound(2)` /
+// `sound = 5` don't tokenise as this command.
+sound_kw        = @{ ^"sound" ~ !(alpha | digit | "_") }
+sound_verb      =  { ident }
+sound_statement =  { sound_kw ~ sound_verb ~ command_inline_args? }
+
+command    = _{ if_inline | pass_stmt | set_statement | delete_statement | assignment | put_statement | go_inline | sound_statement | command_inline | expr }
 obj_prop   =  { "." }
 add        =  { "+" }
 subtract   =  { "-" }

--- a/vm-rust/src/director/chunks/cast_member.rs
+++ b/vm-rust/src/director/chunks/cast_member.rs
@@ -69,7 +69,18 @@ impl CastMemberChunk {
         let specific_data_parsed;
 
         if dir_version >= 500 {
-            member_type = MemberType::from(reader.read_u32().unwrap());
+            let raw_member_type = reader.read_u32().unwrap();
+            // Standard Director numbers a Linked Movie (`#movie`) as type 9, but
+            // this (reverse-engineered) MemberType enum uses 9 for Shape, so
+            // `from(9)` would mislabel a Linked Movie member (e.g. Neopets DGS
+            // `place_holder.dcr`) as Shape. Remap raw 9 to Movie explicitly.
+            // Raw 8 is left as-is (the downstream shape-info disambiguator turns
+            // real QuickDraw shapes at 8 into Shapes; real Flash Asset members
+            // are Ole = 15), and raw 2 stays FilmLoop — both verified correct.
+            member_type = match raw_member_type {
+                9 => MemberType::Movie,
+                other => MemberType::from(other),
+            };
             info_len = reader.read_u32().unwrap() as usize;
             specific_data_len = reader.read_u32().unwrap() as usize;
 

--- a/vm-rust/src/director/chunks/mod.rs
+++ b/vm-rust/src/director/chunks/mod.rs
@@ -75,6 +75,16 @@ pub enum Chunk {
     ScoreOrder(SordChunk),
     TileList(tile_list::TileListChunk),
     Text(TextChunk),
+    /// Plain text of a Rich Text Editor (RTE) cast member, stored in the
+    /// member's RTE1 child chunk. RTE0 (style runs) is kept as Raw; the text
+    /// (RTE1) and the pre-rendered bitmap (RTE2) are surfaced via these
+    /// variants so the MemberType::RTE branch in cast_member.rs can build the
+    /// member.
+    RteText(String),
+    /// Pre-rendered anti-aliased bitmap of an RTE member (RTE2 chunk): an
+    /// 8-byte header (width/height BE u16 + flags) followed by a custom
+    /// row-RLE of 4-bit coverage values. Decoded in cast_member.rs.
+    RteBitmap(Vec<u8>),
     Bitmap(BitmapChunk),
     Palette(PaletteChunk),
     Sound(SoundChunk),
@@ -94,6 +104,20 @@ impl Chunk {
     pub fn as_text(&self) -> Option<&TextChunk> {
         match self {
             Self::Text(data) => Some(data),
+            _ => None,
+        }
+    }
+
+    pub fn as_rte_text(&self) -> Option<&str> {
+        match self {
+            Self::RteText(data) => Some(data.as_str()),
+            _ => None,
+        }
+    }
+
+    pub fn as_rte_bitmap(&self) -> Option<&[u8]> {
+        match self {
+            Self::RteBitmap(data) => Some(data.as_slice()),
             _ => None,
         }
     }
@@ -266,6 +290,20 @@ pub fn make_chunk(
             return Ok(Chunk::SndSamples(view.clone()));
         }
         "STXT" => return Ok(Chunk::Text(TextChunk::read(&mut chunk_reader)?)),
+        "RTE1" => {
+            // Rich Text Editor text content — the raw text of an RTE member.
+            // Labels are typically ASCII; decode leniently and drop a trailing
+            // NUL terminator if present.
+            let mut text = String::from_utf8_lossy(view).into_owned();
+            if text.ends_with('\0') {
+                text.truncate(text.trim_end_matches('\0').len());
+            }
+            return Ok(Chunk::RteText(text));
+        }
+        "RTE2" => {
+            // RTE pre-rendered bitmap — keep raw; decoded in cast_member.rs.
+            return Ok(Chunk::RteBitmap(view.clone()));
+        }
         "BITD" => {
             return Ok(Chunk::Bitmap(BitmapChunk::read(
                 &mut chunk_reader,

--- a/vm-rust/src/director/chunks/pfr1/glyph.rs
+++ b/vm-rust/src/director/chunks/pfr1/glyph.rs
@@ -3028,7 +3028,7 @@ impl<'a> Pfr1DirectParser<'a> {
 
 /// Parse a bitmap glyph from GPS data
 pub fn parse_bitmap_glyph(data: &[u8], char_code: u32) -> Option<BitmapGlyph> {
-    if data.len() < 2 {
+    if data.is_empty() {
         return None;
     }
 
@@ -3067,25 +3067,48 @@ pub fn parse_bitmap_glyph(data: &[u8], char_code: u32) -> Option<BitmapGlyph> {
         }
     }
 
+    // PFR bitmap glyph header. Per-field widths follow the spec (and match the
+    // verified Fontinator/Director reference): position/size format 0 packs the
+    // two values into one byte's nibbles; format 1 is one byte each (signed for
+    // position); format 2/3 widen to 2/3 bytes.
+    let read_signed_nibbles = |data: &[u8], pos: &mut usize| -> (i32, i32) {
+        if *pos >= data.len() {
+            return (0, 0);
+        }
+        let b = data[*pos];
+        *pos += 1;
+        let mut a = ((b >> 4) & 0x0F) as i32;
+        let mut c = (b & 0x0F) as i32;
+        if a & 0x8 != 0 { a -= 16; }
+        if c & 0x8 != 0 { c -= 16; }
+        (a, c)
+    };
+
     let (x_pos, y_pos) = match position_format {
-        0 => (0i32, 0i32),
+        0 => read_signed_nibbles(data, &mut pos),
         1 => (read_i_n(data, &mut pos, 1), read_i_n(data, &mut pos, 1)),
         2 => (read_i_n(data, &mut pos, 2), read_i_n(data, &mut pos, 2)),
-        _ => (read_i_n(data, &mut pos, 4), read_i_n(data, &mut pos, 4)),
+        _ => (read_i_n(data, &mut pos, 3), read_i_n(data, &mut pos, 3)),
     };
 
     let (x_size, y_size) = match size_format {
-        0 => (read_u_n(data, &mut pos, 1), read_u_n(data, &mut pos, 1)),
-        1 => (read_u_n(data, &mut pos, 2), read_u_n(data, &mut pos, 2)),
-        2 => (read_u_n(data, &mut pos, 3), read_u_n(data, &mut pos, 3)),
-        _ => (read_u_n(data, &mut pos, 4), read_u_n(data, &mut pos, 4)),
+        0 => (0u32, 0u32),
+        1 => {
+            if pos >= data.len() { (0, 0) } else {
+                let b = data[pos];
+                pos += 1;
+                (((b >> 4) & 0x0F) as u32, (b & 0x0F) as u32)
+            }
+        }
+        2 => (read_u_n(data, &mut pos, 1), read_u_n(data, &mut pos, 1)),
+        _ => (read_u_n(data, &mut pos, 2), read_u_n(data, &mut pos, 2)),
     };
 
     let set_width = match escapement_format {
-        0 => x_size,
-        1 => read_u_n(data, &mut pos, 1),
-        2 => read_u_n(data, &mut pos, 2),
-        _ => read_u_n(data, &mut pos, 4),
+        0 => 0u32,
+        1 => read_i_n(data, &mut pos, 1).max(0) as u32,
+        2 => read_i_n(data, &mut pos, 2).max(0) as u32,
+        _ => read_i_n(data, &mut pos, 3).max(0) as u32,
     };
 
     let x_size = x_size.min(u16::MAX as u32) as u16;
@@ -3144,25 +3167,36 @@ pub fn parse_bitmap_glyph(data: &[u8], char_code: u32) -> Option<BitmapGlyph> {
 
 /// Decode 4-bit RLE bitmap
 fn decode_rle_bitmap(data: &[u8], width: u16, height: u16) -> Vec<u8> {
+    // PFR1 bitmap image_format 1: each NIBBLE (high then low per byte) is a run
+    // length, and runs ALTERNATE background (unset) / foreground (set), starting
+    // with background. e.g. the bold Volter `l` is `[0x0E]` → run 0 unset, run 14
+    // set → a solid 2×7 bar. The earlier decoder treated `byte>>4` as a count and
+    // `byte&0xF` as a color, reading `0x0E` as "0 cells of color 14" → an empty
+    // glyph (the `caLLed` bug). Output is contiguous packed bits (row-major),
+    // matching the rasterizer's `bit_index = row*width + col` read.
     let total_bits = width as usize * height as usize;
     let total_bytes = (total_bits + 7) / 8;
     let mut result = vec![0u8; total_bytes];
-    let mut out_pos = 0;
-    let mut pos = 0;
+    let mut out_pos = 0usize;
+    let mut set = false; // first run is background
 
-    while pos < data.len() && out_pos < total_bits {
-        let byte = data[pos];
-        pos += 1;
-
-        let count = (byte >> 4) as usize;
-        let value = byte & 0x0F;
-
-        for _ in 0..count {
-            if out_pos >= total_bits { break; }
-            if value != 0 {
-                result[out_pos / 8] |= 1 << (7 - (out_pos % 8));
+    'outer: for &byte in data {
+        for nib in [((byte >> 4) & 0x0F) as usize, (byte & 0x0F) as usize] {
+            if set {
+                for _ in 0..nib {
+                    if out_pos >= total_bits {
+                        break 'outer;
+                    }
+                    result[out_pos / 8] |= 1 << (7 - (out_pos % 8));
+                    out_pos += 1;
+                }
+            } else {
+                out_pos += nib;
+                if out_pos >= total_bits {
+                    break 'outer;
+                }
             }
-            out_pos += 1;
+            set = !set;
         }
     }
 

--- a/vm-rust/src/director/chunks/pfr1/mod.rs
+++ b/vm-rust/src/director/chunks/pfr1/mod.rs
@@ -197,7 +197,15 @@ pub fn parse_pfr1_font_with_target(data: &[u8], target_em_px: i32) -> Result<Pfr
             let glyph_data = &gps_data[start..start + size];
             let zeros_field = (glyph_data[0] >> 4) & 0x07;
 
-            if zeros_field != 0 && font.physical_font.has_bitmap_section {
+            // Inline bitmap detection is a heuristic that misfires on outline
+            // glyphs whose first byte happens to have these bits set. When the
+            // font has a real bitmap strike, its glyphs come from the BCT
+            // (parsed below), so skip the inline path entirely to avoid
+            // misparsing outlines as bitmaps.
+            if zeros_field != 0
+                && font.physical_font.has_bitmap_section
+                && !font.physical_font.has_bitmap_strike
+            {
                 // Bitmap glyph
                 if debug_this {
                     let ch = if char_code >= 32 && char_code < 127 { char_code as u8 as char } else { '?' };
@@ -402,6 +410,64 @@ pub fn parse_pfr1_font_with_target(data: &[u8], target_em_px: i32) -> Result<Pfr
                     let mut fallback = uc_glyph;
                     fallback.char_code = lc as u32;
                     font.glyphs.insert(lc, fallback);
+                }
+            }
+        }
+    }
+
+    // Parse the bitmap character table (BCT) if the physical font declares a
+    // strike. Director renders pixel fonts (Habbo Volter) from these embedded
+    // strikes — small, crisp, hand-tuned — rather than from the outlines (which
+    // are designed larger and render ~30% too big). The BCT sits immediately
+    // before the GPS section; entries are fixed-width
+    // `charCode + gpsSize + gpsOffset` (widths per the strike flags), and each
+    // entry's gpsOffset (relative to the GPS section) points at a bitmap glyph.
+    // The bitmap's advance comes from the matching outline char record's
+    // set-width (the strike stores no escapement), which the rasterizer already
+    // keeps when both an outline and a bitmap exist for a char.
+    let has_strike = font.physical_font.has_bitmap_strike;
+    let n_bmap = font.physical_font.n_bmap_chars as usize;
+    let bct_size = font.physical_font.bct_size as i64;
+    let bct_off = font.physical_font.bct_offset as i64;
+    let bct_two_byte_cc = font.physical_font.bct_two_byte_char_code;
+    let bct_two_byte_sz = font.physical_font.bct_two_byte_gps_size;
+    let bct_three_byte_off = font.physical_font.bct_three_byte_gps_offset;
+    if has_strike && n_bmap > 0 && bct_size > 0 {
+        let bct_base = gps_offset as i64 - bct_size + bct_off;
+        let char_bytes = if bct_two_byte_cc { 2 } else { 1 };
+        let size_bytes = if bct_two_byte_sz { 2 } else { 1 };
+        let off_bytes = if bct_three_byte_off { 3 } else { 2 };
+        let entry_bytes = char_bytes + size_bytes + off_bytes;
+        let n = n_bmap;
+        if bct_base >= 0 {
+            let mut p = bct_base as usize;
+            for _ in 0..n {
+                if p + entry_bytes > data.len() {
+                    break;
+                }
+                let mut cc = 0u32;
+                for _ in 0..char_bytes { cc = (cc << 8) | data[p] as u32; p += 1; }
+                let mut gsz = 0usize;
+                for _ in 0..size_bytes { gsz = (gsz << 8) | data[p] as usize; p += 1; }
+                let mut goff = 0usize;
+                for _ in 0..off_bytes { goff = (goff << 8) | data[p] as usize; p += 1; }
+                let gabs = gps_offset + goff;
+                // Drop degenerate bitmap strikes so they fall back to the vector
+                // outline (rendered crisp via the pixel-font threshold). In
+                // Volter-Bold (Volter_700) the widest glyphs — W (87), w (119),
+                // M (77), m (109) — decode to garbage / blocky strikes that don't
+                // match Director's rendering; Shockwave uses the outline for them.
+                // (Originally only W + m were dropped, so the lowercase 'w' in
+                // Origins' "Create Your Own Habbo" registration heading kept its
+                // garbage strike.) The other 700 strikes (and all regular 400
+                // strikes) are correct and kept, so the baseline anchor still
+                // reads good strike caps.
+                let drop_degenerate_strike = matches!(cc, 87 | 119 | 77 | 109)
+                    && font.font_name.to_ascii_lowercase().contains("700");
+                if !drop_degenerate_strike && cc <= 0xFF && gsz > 0 && gabs + gsz <= data.len() {
+                    if let Some(bmp) = glyph::parse_bitmap_glyph(&data[gabs..gabs + gsz], cc) {
+                        font.bitmap_glyphs.insert(cc as u8, bmp);
+                    }
                 }
             }
         }

--- a/vm-rust/src/director/chunks/pfr1/physical.rs
+++ b/vm-rust/src/director/chunks/pfr1/physical.rs
@@ -85,30 +85,30 @@ pub fn parse_physical_font(
                     let three_byte_bct_size = reader.read_bit();
                     let two_byte_yppm = reader.read_bit();
                     let two_byte_xppm = reader.read_bit();
-                    let n_bitmap_sizes = reader.read_bit() as usize;
+                    // nBitmapSizes is a full BYTE, not a single bit. Reading 1 bit gave 0
+                    // (MSB of the count byte) and silently dropped every strike, so pixel
+                    // fonts (Habbo Volter) fell back to oversized outline rendering.
+                    let n_bitmap_sizes = reader.read_bits(8) as usize;
 
                     for _ in 0..n_bitmap_sizes {
-                        // Use bit-stream reads (not byte-aligned)
-                        // ReadBitsN behavior. After nBitmapSizes (1 bit), we're
-                        // mid-byte; byte-aligned reads would discard remaining bits.
-                        let _xppm = if two_byte_xppm {
+                        let xppm = if two_byte_xppm {
                             reader.read_bits(16)
                         } else {
                             reader.read_bits(8)
                         };
 
-                        let _yppm = if two_byte_yppm {
+                        let yppm = if two_byte_yppm {
                             reader.read_bits(16)
                         } else {
                             reader.read_bits(8)
                         };
 
                         let _zeros2 = reader.read_bits(5);
-                        let _three_byte_gps_offset = reader.read_bit();
-                        let _two_byte_gps_size = reader.read_bit();
-                        let _two_byte_char_code = reader.read_bit();
+                        let three_byte_gps_offset = reader.read_bit();
+                        let two_byte_gps_size = reader.read_bit();
+                        let two_byte_char_code = reader.read_bit();
 
-                        let _bct_size = if three_byte_bct_size {
+                        let bct_size = if three_byte_bct_size {
                             reader.read_bits(24)
                         } else {
                             reader.read_bits(16)
@@ -120,13 +120,23 @@ pub fn parse_physical_font(
                             reader.read_bits(16)
                         };
 
-                        let _n_bmap_chars = if two_byte_n_bmap_chars {
+                        let n_bmap_chars = if two_byte_n_bmap_chars {
                             reader.read_bits(16)
                         } else {
                             reader.read_bits(8)
                         };
 
                         record.bitmap_size_table_offset = bct_offset;
+                        // Store the (single) strike spec so the GPS parser can load the BCT.
+                        record.has_bitmap_strike = true;
+                        record.bct_offset = bct_offset;
+                        record.bct_size = bct_size;
+                        record.n_bmap_chars = n_bmap_chars;
+                        record.bmap_xppm = xppm as u16;
+                        record.bmap_yppm = yppm as u16;
+                        record.bct_three_byte_gps_offset = three_byte_gps_offset;
+                        record.bct_two_byte_gps_size = two_byte_gps_size;
+                        record.bct_two_byte_char_code = two_byte_char_code;
                     }
 
                     record.has_bitmap_section = true;

--- a/vm-rust/src/director/chunks/pfr1/rasterizer.rs
+++ b/vm-rust/src/director/chunks/pfr1/rasterizer.rs
@@ -496,6 +496,19 @@ pub fn rasterize_pfr1_font_with_options(
 ) -> RasterizedFont {
     let phys = &parsed_font.physical_font;
 
+    // Bitmap strikes are hand-tuned pixel bitmaps for ONE native size — the
+    // strike pixels-per-em (`bmap_yppm`, e.g. Volter = 9px). They do NOT scale:
+    // using a 9px strike for an 18px request renders the glyph at ~half size
+    // (the Origins login fields rendered Volter at 7px caps instead of 14px).
+    // So use strikes only when the requested render height matches the strike
+    // ppm (±1 for rounding); otherwise render from the OUTLINE, which scales
+    // correctly. Verified against Shockwave + FontinatorFINAL: Volter 'H' at
+    // 18px is 14px caps (outline), the strike gives 7px. At the native 9px the
+    // strike and the outline agree (so 9px text is unchanged / still crisp).
+    // Strikeless fonts (bmap_yppm==0) always use outlines.
+    let use_strikes = phys.bmap_yppm > 0
+        && (target_height as i32 - phys.bmap_yppm as i32).abs() <= 1;
+
     let outline_res = phys.outline_resolution as f32;
     let target_em_px = parsed_font.target_em_px as f32;
     let coords_scaled = target_em_px > 0.0 && outline_res > 0.0;
@@ -752,14 +765,16 @@ pub fn rasterize_pfr1_font_with_options(
             char_widths[idx] = glyph_pixel_width as u16;
         }
 
-        // Skip rasterization if a bitmap glyph exists — bitmap glyphs are pixel-perfect
-        // pre-rendered by the font designer. The bitmap loop will handle rendering.
-        // UNLESS "outline" preference is set, in which case always rasterize from outlines.
+        // Skip rasterization if a bitmap glyph exists — bitmap glyphs are
+        // pixel-perfect pre-rendered by the font designer. The bitmap loop
+        // handles rendering. (Degenerate strikes are dropped at parse time so
+        // they fall through to this outline render.) UNLESS "outline"
+        // preference is set, in which case always rasterize from outlines.
         let prefer_outline = {
             use crate::player::font::{get_glyph_preference, GlyphPreference};
             get_glyph_preference() == GlyphPreference::Outline
         };
-        if !prefer_outline && parsed_font.bitmap_glyphs.contains_key(&char_code) {
+        if !prefer_outline && use_strikes && parsed_font.bitmap_glyphs.contains_key(&char_code) {
             continue;
         }
 
@@ -824,24 +839,26 @@ pub fn rasterize_pfr1_font_with_options(
 
         // Use Canvas2D (Skia-backed) for all font rendering.
         //
-        // For PIXEL fonts (PFR1 cast members that ship pre-rendered bitmap
-        // glyphs alongside outlines — fff_reaction, volter, prima_mono,
-        // v/vb, etc.): threshold the Canvas2D AA output to binary at 128.
-        // The bitmap glyphs are designed for integer-coordinate cells, and
-        // any sub-pixel AA would blur their crisp pixel edges. The earlier
-        // gate `coords_scaled` was too coarse — with our parse-at-
-        // outline_resolution change it became `true` for *all* outline
-        // fonts too, which then killed thin italic stems (lowercase l, i,
-        // uppercase I in fugue_arial_italic) whose AA coverage falls
-        // below 128 at small render sizes. Fontinator's SkiaSharp path
-        // does NOT threshold and renders these correctly at 12px.
+        // For PIXEL fonts (rectilinear bitmap-style designs — fff_reaction,
+        // volter, prima_mono, v/vb, etc.): threshold the Canvas2D AA output
+        // to binary at 128. These glyphs are designed for integer-coordinate
+        // cells, and any sub-pixel AA blurs their crisp pixel edges (Habbo
+        // Origins' Volter login text rendered as a grey halo otherwise).
         //
-        // For OUTLINE fonts (Arial / Verdana / fugue_arial etc.): keep
-        // the Canvas2D AA coverage as-is. Matches Skia's analytic AA and
-        // Font Xtra's 4-bit-per-pixel coverage + SRCPAINT composite.
-        let is_pixel_font = phys.has_bitmap_section
-            && !parsed_font.bitmap_glyphs.is_empty();
-        let alpha_mask = if coords_scaled && is_pixel_font {
+        // Classify by GEOMETRY (`parsed_font.is_pixel_font`: ~0% béziers,
+        // ~100% axis-aligned edges) rather than by the presence of bitmap
+        // strikes. Volter declares a bitmap section but ships ZERO parsed
+        // bitmap glyphs (`has_bitmap_section=true`, `bitmap_glyphs` empty),
+        // so the old `has_bitmap_section && !bitmap_glyphs.is_empty()` test
+        // was false and it fell to the AA path. The earlier `coords_scaled`
+        // gate is also dropped: it became `true` for all outline fonts after
+        // the parse-at-outline_resolution change AND is `false` on the
+        // cast-load (native-size) rasterization, so it gated inconsistently.
+        // Smooth fonts (Arial / Verdana / fugue_arial, incl. thin italic
+        // stems) are curve-heavy → `is_pixel_font=false` → keep AA coverage.
+        let is_pixel_font = parsed_font.is_pixel_font
+            || (phys.has_bitmap_section && !parsed_font.bitmap_glyphs.is_empty());
+        let alpha_mask = if is_pixel_font {
             // Canvas2D with even-odd fill → binary threshold (pixel-font path)
             let canvas_result = {
                 #[cfg(target_arch = "wasm32")]
@@ -960,7 +977,7 @@ pub fn rasterize_pfr1_font_with_options(
         get_glyph_preference() == GlyphPreference::Outline
     };
     for (&char_code, bmp_glyph) in &parsed_font.bitmap_glyphs {
-        if skip_bitmap_glyphs { continue; }
+        if skip_bitmap_glyphs || !use_strikes { continue; }
         let has_outline = parsed_font.glyphs.contains_key(&char_code);
         if has_outline {
             bitmap_overlap_outline += 1;
@@ -1022,9 +1039,11 @@ pub fn rasterize_pfr1_font_with_options(
             char_widths[idx] = bmp_adv;
         }
 
-        // Copy bitmap data to RGBA grid
-        // Convert PFR Y-up y_pos to bitmap Y-down using baseline
-        let py_base = baseline_row_px as i32 - bmp_glyph.y_pos as i32;
+        // Copy bitmap data to RGBA grid.
+        // PFR bitmap y_pos is the Y-up offset of the glyph's BOTTOM from the
+        // baseline; the top row is therefore baseline - y_pos - y_size (matches
+        // the verified Fontinator/Director reference render).
+        let py_base = baseline_row_px as i32 - bmp_glyph.y_pos as i32 - bmp_glyph.y_size as i32;
         let px_base = bmp_glyph.x_pos as i32;
         let glyph_bits_per_row = bmp_glyph.x_size as usize;
         for gy in 0..bmp_glyph.y_size as usize {
@@ -1032,8 +1051,11 @@ pub fn rasterize_pfr1_font_with_options(
             if py_signed < 0 || py_signed as usize >= bitmap_height { continue; }
             let py = py_signed as usize;
             if py >= cell_y + cell_height { continue; }
+            // PFR bitmap rows are stored bottom-to-top (Y-up), so the top
+            // destination row (gy=0) reads the LAST bit-stream row.
+            let src_row = bmp_glyph.y_size as usize - 1 - gy;
             for gx in 0..bmp_glyph.x_size as usize {
-                let bit_index = gy * glyph_bits_per_row + gx;
+                let bit_index = src_row * glyph_bits_per_row + gx;
                 let byte_idx = bit_index / 8;
                 let bit_idx = 7 - (bit_index % 8);
                 if byte_idx < bmp_glyph.image_data.len() {

--- a/vm-rust/src/director/chunks/pfr1/types.rs
+++ b/vm-rust/src/director/chunks/pfr1/types.rs
@@ -236,6 +236,16 @@ pub struct PhysicalFontRecord {
     pub extra_type5_line_spacing: i16,
     pub extra_type5_word39: i16,
     pub two_byte_char_code: bool,
+    // Bitmap strike (extra item type 1, nBitmapSizes>0). Single strike supported.
+    pub has_bitmap_strike: bool,
+    pub bct_offset: u32,
+    pub bct_size: u32,
+    pub n_bmap_chars: u32,
+    pub bmap_xppm: u16,
+    pub bmap_yppm: u16,
+    pub bct_three_byte_gps_offset: bool,
+    pub bct_two_byte_gps_size: bool,
+    pub bct_two_byte_char_code: bool,
 }
 
 impl PhysicalFontRecord {
@@ -282,6 +292,15 @@ impl PhysicalFontRecord {
             extra_type5_line_spacing: 0,
             extra_type5_word39: 0,
             two_byte_char_code: false,
+            has_bitmap_strike: false,
+            bct_offset: 0,
+            bct_size: 0,
+            n_bmap_chars: 0,
+            bmap_xppm: 0,
+            bmap_yppm: 0,
+            bct_three_byte_gps_offset: false,
+            bct_two_byte_gps_size: false,
+            bct_two_byte_char_code: false,
         }
     }
 }

--- a/vm-rust/src/director/chunks/score.rs
+++ b/vm-rust/src/director/chunks/score.rs
@@ -583,7 +583,7 @@ impl ScoreFrameData {
         while !reader.eof() {
             match reader.read_u16() {
                 Ok(length) => {
-                    if length == 0 { break; }
+                    if length < 2 { break; } // 0 = terminator, 1 = trailing pad
                     let skip = (length as usize).saturating_sub(2);
                     if reader.pos + skip > reader.length { break; }
                     reader.jmp(reader.pos + skip);
@@ -622,7 +622,15 @@ impl ScoreFrameData {
                 .read_u16()
                 .map_err(|e| format!("Failed to read frame length: {:?}", e))?;
 
-            if length == 0 {
+            // A frame block's `length` includes its own 2-byte length field, so
+            // the minimum valid value is 2 (an empty frame). 0 is the normal
+            // terminator; 1 (or any value < 2) is trailing padding at the end of
+            // the entry — NOT a real frame. Treat it as the terminator. Without
+            // this, `length - 2` underflows the u16 to 65535 and the subsequent
+            // read_bytes(65535) aborts the whole score parse — which silently
+            // emptied many filmloop SCVWs (SpongeBob "JellyFishin'" jelly/health
+            // filmloops, whose entry0 ends with a 2-byte 0x0001 pad).
+            if length < 2 {
                 break;
             }
 
@@ -1802,7 +1810,7 @@ impl ScoreChunk {
     /// Analyze score entries beyond Entry[0] for behavior attachment data
     fn analyze_behavior_attachment_entries(
         entries: &Vec<Vec<u8>>,
-        dir_version: u16,
+        _dir_version: u16,
     ) -> Result<Vec<(FrameIntervalPrimary, Option<FrameIntervalSecondary>)>, String> {
         let mut results = vec![];
         let mut i = 2; // Start at 2, skip entries 0 and 1
@@ -1835,35 +1843,31 @@ impl ScoreChunk {
                 continue;
             }
 
-            // Primary entries: 40 bytes base (5 x u32 fields + 20-byte
-            // TweenInfo) plus zero or more trailing u32s of authored
-            // keyframe indices. v8.0 movies only ever produce 40/44/48
-            // byte primaries (0-2 trailing keyframes); v8.5+ extends to
-            // 52 (3 trailing keyframes) and beyond — Fugue No.4 / i04.dir
-            // has primary entries of 72, 116, 188, 232, 336+ bytes for
-            // sprites with many authored keyframes along an animated
-            // path. Accepting 52+ unconditionally previously
-            // over-matched non-primary chunks in Junkbot (v8.0), so we
-            // still gate the wider sizes by movie version AND validate
-            // the first 8 bytes look like (start_frame, end_frame) of
-            // a real primary (small, ascending) to avoid false matches.
-            let accept_extended = dir_version >= 850;
-            let size_accepted_basic = matches!(entry_bytes.len(), 40 | 44 | 48)
-                || (accept_extended && entry_bytes.len() == 52);
-            // Allow any 4-byte-aligned entry >= 40 bytes on D8.5+ if the
-            // header looks plausible — that's the path-keyframe-bearing
-            // case that was getting rejected.
-            let size_accepted_extended = accept_extended
-                && entry_bytes.len() > 52
-                && entry_bytes.len() % 4 == 0
-                && entry_bytes.len() >= 8
-                && {
+            // Primary span entries: a 40-byte base (5 x u32 fields + 20-byte
+            // TweenInfo) plus zero or more trailing u32s of authored keyframe
+            // indices, so any size 40 + 4*N (40, 44, 48, 52, 56, ...) is
+            // structurally valid for a tweened sprite.
+            //
+            // 40/44/48 are accepted unconditionally. For 52+ we DON'T gate on
+            // movie version — a previous `dir_version >= 850` gate dropped real
+            // 52/56-byte spans in D6/D7 movies (SpongeBob "JellyFishin'" v600:
+            // the bikini backdrop ch10 36-39 span is 56 bytes; nomiss v700 has
+            // them too), which made whole sprites vanish. The version gate was
+            // also unnecessary for its original purpose: Junkbot (v800), the
+            // movie it was protecting, has NO 52+ entries at all. Instead we
+            // validate the header looks like a real primary — plausible
+            // ascending (start_frame, end_frame) and an in-range channel_index
+            // — which reliably rejects the behavior/initializer chunks (their
+            // first u32s are cast ids or ASCII, far outside these ranges).
+            let n = entry_bytes.len();
+            let size_accepted = matches!(n, 40 | 44 | 48)
+                || (n >= 52 && n % 4 == 0 && {
                     let b = entry_bytes;
                     let sf = u32::from_be_bytes([b[0], b[1], b[2], b[3]]);
                     let ef = u32::from_be_bytes([b[4], b[5], b[6], b[7]]);
-                    sf >= 1 && sf <= 10000 && ef >= sf && ef <= 100000
-                };
-            let size_accepted = size_accepted_basic || size_accepted_extended;
+                    let ch = u32::from_be_bytes([b[16], b[17], b[18], b[19]]);
+                    sf >= 1 && sf <= 10000 && ef >= sf && ef <= 100000 && ch < 512
+                });
             match entry_bytes.len() {
                 _ if size_accepted => {
                     // Primary entry
@@ -1918,10 +1922,8 @@ impl ScoreChunk {
                             // cast_lib/cast_member.  If the first u32 looks like a valid
                             // start_frame (1–10000) and the second u32 >= first, treat it as a
                             // primary rather than a behavior list.
-                            let primary_size_match = next_size == 40
-                                || next_size == 44
-                                || next_size == 48
-                                || (accept_extended && next_size == 52);
+                            let primary_size_match = matches!(next_size, 40 | 44 | 48)
+                                || (next_size >= 52 && next_size % 4 == 0);
                             let looks_like_primary = if primary_size_match && next_size >= 8 {
                                 let b = &entries[j];
                                 let first_u32 = u32::from_be_bytes([b[0], b[1], b[2], b[3]]);

--- a/vm-rust/src/director/chunks/score.rs
+++ b/vm-rust/src/director/chunks/score.rs
@@ -602,50 +602,51 @@ impl ScoreFrameData {
             header.frame_count = actual_frame_count;
         }
 
-        debug!(
-            "ScoreFrameData {} {} {}",
-            header.frame_count, header.num_channels, header.sprite_record_size
-        );
-
-        let mut channel_data = vec![
-            0u8;
-            (header.frame_count as usize)
-                * (header.num_channels as usize)
-                * (header.sprite_record_size as usize)
-        ];
-
         let frame_size = (header.num_channels as usize) * (header.sprite_record_size as usize);
+
+        // The score frame layout is selected by the MOVIE version, not by
+        // frames_version — D4 and D5 both have frames_version<=7 but use
+        // incompatible layouts (ScummVM dispatches on movie version in frame.cpp):
+        //   D4 (400-499): 40-byte main channels + 20-byte sprite records
+        //   D5 (500-599): 48-byte main channels + 24-byte sprite records
+        //   D6+ (600+):   no packed main channels; all channels uniform.
+        let is_d4 = dir_version >= 400 && dir_version < 500;
+        let is_d5 = dir_version >= 500 && dir_version < 600;
+        // Fall back on frames_version when dir_version is unset (pre-D6 movies
+        // always have frames_version<=7); treat as D5, the historical default.
+        let is_d5 = is_d5 || (!is_d4 && dir_version < 400 && header.frames_version <= 7);
+        let main_channels_size: usize = if is_d4 { 40 } else if is_d5 { 48 } else { 0 };
+
+        // Expand + parse the delta-encoded frame stream ONE frame at a time using a
+        // single rolling buffer (num_channels × sprite_record_size, ~48 KB) that
+        // carries forward between frames. The previous code materialised a dense
+        // frame_count × frame_size grid AND retained it in `decompressed_data`
+        // (a field that is never read): a max-channel movie like Infestation
+        // (frame_count 2075 × num_channels 1006 × 48) allocated ~100 MB per score
+        // chunk, permanently inflating the un-shrinkable WASM heap. Carry-forward is
+        // now implicit — `frame_buf` keeps the previous frame's bytes and each delta
+        // overwrites only what changed; the frame is parsed immediately, then reused.
+        let mut frame_buf = vec![0u8; frame_size];
+        let mut frame_channel_data: Vec<(u32, u16, ScoreFrameChannelData)> = vec![];
+        let mut sound_channel_data: Vec<(u32, u16, SoundChannelData)> = vec![];
+        let mut tempo_channel_data: Vec<(u32, TempoChannelData)> = vec![];
+        let mut palette_channel_data: Vec<(u32, i16, i16)> = vec![];
 
         let mut frame_index: u32 = 0;
         while !reader.eof() && frame_index < header.frame_count {
             let length = reader
                 .read_u16()
                 .map_err(|e| format!("Failed to read frame length: {:?}", e))?;
-
-            // A frame block's `length` includes its own 2-byte length field, so
-            // the minimum valid value is 2 (an empty frame). 0 is the normal
-            // terminator; 1 (or any value < 2) is trailing padding at the end of
-            // the entry — NOT a real frame. Treat it as the terminator. Without
-            // this, `length - 2` underflows the u16 to 65535 and the subsequent
-            // read_bytes(65535) aborts the whole score parse — which silently
-            // emptied many filmloop SCVWs (SpongeBob "JellyFishin'" jelly/health
-            // filmloops, whose entry0 ends with a 2-byte 0x0001 pad).
+            // `length` includes its own 2-byte field, so <2 is the terminator /
+            // trailing pad (0x0001), NOT a real frame — and avoids a length-2
+            // u16 underflow that used to abort the whole score parse.
             if length < 2 {
                 break;
             }
 
-            // Copy entire previous frame first (carry-forward).
-            // Deltas will overwrite only the bytes that changed.
-            // This is correct for both D5 (48-byte main channels) and D6+ (uniform channels).
-            if frame_index > 0 {
-                let prev_frame_offset = ((frame_index - 1) as usize) * frame_size;
-                let curr_frame_offset = (frame_index as usize) * frame_size;
-                channel_data.copy_within(
-                    prev_frame_offset..prev_frame_offset + frame_size,
-                    curr_frame_offset,
-                );
-            }
-
+            // Apply this frame's deltas on top of the carried-forward buffer.
+            // Delta stream: (channel_size: u16, channel_offset: u16, data[channel_size]);
+            // channel_offset is a byte offset within the frame.
             let frame_length = length - 2;
             if frame_length > 0 {
                 let chunk_data = reader
@@ -653,10 +654,6 @@ impl ScoreFrameData {
                     .map_err(|e| format!("Failed to read chunk data: {:?}", e))?;
                 let mut frame_chunk_reader = BinaryReader::from_u8(chunk_data);
                 frame_chunk_reader.set_endian(Endian::Big);
-
-                // Apply deltas on top of carried-forward data.
-                // Delta stream: (channel_size: u16, channel_offset: u16, data: [u8; channel_size])
-                // channel_offset is a raw byte offset within the frame buffer.
                 while !frame_chunk_reader.eof() {
                     let channel_size = frame_chunk_reader
                         .read_u16()
@@ -669,48 +666,22 @@ impl ScoreFrameData {
                     let channel_delta = frame_chunk_reader
                         .read_bytes(channel_size)
                         .map_err(|e| format!("Failed to read channel delta: {:?}", e))?;
-
-                    let frame_offset = (frame_index as usize) * frame_size;
-                    let end_offset = frame_offset + channel_offset + channel_size;
-                    if end_offset > channel_data.len() {
-                        error!("Channel data copy out of bounds. Frame offset: {}, Channel offset: {}, Channel size: {}, Total len: {}",
-                            frame_offset, channel_offset, channel_size, channel_data.len());
+                    let end_offset = channel_offset + channel_size;
+                    if end_offset > frame_buf.len() {
+                        error!("Channel data copy out of bounds. Channel offset: {}, Channel size: {}, Frame len: {}",
+                            channel_offset, channel_size, frame_buf.len());
                         return Err("Channel data copy out of bounds".to_string());
                     }
-                    channel_data[frame_offset + channel_offset..end_offset]
-                        .copy_from_slice(&channel_delta);
+                    frame_buf[channel_offset..end_offset].copy_from_slice(&channel_delta);
                 }
             }
-            frame_index = frame_index + 1;
-        }
 
-        // The score frame layout is selected by the MOVIE version, not by
-        // frames_version — Director 4 and Director 5 BOTH have frames_version<=7
-        // but use incompatible sprite/main-channel layouts (ScummVM dispatches
-        // on movie version in frame.cpp). D4 and D5 differ in both the main
-        // channel block size and the per-sprite field order:
-        //   D4 (400-499): 40-byte main channels + 20-byte D4 sprite records
-        //   D5 (500-599): 48-byte main channels + 24-byte D5 sprite records
-        //   D6+ (600+):   no packed main channels; all channels uniform.
-        let is_d4 = dir_version >= 400 && dir_version < 500;
-        let is_d5 = dir_version >= 500 && dir_version < 600;
-        // Fall back on frames_version for the (rare) case where dir_version is
-        // unset: pre-D6 movies always have frames_version<=7. Treat such a
-        // movie as D5 (the historical default) rather than misreading it as D6+.
-        let is_d5 = is_d5 || (!is_d4 && dir_version < 400 && header.frames_version <= 7);
-        let main_channels_size: usize = if is_d4 { 40 } else if is_d5 { 48 } else { 0 };
-
-        let (decompressed_data, frame_channel_data, sound_channel_data, tempo_channel_data, palette_channel_data) = {
-            let mut frame_channel_data = vec![];
-            let mut sound_channel_data = vec![];
-            let mut tempo_channel_data = vec![];
-            let mut palette_channel_data: Vec<(u32, i16, i16)> = vec![];
-            let decompressed_data = channel_data;
-            let mut channel_reader = BinaryReader::from_vec(&decompressed_data);
-            channel_reader.set_endian(Endian::Big);
-
-            for frame_index in 0..header.frame_count {
-                let frame_start = (frame_index as usize) * frame_size;
+            // Parse the just-expanded frame directly out of the rolling buffer
+            // (frame_start is 0 — the buffer holds exactly this one frame).
+            {
+                let frame_start = 0usize;
+                let mut channel_reader = BinaryReader::from_u8(frame_buf.as_slice());
+                channel_reader.set_endian(Endian::Big);
 
                 if is_d4 {
                     // D4: Main channels packed in first 40 bytes.
@@ -1006,18 +977,17 @@ impl ScoreFrameData {
                     }
                 }
             }
+            frame_index += 1;
+        }
 
-            log::debug!(
-                "🏁 Finished processing {} frames. Sprites: {}, Sounds: {}, Tempo changes: {}, Palette changes: {}",
-                header.frame_count, frame_channel_data.len(), sound_channel_data.len(), tempo_channel_data.len(), palette_channel_data.len()
-            );
-
-            (decompressed_data, frame_channel_data, sound_channel_data, tempo_channel_data, palette_channel_data)
-        };
+        log::debug!(
+            "🏁 Finished processing {} frames. Sprites: {}, Sounds: {}, Tempo changes: {}, Palette changes: {}",
+            header.frame_count, frame_channel_data.len(), sound_channel_data.len(), tempo_channel_data.len(), palette_channel_data.len()
+        );
 
         Ok(ScoreFrameData {
             header,
-            decompressed_data,
+            decompressed_data: Vec::new(),
             frame_channel_data,
             sound_channel_data,
             tempo_channel_data,
@@ -2059,9 +2029,12 @@ impl ScoreChunk {
                     }
                 }
                 _ => {
-                    // Skip other entry types
+                    // Skip other entry types. debug!, not warn! — this fires per
+                    // skipped entry during score parse and floods the browser
+                    // console (which retains every entry); skipping is expected
+                    // and non-fatal.
                     if entry_bytes.len() > 0 {
-                        warn!(
+                        debug!(
                             "⚠️ Skipping entry {} with unexpected size {} bytes (expected 40/44/48 for primary). First bytes: {}",
                             i,
                             entry_bytes.len(),

--- a/vm-rust/src/director/chunks/w3d/clod_decoder.rs
+++ b/vm-rust/src/director/chunks/w3d/clod_decoder.rs
@@ -9,6 +9,63 @@ use super::bitstream::IFXBitStreamCompressed;
 use super::clod_types::*;
 use super::types::*;
 
+/// Recompute per-vertex normals geometrically: area-weighted average of the
+/// normals of all faces using each vertex, then normalize.
+///
+/// The CLOD stream's coded normals decode with a WRONG prediction basis (the
+/// U3D spec predicts from the average of adjacent GEOMETRIC face normals split
+/// by the crease parameter, but this port — like the C# W3DParser reference —
+/// seeds the prediction from a previously-decoded normal). The result has the
+/// correct polar angle (Z) but a garbage azimuth (X/Y). Director recomputes
+/// normals from geometry instead, which is what this does. For non-indexed flat
+/// meshes (each vertex in exactly one face) this yields the flat face normal;
+/// shared-vertex meshes get smoothed — matching the file's flat/smooth intent,
+/// which is encoded by whether vertices are shared. Mirrors the C# reference's
+/// `RecalculateSmoothNormals`. See memory w3d-clod-normal-decode-geometric-prediction.
+pub(crate) fn recompute_smooth_normals(
+    positions: &[[f32; 3]],
+    faces: &[[u32; 3]],
+) -> Vec<[f32; 3]> {
+    let mut accum = vec![[0.0f32; 3]; positions.len()];
+    for f in faces {
+        let (i0, i1, i2) = (f[0] as usize, f[1] as usize, f[2] as usize);
+        if i0 >= positions.len() || i1 >= positions.len() || i2 >= positions.len() {
+            continue;
+        }
+        if i0 == i1 || i1 == i2 || i0 == i2 {
+            continue;
+        }
+        let p0 = positions[i0];
+        let p1 = positions[i1];
+        let p2 = positions[i2];
+        let e1 = [p1[0] - p0[0], p1[1] - p0[1], p1[2] - p0[2]];
+        let e2 = [p2[0] - p0[0], p2[1] - p0[1], p2[2] - p0[2]];
+        // Cross product magnitude == 2 * triangle area => area-weighted.
+        let nx = e1[1] * e2[2] - e1[2] * e2[1];
+        let ny = e1[2] * e2[0] - e1[0] * e2[2];
+        let nz = e1[0] * e2[1] - e1[1] * e2[0];
+        if nx * nx + ny * ny + nz * nz < 1e-12 {
+            continue;
+        }
+        for &vi in &[i0, i1, i2] {
+            accum[vi][0] += nx;
+            accum[vi][1] += ny;
+            accum[vi][2] += nz;
+        }
+    }
+    accum
+        .into_iter()
+        .map(|[x, y, z]| {
+            let len = (x * x + y * y + z * z).sqrt();
+            if len > 1e-8 {
+                [x / len, y / len, z / len]
+            } else {
+                [0.0, 1.0, 0.0]
+            }
+        })
+        .collect()
+}
+
 #[derive(Clone, Debug)]
 pub struct ClodMeshDecoder {
     meshes: Vec<MeshState>,
@@ -646,10 +703,11 @@ impl ClodMeshDecoder {
             .iter()
             .enumerate()
             .map(|(i, mesh)| {
+                let normals = recompute_smooth_normals(&mesh.positions, &mesh.faces);
                 ClodDecodedMesh {
                     name: format!("mesh_{}", i),
                     positions: mesh.positions.clone(),
-                    normals: mesh.normals.clone(),
+                    normals,
                     tex_coords: mesh.tex_coords.clone(),
                     faces: mesh.faces.clone(),
                     diffuse_colors: Vec::new(),
@@ -672,7 +730,7 @@ impl ClodMeshDecoder {
                     return ClodDecodedMesh {
                         name: format!("mesh_{}", i),
                         positions: mesh.positions.clone(),
-                        normals: mesh.normals.clone(),
+                        normals: recompute_smooth_normals(&mesh.positions, &mesh.faces),
                         tex_coords: mesh.tex_coords.clone(),
                         faces: mesh.faces.clone(),
                         diffuse_colors: Vec::new(),
@@ -729,10 +787,12 @@ impl ClodMeshDecoder {
                     layer[..vert_count.min(layer.len())].to_vec()
                 }).collect();
 
+                let positions = mesh.positions[..vert_count].to_vec();
+                let normals = recompute_smooth_normals(&positions, &faces);
                 ClodDecodedMesh {
                     name: format!("mesh_{}", i),
-                    positions: mesh.positions[..vert_count].to_vec(),
-                    normals: mesh.normals[..vert_count.min(mesh.normals.len())].to_vec(),
+                    positions,
+                    normals,
                     tex_coords: tc,
                     faces,
                     diffuse_colors: Vec::new(),
@@ -760,10 +820,11 @@ impl ClodMeshDecoder {
                     }
                 }
 
+                let normals = recompute_smooth_normals(&mesh.positions, &faces);
                 ClodDecodedMesh {
                     name: format!("mesh_{}", i),
                     positions: mesh.positions.clone(),
-                    normals: mesh.normals.clone(),
+                    normals,
                     tex_coords: mesh.tex_coords.clone(),
                     faces,
                     diffuse_colors: Vec::new(),

--- a/vm-rust/src/director/chunks/w3d/mod.rs
+++ b/vm-rust/src/director/chunks/w3d/mod.rs
@@ -16,6 +16,7 @@ pub mod raycast;
 pub mod skeleton;
 pub mod gltf_export;
 pub mod subdivision;
+pub mod text3d;
 
 pub use types::W3dScene;
 

--- a/vm-rust/src/director/chunks/w3d/primitives.rs
+++ b/vm-rust/src/director/chunks/w3d/primitives.rs
@@ -716,9 +716,23 @@ pub fn extrude_text_to_mesh(
     outline_resolution: u16,
     font_size: f32,
     tunnel_depth: f32,
+    bevel_type: u32,
+    bevel_depth: f32,
+    smoothness: u32,
+    display_face: i32,
 ) -> super::types::ClodDecodedMesh {
     let scale = font_size / outline_resolution.max(1) as f32;
     let depth = tunnel_depth.max(1.0);
+    // displayFace bitmask: bit0=#front, bit1=#tunnel, bit2=#back; -1 = all.
+    let params = super::text3d::ExtrudeParams {
+        depth,
+        bevel_type,
+        bevel_depth: bevel_depth.max(0.0),
+        smoothness,
+        front: display_face == -1 || (display_face & 1) != 0,
+        tunnel: display_face == -1 || (display_face & 2) != 0,
+        back: display_face == -1 || (display_face & 4) != 0,
+    };
 
     // First pass: compute total width for centering
     let mut total_width = 0.0_f32;
@@ -746,18 +760,17 @@ pub fn extrude_text_to_mesh(
             continue; // space or blank glyph
         }
 
+        // Extrude the WHOLE glyph at once (all contours together) so the caps are
+        // tessellated with holes subtracted — the per-contour triangle-fan used to
+        // fill the counters of O / A / 8 / e solid. (Faithful to the IFX pipeline:
+        // contours -> earcut-with-holes caps + per-edge tunnel walls.)
         let polylines = flatten_glyph(glyph, scale, x_cursor);
-        for poly in &polylines {
-            let base = all_positions.len() as u32;
-            let (pos, nrm, faces) = extrude_contour(
-                &poly.iter().map(|p| [p[0], p[1]]).collect::<Vec<_>>(),
-                depth,
-            );
-            all_positions.extend_from_slice(&pos);
-            all_normals.extend_from_slice(&nrm);
-            for f in &faces {
-                all_faces.push([f[0] + base, f[1] + base, f[2] + base]);
-            }
+        let base = all_positions.len() as u32;
+        let (pos, nrm, faces) = super::text3d::extrude_glyph(&polylines, &params);
+        all_positions.extend_from_slice(&pos);
+        all_normals.extend_from_slice(&nrm);
+        for f in &faces {
+            all_faces.push([f[0] + base, f[1] + base, f[2] + base]);
         }
         x_cursor += advance;
     }

--- a/vm-rust/src/director/chunks/w3d/primitives.rs
+++ b/vm-rust/src/director/chunks/w3d/primitives.rs
@@ -220,6 +220,37 @@ pub fn extrude_alpha_mask_to_mesh(
         return super::types::ClodDecodedMesh::default();
     }
 
+    // Cap the working resolution. Geometry is emitted PER SOLID PIXEL × per bevel
+    // layer, and the incoming mask is the SUPERSAMPLED native-text render — so a
+    // large text (e.g. 2000×800) would emit millions of quads and spike memory
+    // (~800 MB, observed on dcr_intel/3DText). Downsample the mask so the mesh
+    // stays bounded; pixel-based extrusion is already an approximation, so a
+    // capped grid is visually fine and the world_width/height mapping is
+    // unchanged (pixel_width/height below scale to the reduced grid).
+    const MAX_DIM: u32 = 256;
+    let step = ((width.max(height) + MAX_DIM - 1) / MAX_DIM).max(1);
+    let downsampled: Option<(u32, u32, Vec<u8>)> = if step > 1 {
+        let ew = (width / step).max(1);
+        let eh = (height / step).max(1);
+        let mut ds = vec![0u8; (ew as usize) * (eh as usize) * 4];
+        for y in 0..eh {
+            for x in 0..ew {
+                let sx = (x * step).min(width - 1) as usize;
+                let sy = (y * step).min(height - 1) as usize;
+                let s = (sy * (width as usize) + sx) * 4;
+                let d = ((y as usize) * (ew as usize) + (x as usize)) * 4;
+                ds[d..d + 4].copy_from_slice(&rgba[s..s + 4]);
+            }
+        }
+        Some((ew, eh, ds))
+    } else {
+        None
+    };
+    let (width, height, rgba): (u32, u32, &[u8]) = match &downsampled {
+        Some((ew, eh, ds)) => (*ew, *eh, ds.as_slice()),
+        None => (width, height, rgba),
+    };
+
     let world_width = world_width.max(1.0);
     let world_height = world_height.max(1.0);
     let pixel_width = world_width / (width as f32).max(1.0);

--- a/vm-rust/src/director/chunks/w3d/raycast.rs
+++ b/vm-rust/src/director/chunks/w3d/raycast.rs
@@ -117,7 +117,7 @@ pub fn raycast_scene(
     scene: &W3dScene,
     max_dist: f32,
 ) -> Option<RayHit> {
-    raycast_scene_multi(ray, scene, max_dist, 1, None, None).into_iter().next()
+    raycast_scene_multi(ray, scene, max_dist, 1, None, None, None).into_iter().next()
 }
 
 /// Test ray against all meshes in a scene, returning up to max_hits sorted by distance.
@@ -130,6 +130,7 @@ pub fn raycast_scene_multi(
     max_hits: usize,
     node_transforms: Option<&std::collections::HashMap<String, [f32; 16]>>,
     excluded_nodes: Option<&std::collections::HashSet<String>>,
+    included_nodes: Option<&std::collections::HashSet<String>>,
 ) -> Vec<RayHit> {
     let mut all_hits: Vec<RayHit> = Vec::new();
 
@@ -138,6 +139,17 @@ pub fn raycast_scene_multi(
         // Skip excluded nodes (invisible or detached models)
         if let Some(excluded) = excluded_nodes {
             if excluded.contains(&node.name) { continue; }
+        }
+        // #modelList whitelist (modelsUnderRay/Loc optionsList): when provided and
+        // non-empty, only models whose name is in the list are tested; all others are
+        // ignored even if under the ray. Empty / None => no restriction (test all),
+        // matching the dictionary's "if omitted, all models" wording.
+        if let Some(included) = included_nodes {
+            if !included.is_empty()
+                && !included.iter().any(|n| n.eq_ignore_ascii_case(&node.name))
+            {
+                continue;
+            }
         }
         let resource = if !node.model_resource_name.is_empty() {
             &node.model_resource_name
@@ -358,10 +370,22 @@ fn raycast_mesh(
         let i2 = face[2] as usize;
         if i0 >= positions.len() || i1 >= positions.len() || i2 >= positions.len() { continue; }
         if let Some((t, u, v)) = ray_triangle_intersect(ray, &positions[i0], &positions[i1], &positions[i2]) {
-            // No backface culling - Director's modelsUnderRay tests both sides
             let edge1 = sub(positions[i1], positions[i0]);
             let edge2 = sub(positions[i2], positions[i0]);
             let normal = normalize(cross(edge1, edge2));
+
+            // Front-face culling. Director's modelsUnderRay returns ONLY front-face entries
+            // (where the ray enters a surface), never back-faces/exits — confirmed against
+            // Director 11.5: a ray cast from INSIDE a box returns no hit for that box, even
+            // with visibility #both. dirplayer previously tested both sides, so a Rasterwerks
+            // bot's collision/LOS rays hit the exit faces of its own body/proxy and of any
+            // geometry it stood inside → phantom near-hits → stuck navigation (constant
+            // re-path/mismatch), no line-of-sight to the player (never fires), and rockets
+            // detonating on adjacent geometry (self-splash). Skip a face the ray is exiting
+            // (its normal points along the ray direction).
+            if dot(normal, ray.direction) >= 0.0 {
+                continue;
+            }
 
             if t > 0.0 && t < max_dist {
                 if closest.as_ref().map_or(true, |c| t < c.distance) {

--- a/vm-rust/src/director/chunks/w3d/skeleton.rs
+++ b/vm-rust/src/director/chunks/w3d/skeleton.rs
@@ -56,15 +56,20 @@ pub fn build_bone_matrices(
     motion: Option<&W3dMotion>,
     time: f32,
 ) -> Vec<[f32; 16]> {
-    build_bone_matrices_ex(skeleton, motion, time, false)
+    build_bone_matrices_ex(skeleton, motion, time, false, None)
 }
 
-/// Build bone matrices with optional root lock.
+/// Build bone matrices with optional root lock and per-bone manual overrides.
+/// `overrides` maps a 0-based bone index to a LOCAL transform set via
+/// `bonesPlayer.bone[i].transform` — it replaces the motion/rest local for that
+/// bone (its rotation/scale is used and its translation is resolved to the rest
+/// length, so a script that sets only a rotation keeps the bone's length).
 pub fn build_bone_matrices_ex(
     skeleton: &W3dSkeleton,
     motion: Option<&W3dMotion>,
     time: f32,
     root_lock: bool,
+    overrides: Option<&std::collections::HashMap<usize, [f32; 16]>>,
 ) -> Vec<[f32; 16]> {
     let count = skeleton.bones.len();
     let mut local_matrices = Vec::with_capacity(count);
@@ -75,6 +80,24 @@ pub fn build_bone_matrices_ex(
 
     // Build local matrices from motion tracks or rest pose
     for (bone_idx, bone) in skeleton.bones.iter().enumerate() {
+        // Manual per-bone override (bonesPlayer.bone[i].transform = t) takes
+        // precedence over the motion. Use its rotation/scale but resolve the
+        // translation (zero for a preRotate-only script) to the rest length so
+        // the body keeps its shape while the override rotation drives it.
+        if let Some(ov) = overrides.and_then(|o| o.get(&bone_idx)) {
+            let (px, py, pz) = if root_lock && bone.parent_index < 0 {
+                (0.0, 0.0, 0.0)
+            } else {
+                resolve_local_translation(skeleton, bone_idx, ov[12], ov[13], ov[14])
+            };
+            let mut local = *ov;
+            local[12] = px;
+            local[13] = py;
+            local[14] = pz;
+            local_matrices.push(local);
+            has_motion_track[bone_idx] = true;
+            continue;
+        }
         if let Some(mot) = motion {
             if let Some(track) = mot.find_track_by_bone(&bone.name) {
                 let kf = track.evaluate(time);

--- a/vm-rust/src/director/chunks/w3d/text3d.rs
+++ b/vm-rust/src/director/chunks/w3d/text3d.rs
@@ -1,0 +1,943 @@
+//! 3D text (`extrude3D`) geometry — the contour-based pipeline that replaces the
+//! old per-contour triangle-fan cap.
+//!
+//! Faithful to Director's IFX 3D-glyph pipeline (see docs/3dtext-extrude3d.md):
+//! a glyph is a set of closed 2D contours (outer outlines + holes). The caps
+//! (front/back faces) are filled with a polygon-with-HOLES triangulation so the
+//! counters of O / A / 8 / e / B … come out hollow instead of solid, and the
+//! tunnel side-walls are emitted per contour edge.
+//!
+//! Phase 1 = correct caps + flat tunnel (no bevel). Bevel (#miter/#round),
+//! displayFace selection and planar UVs are later phases.
+
+/// Signed area of a closed 2D polygon. CCW (counter-clockwise) is positive.
+fn signed_area(c: &[[f32; 2]]) -> f32 {
+    let n = c.len();
+    if n < 3 {
+        return 0.0;
+    }
+    let mut a = 0.0_f32;
+    let mut j = n - 1;
+    for i in 0..n {
+        a += (c[j][0] + c[i][0]) * (c[j][1] - c[i][1]);
+        j = i;
+    }
+    -a * 0.5
+}
+
+/// Even-odd ray-cast point-in-polygon test.
+fn point_in_poly(p: [f32; 2], c: &[[f32; 2]]) -> bool {
+    let n = c.len();
+    if n < 3 {
+        return false;
+    }
+    let mut inside = false;
+    let mut j = n - 1;
+    for i in 0..n {
+        let (xi, yi) = (c[i][0], c[i][1]);
+        let (xj, yj) = (c[j][0], c[j][1]);
+        if ((yi > p[1]) != (yj > p[1]))
+            && (p[0] < (xj - xi) * (p[1] - yi) / (yj - yi) + xi)
+        {
+            inside = !inside;
+        }
+        j = i;
+    }
+    inside
+}
+
+/// Nesting depth of contour `i`: how many OTHER contours contain it (test the
+/// contour's first vertex). Even depth = solid (outer), odd depth = hole.
+fn nesting_depth(contours: &[Vec<[f32; 2]>], i: usize) -> usize {
+    let probe = match contours[i].first() {
+        Some(p) => *p,
+        None => return 0,
+    };
+    let mut depth = 0;
+    for (j, c) in contours.iter().enumerate() {
+        if j != i && c.len() >= 3 && point_in_poly(probe, c) {
+            depth += 1;
+        }
+    }
+    depth
+}
+
+/// Triangulate the glyph caps (the filled region, holes subtracted) over the
+/// FLAT concatenation of all contour points. `offsets[i]` is the first global
+/// index of contour `i`. Returns triangles as global point indices. Winding is
+/// left as earcut produced it; the extruder forces per-face winding for ±Z.
+fn triangulate_caps(contours: &[Vec<[f32; 2]>], offsets: &[usize]) -> Vec<[u32; 3]> {
+    let n = contours.len();
+    let depths: Vec<usize> = (0..n).map(|i| nesting_depth(contours, i)).collect();
+
+    let mut tris: Vec<[u32; 3]> = Vec::new();
+    for outer in 0..n {
+        if contours[outer].len() < 3 || depths[outer] % 2 != 0 {
+            continue; // only solid (even-depth) contours are outers
+        }
+        // Holes = immediately-nested (depth+1) contours contained in this outer.
+        let mut holes: Vec<usize> = Vec::new();
+        for h in 0..n {
+            if h != outer
+                && contours[h].len() >= 3
+                && depths[h] == depths[outer] + 1
+                && point_in_poly(contours[h][0], &contours[outer])
+            {
+                holes.push(h);
+            }
+        }
+
+        // Build earcut input: outer ring then each hole ring, flat [x,y,...].
+        let ring_order: Vec<usize> = std::iter::once(outer).chain(holes.iter().copied()).collect();
+        let mut data: Vec<f64> = Vec::new();
+        let mut hole_indices: Vec<usize> = Vec::new();
+        let mut local_to_global: Vec<u32> = Vec::new();
+        for (ri, &ci) in ring_order.iter().enumerate() {
+            if ri > 0 {
+                hole_indices.push(data.len() / 2); // vertex index where this hole starts
+            }
+            for (k, p) in contours[ci].iter().enumerate() {
+                data.push(p[0] as f64);
+                data.push(p[1] as f64);
+                local_to_global.push((offsets[ci] + k) as u32);
+            }
+        }
+
+        if let Ok(idx) = earcutr::earcut(&data, &hole_indices, 2) {
+            for t in idx.chunks_exact(3) {
+                tris.push([
+                    local_to_global[t[0]],
+                    local_to_global[t[1]],
+                    local_to_global[t[2]],
+                ]);
+            }
+        }
+    }
+    tris
+}
+
+/// Extrusion parameters (mirrors Director's 3D-text properties).
+#[derive(Clone, Copy, Debug)]
+pub struct ExtrudeParams {
+    /// `tunnelDepth` — total extrusion length along +Z.
+    pub depth: f32,
+    /// `bevelType`: 0 = #none, 1 = #miter, 2 = #round.
+    pub bevel_type: u32,
+    /// `bevelDepth` — chamfer size (inward inset and Z extent of each chamfer).
+    pub bevel_depth: f32,
+    /// `smoothness` — drives the #round chamfer arc subdivision.
+    pub smoothness: u32,
+    /// `displayFace` selection — generate the front cap / back cap / tunnel
+    /// (sides + bevel) only when the corresponding flag is set.
+    pub front: bool,
+    pub back: bool,
+    pub tunnel: bool,
+}
+
+impl ExtrudeParams {
+    /// Flat extrusion (no bevel), all faces, of the given depth.
+    pub fn flat(depth: f32) -> Self {
+        ExtrudeParams {
+            depth,
+            bevel_type: 0,
+            bevel_depth: 0.0,
+            smoothness: 0,
+            front: true,
+            back: true,
+            tunnel: true,
+        }
+    }
+}
+
+fn edge_unit(a: [f32; 2], b: [f32; 2]) -> [f32; 2] {
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    let l = (dx * dx + dy * dy).sqrt().max(1e-8);
+    [dx / l, dy / l]
+}
+
+fn normalize3(v: [f32; 3]) -> [f32; 3] {
+    let l = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt().max(1e-8);
+    [v[0] / l, v[1] / l, v[2] / l]
+}
+
+/// Per-vertex outward normals for a closed contour: `unit` = the unit angle
+/// bisector (for shading), `miter` = the same direction scaled by the miter
+/// factor 1/cos(half-angle) (clamped) so an inward offset keeps the inset edges
+/// parallel and corners gap-free.
+fn vertex_normals(c: &[[f32; 2]]) -> (Vec<[f32; 2]>, Vec<[f32; 2]>) {
+    let n = c.len();
+    let mut unit = vec![[0.0_f32, 0.0]; n];
+    let mut miter = vec![[0.0_f32, 0.0]; n];
+    for i in 0..n {
+        let prev = c[(i + n - 1) % n];
+        let cur = c[i];
+        let next = c[(i + 1) % n];
+        let e0 = edge_unit(prev, cur); // incoming edge
+        let e1 = edge_unit(cur, next); // outgoing edge
+        let rp0 = [e0[1], -e0[0]]; // right perpendicular (outward for CCW)
+        let rp1 = [e1[1], -e1[0]];
+        let mut b = [rp0[0] + rp1[0], rp0[1] + rp1[1]];
+        let l = (b[0] * b[0] + b[1] * b[1]).sqrt();
+        if l < 1e-6 {
+            b = rp1; // 180° reversal — fall back to the edge normal
+        } else {
+            b = [b[0] / l, b[1] / l];
+        }
+        unit[i] = b;
+        // cos(half-angle) between the bisector and an edge normal; clamp → miter limit ≈ 4.
+        let cosang = (b[0] * rp1[0] + b[1] * rp1[1]).max(0.25);
+        let s = 1.0 / cosang;
+        miter[i] = [b[0] * s, b[1] * s];
+    }
+    (unit, miter)
+}
+
+fn push_quad(
+    positions: &mut Vec<[f32; 3]>,
+    normals: &mut Vec<[f32; 3]>,
+    faces: &mut Vec<[u32; 3]>,
+    quad: [[f32; 3]; 4],
+    norms: [[f32; 3]; 4],
+) {
+    let v = positions.len() as u32;
+    positions.extend_from_slice(&quad);
+    normals.extend_from_slice(&norms);
+    faces.push([v, v + 1, v + 2]);
+    faces.push([v, v + 2, v + 3]);
+}
+
+/// Extrude a glyph (a set of closed contours, outer + holes) into a 3D mesh:
+/// front cap at z=0 (normal −Z), back cap at z=`depth` (normal +Z), and side
+/// walls (a straight tunnel for #none, or a chamfer→tunnel→chamfer for
+/// #miter/#round). Holes are filled correctly.
+///
+/// Returns (positions, normals, faces).
+pub fn extrude_glyph(
+    contours: &[Vec<[f32; 2]>],
+    params: &ExtrudeParams,
+) -> (Vec<[f32; 3]>, Vec<[f32; 3]>, Vec<[u32; 3]>) {
+    let depth = params.depth.max(1e-4);
+
+    // Working copy with consistent orientation: outers CCW, holes CW. This makes
+    // the right-hand edge perpendicular (dy,−dx) the outward wall normal for
+    // outers and the into-the-void normal for holes (both = facing away from the
+    // solid material), and keeps cap winding predictable.
+    let n_contours = contours.len();
+    let depths: Vec<usize> = (0..n_contours).map(|i| nesting_depth(contours, i)).collect();
+    let work: Vec<Vec<[f32; 2]>> = contours
+        .iter()
+        .enumerate()
+        .filter(|(_, c)| c.len() >= 3)
+        .map(|(i, c)| {
+            let area = signed_area(c);
+            let want_ccw = depths[i] % 2 == 0; // outer wants CCW (area > 0)
+            let mut v = c.clone();
+            if (want_ccw && area < 0.0) || (!want_ccw && area > 0.0) {
+                v.reverse();
+            }
+            v
+        })
+        .collect();
+
+    if work.is_empty() {
+        return (Vec::new(), Vec::new(), Vec::new());
+    }
+
+    // Flat offsets for the cap vertex sets.
+    let mut offsets = Vec::with_capacity(work.len());
+    let mut total = 0usize;
+    for c in &work {
+        offsets.push(total);
+        total += c.len();
+    }
+    let n = total as u32;
+
+    let mut positions: Vec<[f32; 3]> = Vec::with_capacity(total * 2);
+    let mut normals: Vec<[f32; 3]> = Vec::with_capacity(total * 2);
+    let mut faces: Vec<[u32; 3]> = Vec::new();
+
+    // Front cap vertices (z = 0, normal −Z), then back cap vertices (z = depth, +Z).
+    for c in &work {
+        for p in c {
+            positions.push([p[0], p[1], 0.0]);
+            normals.push([0.0, 0.0, -1.0]);
+        }
+    }
+    for c in &work {
+        for p in c {
+            positions.push([p[0], p[1], depth]);
+            normals.push([0.0, 0.0, 1.0]);
+        }
+    }
+
+    // Caps: triangulate once, emit front and/or back per displayFace with forced winding.
+    if params.front || params.back {
+        let cap_tris = triangulate_caps(&work, &offsets);
+        for t in &cap_tris {
+            let (a, b, c) = (t[0], t[1], t[2]);
+            let pa = positions[a as usize];
+            let pb = positions[b as usize];
+            let pc = positions[c as usize];
+            // XY cross product z-component → triangle winding in the plane.
+            let cross = (pb[0] - pa[0]) * (pc[1] - pa[1]) - (pb[1] - pa[1]) * (pc[0] - pa[0]);
+            // FRONT (normal −Z): viewed from below it must be CCW → from above CW → cross < 0.
+            if params.front {
+                if cross > 0.0 {
+                    faces.push([a, c, b]);
+                } else {
+                    faces.push([a, b, c]);
+                }
+            }
+            // BACK (normal +Z): cross > 0 (CCW from above).
+            if params.back {
+                if cross > 0.0 {
+                    faces.push([a + n, b + n, c + n]);
+                } else {
+                    faces.push([a + n, c + n, b + n]);
+                }
+            }
+        }
+    }
+
+    // displayFace without #tunnel → caps only, no sides.
+    if !params.tunnel {
+        return (positions, normals, faces);
+    }
+
+    // Side walls. #none → straight tunnel. #miter/#round → a chamfer from the
+    // full-outline cap edge (z=0) inward to the inset tunnel, the tunnel, then a
+    // mirrored chamfer back out to the full-outline back edge (z=depth). The inset
+    // uses the per-vertex miter normal so corners stay gap-free.
+    let bevel = if params.bevel_type == 0 {
+        0.0
+    } else {
+        // A chamfer can't take more than half the depth (front + back).
+        params.bevel_depth.max(0.0).min(depth * 0.5 - 1e-3).max(0.0)
+    };
+    let arc_steps: usize = if params.bevel_type == 2 {
+        ((params.smoothness.max(1) as usize) / 2).clamp(2, 6) // #round: arc subdivisions
+    } else {
+        1 // #miter: single flat chamfer
+    };
+    use std::f32::consts::FRAC_PI_2;
+
+    for c in &work {
+        let m = c.len();
+        // Per-vertex outward normals: `unit` is the smooth angle-bisector used for
+        // SHADING (so curved edges read as one smooth lit edge instead of faceting
+        // per segment), `miter` is the (miter-limited) offset for the bevel inset.
+        let (unit, miter) = vertex_normals(c);
+
+        if bevel <= 0.0 {
+            // Flat tunnel: one quad per edge, smooth per-vertex side normals.
+            for i in 0..m {
+                let j = (i + 1) % m;
+                let p0 = c[i];
+                let p1 = c[j];
+                let ni = [unit[i][0], unit[i][1], 0.0];
+                let nj = [unit[j][0], unit[j][1], 0.0];
+                push_quad(
+                    &mut positions, &mut normals, &mut faces,
+                    [[p0[0], p0[1], 0.0], [p1[0], p1[1], 0.0], [p1[0], p1[1], depth], [p0[0], p0[1], depth]],
+                    [ni, nj, nj, ni],
+                );
+            }
+            continue;
+        }
+
+        let inset: Vec<[f32; 2]> = (0..m)
+            .map(|i| [c[i][0] - bevel * miter[i][0], c[i][1] - bevel * miter[i][1]])
+            .collect();
+        let z_fi = bevel; // front inset plane
+        let z_bi = depth - bevel; // back inset plane
+
+        for i in 0..m {
+            let j = (i + 1) % m;
+
+            // Front chamfer: full edge (z=0) → inset (z=bevel). Smooth per-vertex
+            // normals (front → side) so the lit bevel is one clean edge.
+            let fpos = |k: usize, a: f32| -> [f32; 3] {
+                let off = bevel * (1.0 - a.cos());
+                [c[k][0] - off * miter[k][0], c[k][1] - off * miter[k][1], bevel * a.sin()]
+            };
+            let fnrm = |k: usize, a: f32| -> [f32; 3] {
+                normalize3([unit[k][0] * a.sin(), unit[k][1] * a.sin(), -a.cos()])
+            };
+            for s in 0..arc_steps {
+                let a0 = (s as f32 / arc_steps as f32) * FRAC_PI_2;
+                let a1 = ((s + 1) as f32 / arc_steps as f32) * FRAC_PI_2;
+                let q = [fpos(i, a0), fpos(j, a0), fpos(j, a1), fpos(i, a1)];
+                let nrm = [fnrm(i, a0), fnrm(j, a0), fnrm(j, a1), fnrm(i, a1)];
+                push_quad(&mut positions, &mut normals, &mut faces, q, nrm);
+            }
+
+            // Tunnel: inset front (z_fi) → inset back (z_bi), smooth side normals.
+            {
+                let ni = [unit[i][0], unit[i][1], 0.0];
+                let nj = [unit[j][0], unit[j][1], 0.0];
+                push_quad(
+                    &mut positions, &mut normals, &mut faces,
+                    [
+                        [inset[i][0], inset[i][1], z_fi],
+                        [inset[j][0], inset[j][1], z_fi],
+                        [inset[j][0], inset[j][1], z_bi],
+                        [inset[i][0], inset[i][1], z_bi],
+                    ],
+                    [ni, nj, nj, ni],
+                );
+            }
+
+            // Back chamfer: inset (z=z_bi) → full edge (z=depth), mirrored arc.
+            let bpos = |k: usize, a: f32| -> [f32; 3] {
+                let off = bevel * a.cos();
+                [c[k][0] - off * miter[k][0], c[k][1] - off * miter[k][1], depth - bevel * a.cos()]
+            };
+            let bnrm = |k: usize, a: f32| -> [f32; 3] {
+                normalize3([unit[k][0] * a.cos(), unit[k][1] * a.cos(), a.sin()])
+            };
+            for s in 0..arc_steps {
+                let a0 = (s as f32 / arc_steps as f32) * FRAC_PI_2;
+                let a1 = ((s + 1) as f32 / arc_steps as f32) * FRAC_PI_2;
+                let q = [bpos(i, a0), bpos(j, a0), bpos(j, a1), bpos(i, a1)];
+                let nrm = [bnrm(i, a0), bnrm(j, a0), bnrm(j, a1), bnrm(i, a1)];
+                push_quad(&mut positions, &mut normals, &mut faces, q, nrm);
+            }
+        }
+    }
+
+    (positions, normals, faces)
+}
+
+/// Linear interpolation parameter where `thr` is crossed between corner values
+/// `a` and `b` (guarded against a zero denominator).
+fn cross_t(a: f32, b: f32, thr: f32) -> f32 {
+    let d = b - a;
+    if d.abs() < 1e-6 {
+        0.5
+    } else {
+        ((thr - a) / d).clamp(0.0, 1.0)
+    }
+}
+
+/// Separable box blur of a scalar field, clamped at the edges (one pass ≈ a
+/// triangular/Gaussian-ish smoothing of the alpha before contour tracing).
+fn box_blur(src: &[f32], w: usize, h: usize, r: usize) -> Vec<f32> {
+    let ri = r as i32;
+    let mut tmp = vec![0.0f32; src.len()];
+    for y in 0..h {
+        let row = y * w;
+        for x in 0..w {
+            let (mut s, mut c) = (0.0f32, 0.0f32);
+            for dx in -ri..=ri {
+                let xx = x as i32 + dx;
+                if xx >= 0 && (xx as usize) < w {
+                    s += src[row + xx as usize];
+                    c += 1.0;
+                }
+            }
+            tmp[row + x] = s / c;
+        }
+    }
+    let mut out = vec![0.0f32; src.len()];
+    for y in 0..h {
+        for x in 0..w {
+            let (mut s, mut c) = (0.0f32, 0.0f32);
+            for dy in -ri..=ri {
+                let yy = y as i32 + dy;
+                if yy >= 0 && (yy as usize) < h {
+                    s += tmp[yy as usize * w + x];
+                    c += 1.0;
+                }
+            }
+            out[y * w + x] = s / c;
+        }
+    }
+    out
+}
+
+/// Trace closed iso-contours of an alpha mask at `threshold` via marching
+/// squares (sub-pixel crossings), returning closed polygons in PIXEL space
+/// (x∈[0,width], y∈[0,height]). Outer outlines and holes both come out as
+/// separate loops; which is a hole is decided later by `extrude_glyph`'s
+/// even-odd nesting. Loops are Douglas-Peucker simplified by `simplify_eps`
+/// (pixels) to keep the mesh light. This is the no-PFR (system/native font)
+/// outline source: the text is rasterised, then revectorised here.
+pub fn vectorize_alpha(
+    width: u32,
+    height: u32,
+    rgba: &[u8],
+    threshold: u8,
+    simplify_eps: f32,
+    smooth_iters: usize,
+    blur_radius: usize,
+) -> Vec<Vec<[f32; 2]>> {
+    let w = width as usize;
+    let h = height as usize;
+    if w < 2 || h < 2 || rgba.len() < w * h * 4 {
+        return Vec::new();
+    }
+    let thr = threshold as f32;
+    // Pre-blur the alpha so the iso-contour is a smooth curve instead of the wavy
+    // 50%-coverage boundary of an anti-aliased edge (the dominant source of the
+    // jagged outline). Marching squares then traces the blurred field.
+    let mut abuf: Vec<f32> = (0..w * h).map(|i| rgba[i * 4 + 3] as f32).collect();
+    if blur_radius > 0 {
+        abuf = box_blur(&abuf, w, h, blur_radius);
+    }
+    let alpha = |x: usize, y: usize| -> f32 { abuf[y * w + x] };
+
+    let mut segs: Vec<([f32; 2], [f32; 2])> = Vec::new();
+    for y in 0..h - 1 {
+        for x in 0..w - 1 {
+            let a0 = alpha(x, y); // top-left
+            let a1 = alpha(x + 1, y); // top-right
+            let a2 = alpha(x + 1, y + 1); // bottom-right
+            let a3 = alpha(x, y + 1); // bottom-left
+            let case = (a0 >= thr) as u8
+                | (((a1 >= thr) as u8) << 1)
+                | (((a2 >= thr) as u8) << 2)
+                | (((a3 >= thr) as u8) << 3);
+            if case == 0 || case == 15 {
+                continue;
+            }
+            let (xf, yf) = (x as f32, y as f32);
+            // Crossing point on edge e, ALWAYS parameterised from the lower grid
+            // index toward the higher one so the point on a shared edge is computed
+            // identically by both adjacent cells (else AA text fragments):
+            //   0=top   : c0(x,y)   → c1(x+1,y)     pt = (x+t, y)
+            //   1=right : c1(x+1,y) → c2(x+1,y+1)   pt = (x+1, y+t)
+            //   2=bottom: c3(x,y+1) → c2(x+1,y+1)   pt = (x+t, y+1)
+            //   3=left  : c0(x,y)   → c3(x,y+1)     pt = (x, y+t)
+            let pt = |e: u8| -> [f32; 2] {
+                match e {
+                    0 => [xf + cross_t(a0, a1, thr), yf],
+                    1 => [xf + 1.0, yf + cross_t(a1, a2, thr)],
+                    2 => [xf + cross_t(a3, a2, thr), yf + 1.0],
+                    _ => [xf, yf + cross_t(a0, a3, thr)],
+                }
+            };
+            let pairs: &[(u8, u8)] = match case {
+                1 | 14 => &[(3, 0)],
+                2 | 13 => &[(0, 1)],
+                3 | 12 => &[(3, 1)],
+                4 | 11 => &[(1, 2)],
+                6 | 9 => &[(0, 2)],
+                7 | 8 => &[(2, 3)],
+                5 => &[(3, 0), (1, 2)],  // saddle (fixed resolution)
+                10 => &[(0, 1), (2, 3)], // saddle
+                _ => &[],
+            };
+            for &(ea, eb) in pairs {
+                segs.push((pt(ea), pt(eb)));
+            }
+        }
+    }
+
+    // Smooth the stair-stepped marching-squares loops (corner-averaging) so the
+    // outline reads as a curve, THEN simplify, THEN drop tiny noise specks (stray
+    // AA pixels that cross the threshold). DP alone can't remove a stairstep
+    // because its alternating vertices are all "far" from the chord.
+    let min_area = (simplify_eps * simplify_eps).max(2.0);
+    link_segments(&segs)
+        .into_iter()
+        .map(|loop_pts| smooth_closed(&loop_pts, smooth_iters))
+        .map(|loop_pts| simplify_closed(&loop_pts, simplify_eps))
+        .filter(|c| c.len() >= 3 && signed_area(c).abs() > min_area)
+        .collect()
+}
+
+/// One Laplacian pass on a closed loop: each point moves `factor` of the way to
+/// the midpoint of its neighbours.
+fn laplacian_pass(pts: &[[f32; 2]], factor: f32) -> Vec<[f32; 2]> {
+    let n = pts.len();
+    (0..n)
+        .map(|i| {
+            let a = pts[(i + n - 1) % n];
+            let b = pts[i];
+            let c = pts[(i + 1) % n];
+            let mx = (a[0] + c[0]) * 0.5;
+            let my = (a[1] + c[1]) * 0.5;
+            [b[0] + factor * (mx - b[0]), b[1] + factor * (my - b[1])]
+        })
+        .collect()
+}
+
+/// Taubin (λ/μ) smoothing of a closed loop: a positive shrink pass followed by a
+/// negative inflate pass per iteration. De-jags the marching-squares stairstep
+/// WITHOUT the net shrinkage of plain averaging — important so thin strokes in
+/// small text (the stems of l/i/j) survive instead of collapsing into blobs.
+fn smooth_closed(pts: &[[f32; 2]], iters: usize) -> Vec<[f32; 2]> {
+    if pts.len() < 5 || iters == 0 {
+        return pts.to_vec();
+    }
+    let lambda = 0.5_f32;
+    let mu = -0.53_f32;
+    let mut cur = pts.to_vec();
+    for _ in 0..iters {
+        cur = laplacian_pass(&cur, lambda);
+        cur = laplacian_pass(&cur, mu);
+    }
+    cur
+}
+
+/// Quantise a point for endpoint matching (marching-squares crossings on a
+/// shared edge are identical, so a coarse key links neighbouring cells).
+fn key(p: [f32; 2]) -> (i32, i32) {
+    ((p[0] * 16.0).round() as i32, (p[1] * 16.0).round() as i32)
+}
+
+/// Link undirected segments into closed loops by matching shared endpoints.
+fn link_segments(segs: &[([f32; 2], [f32; 2])]) -> Vec<Vec<[f32; 2]>> {
+    use std::collections::HashMap;
+    // point key -> list of (segment index, endpoint 0|1)
+    let mut adj: HashMap<(i32, i32), Vec<(usize, u8)>> = HashMap::new();
+    for (i, s) in segs.iter().enumerate() {
+        adj.entry(key(s.0)).or_default().push((i, 0));
+        adj.entry(key(s.1)).or_default().push((i, 1));
+    }
+    let mut used = vec![false; segs.len()];
+    let mut loops: Vec<Vec<[f32; 2]>> = Vec::new();
+
+    for start in 0..segs.len() {
+        if used[start] {
+            continue;
+        }
+        let mut loop_pts: Vec<[f32; 2]> = Vec::new();
+        let mut cur = start;
+        let mut from_end: u8 = 0; // we enter `cur` at endpoint 0, exit at 1
+        loop {
+            used[cur] = true;
+            let (p_in, p_out) = if from_end == 0 {
+                (segs[cur].0, segs[cur].1)
+            } else {
+                (segs[cur].1, segs[cur].0)
+            };
+            loop_pts.push(p_in);
+            // find the next unused segment sharing p_out
+            let k = key(p_out);
+            let mut next: Option<(usize, u8)> = None;
+            if let Some(list) = adj.get(&k) {
+                for &(si, end) in list {
+                    if si != cur && !used[si] {
+                        next = Some((si, end));
+                        break;
+                    }
+                }
+            }
+            match next {
+                Some((si, end)) => {
+                    cur = si;
+                    from_end = end; // we arrive at `end`, so exit the other side
+                }
+                None => {
+                    break;
+                }
+            }
+            if cur == start {
+                break;
+            }
+        }
+        if loop_pts.len() >= 3 {
+            loops.push(loop_pts);
+        }
+    }
+    loops
+}
+
+fn dist_pt_seg2(p: [f32; 2], a: [f32; 2], b: [f32; 2]) -> f32 {
+    let dx = b[0] - a[0];
+    let dy = b[1] - a[1];
+    let l2 = dx * dx + dy * dy;
+    if l2 < 1e-9 {
+        let ex = p[0] - a[0];
+        let ey = p[1] - a[1];
+        return ex * ex + ey * ey;
+    }
+    let t = (((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / l2).clamp(0.0, 1.0);
+    let px = a[0] + t * dx;
+    let py = a[1] + t * dy;
+    let ex = p[0] - px;
+    let ey = p[1] - py;
+    ex * ex + ey * ey
+}
+
+fn dp_rec(pts: &[[f32; 2]], a: usize, b: usize, eps2: f32, keep: &mut [bool]) {
+    if b <= a + 1 {
+        return;
+    }
+    let mut idx = 0;
+    let mut dmax = 0.0_f32;
+    for i in (a + 1)..b {
+        let d = dist_pt_seg2(pts[i], pts[a], pts[b]);
+        if d > dmax {
+            dmax = d;
+            idx = i;
+        }
+    }
+    if dmax > eps2 {
+        keep[idx] = true;
+        dp_rec(pts, a, idx, eps2, keep);
+        dp_rec(pts, idx, b, eps2, keep);
+    }
+}
+
+/// Douglas-Peucker simplify a CLOSED loop: split at the point farthest from the
+/// start, simplify both arcs, keep the close.
+fn simplify_closed(pts: &[[f32; 2]], eps: f32) -> Vec<[f32; 2]> {
+    let n = pts.len();
+    if n < 4 || eps <= 0.0 {
+        return pts.to_vec();
+    }
+    let mut far = 0;
+    let mut fd = 0.0_f32;
+    for i in 1..n {
+        let dx = pts[i][0] - pts[0][0];
+        let dy = pts[i][1] - pts[0][1];
+        let d = dx * dx + dy * dy;
+        if d > fd {
+            fd = d;
+            far = i;
+        }
+    }
+    let eps2 = eps * eps;
+    let mut keep = vec![false; n];
+    keep[0] = true;
+    keep[far] = true;
+    dp_rec(pts, 0, far, eps2, &mut keep);
+    dp_rec(pts, far, n - 1, eps2, &mut keep);
+    (0..n).filter(|&i| keep[i]).map(|i| pts[i]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tri_area_xy(p: &[[f32; 3]], t: &[u32; 3]) -> f32 {
+        let a = p[t[0] as usize];
+        let b = p[t[1] as usize];
+        let c = p[t[2] as usize];
+        0.5 * ((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])).abs()
+    }
+
+    #[test]
+    fn signed_area_orientation() {
+        // CCW square → positive.
+        let ccw = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+        assert!(signed_area(&ccw) > 0.0);
+        let mut cw = ccw.clone();
+        cw.reverse();
+        assert!(signed_area(&cw) < 0.0);
+    }
+
+    #[test]
+    fn square_with_hole_caps_are_hollow() {
+        // Outer 10x10 (CCW) with a 4x4 centred hole (CW). Filled area = 84.
+        let outer = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+        let hole = vec![[3.0, 3.0], [3.0, 7.0], [7.0, 7.0], [7.0, 3.0]]; // CW
+        let contours = vec![outer, hole];
+
+        let (pos, nrm, faces) = extrude_glyph(&contours, &ExtrudeParams::flat(5.0));
+        assert!(!faces.is_empty());
+
+        // Front-cap triangles = those whose 3 verts are all at z≈0.
+        let front: Vec<&[u32; 3]> = faces
+            .iter()
+            .filter(|t| t.iter().all(|&i| pos[i as usize][2].abs() < 1e-3))
+            .collect();
+        assert!(!front.is_empty(), "no front-cap triangles");
+
+        // (a) Total front-cap area ≈ 84 (hole subtracted, not 100).
+        let area: f32 = front.iter().map(|t| tri_area_xy(&pos, t)).sum();
+        assert!((area - 84.0).abs() < 0.5, "front cap area {area} != ~84 (hole not subtracted?)");
+
+        // (b) No front-cap triangle centroid lies inside the hole.
+        for t in &front {
+            let a = pos[t[0] as usize];
+            let b = pos[t[1] as usize];
+            let c = pos[t[2] as usize];
+            let cx = (a[0] + b[0] + c[0]) / 3.0;
+            let cy = (a[1] + b[1] + c[1]) / 3.0;
+            let in_hole = cx > 3.0 && cx < 7.0 && cy > 3.0 && cy < 7.0;
+            assert!(!in_hole, "cap triangle centroid ({cx},{cy}) inside the hole");
+        }
+
+        // (c) Front-cap normals point −Z.
+        for t in &front {
+            for &i in t.iter() {
+                assert!(nrm[i as usize][2] < 0.0, "front cap normal not −Z");
+            }
+        }
+    }
+
+    #[test]
+    fn concave_l_shape_fills() {
+        // An L (concave) — a triangle fan from vertex 0 would spill outside.
+        let l = vec![
+            [0.0, 0.0],
+            [6.0, 0.0],
+            [6.0, 2.0],
+            [2.0, 2.0],
+            [2.0, 6.0],
+            [0.0, 6.0],
+        ];
+        let (pos, _n, faces) = extrude_glyph(&[l], &ExtrudeParams::flat(3.0));
+        let front: Vec<&[u32; 3]> = faces
+            .iter()
+            .filter(|t| t.iter().all(|&i| pos[i as usize][2].abs() < 1e-3))
+            .collect();
+        let area: f32 = front.iter().map(|t| tri_area_xy(&pos, t)).sum();
+        // L area = 6*2 + 2*4 = 20.
+        assert!((area - 20.0).abs() < 0.5, "L-shape front area {area} != ~20");
+    }
+
+    #[test]
+    fn miter_bevel_insets_tunnel_and_keeps_full_caps() {
+        // 10x10 square, depth 6, miter bevel 1.0.
+        let sq = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+        let params = ExtrudeParams { depth: 6.0, bevel_type: 1, bevel_depth: 1.0, smoothness: 0, front: true, back: true, tunnel: true };
+        let (pos, _n, faces) = extrude_glyph(&[sq], &params);
+        assert!(!faces.is_empty());
+
+        // Front cap is still the FULL outline (area ~100) at z=0.
+        let front: Vec<&[u32; 3]> = faces
+            .iter()
+            .filter(|t| t.iter().all(|&i| pos[i as usize][2].abs() < 1e-3))
+            .collect();
+        let area: f32 = front.iter().map(|t| tri_area_xy(&pos, t)).sum();
+        assert!((area - 100.0).abs() < 0.5, "beveled front cap area {area} != ~100 (cap should stay full)");
+
+        // The bevel must inset the wall by ~bevelDepth: corner (0,0) → (1,1).
+        // So the inset left edge sits at x≈1 (vs the full outline's x=0/10), at a
+        // z beyond the front cap plane.
+        let inset_seen = pos.iter().any(|p| (p[0] - 1.0).abs() < 0.25 && p[2] > 0.5);
+        assert!(inset_seen, "no inset wall vertices (x≈1) — bevel did not inset");
+    }
+
+    #[test]
+    fn round_bevel_produces_more_rings_than_miter() {
+        let sq = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+        let miter = ExtrudeParams { depth: 6.0, bevel_type: 1, bevel_depth: 1.0, smoothness: 6, front: true, back: true, tunnel: true };
+        let round = ExtrudeParams { depth: 6.0, bevel_type: 2, bevel_depth: 1.0, smoothness: 6, front: true, back: true, tunnel: true };
+        let (_pm, _nm, fm) = extrude_glyph(&[sq.clone()], &miter);
+        let (_pr, _nr, fr) = extrude_glyph(&[sq], &round);
+        assert!(fr.len() > fm.len(), "round bevel ({}) should add arc rings vs miter ({})", fr.len(), fm.len());
+    }
+
+    fn alpha_bitmap(w: u32, h: u32, fill: &dyn Fn(u32, u32) -> bool) -> Vec<u8> {
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        for y in 0..h {
+            for x in 0..w {
+                if fill(x, y) {
+                    rgba[((y * w + x) * 4 + 3) as usize] = 255;
+                }
+            }
+        }
+        rgba
+    }
+
+    #[test]
+    fn vectorize_filled_square_one_contour() {
+        let (w, h) = (10u32, 10u32);
+        let rgba = alpha_bitmap(w, h, &|x, y| (3..7).contains(&x) && (3..7).contains(&y));
+        let contours = vectorize_alpha(w, h, &rgba, 128, 0.0, 0, 0);
+        assert_eq!(contours.len(), 1, "expected 1 contour, got {}", contours.len());
+        // 50% crossing → square spans ~[2.5,6.5] → area ~16.
+        let area = signed_area(&contours[0]).abs();
+        assert!((area - 16.0).abs() < 2.0, "vectorized square area {area} != ~16");
+    }
+
+    #[test]
+    fn vectorize_square_with_hole_two_contours_and_hollow_cap() {
+        let (w, h) = (12u32, 12u32);
+        let rgba = alpha_bitmap(w, h, &|x, y| {
+            (2..10).contains(&x) && (2..10).contains(&y) && !((5..7).contains(&x) && (5..7).contains(&y))
+        });
+        let contours = vectorize_alpha(w, h, &rgba, 128, 0.0, 0, 0);
+        assert_eq!(contours.len(), 2, "expected outer+hole = 2 contours, got {}", contours.len());
+        // Feed into extrude_glyph: the cap must subtract the hole (outer ~64 − hole ~4 = ~60).
+        let (pos, _n, faces) = extrude_glyph(&contours, &ExtrudeParams::flat(2.0));
+        let front: Vec<&[u32; 3]> = faces
+            .iter()
+            .filter(|t| t.iter().all(|&i| pos[i as usize][2].abs() < 1e-3))
+            .collect();
+        let area: f32 = front.iter().map(|t| tri_area_xy(&pos, t)).sum();
+        assert!((area - 60.0).abs() < 6.0, "vectorized hole cap area {area} != ~60");
+    }
+
+    #[test]
+    fn vectorize_aa_edge_no_sawtooth() {
+        // Anti-aliased vertical edge → cross_t ≈ 0.335 (not 0.5). The left boundary
+        // must trace a straight line; the old mirrored bottom/left crossings made it
+        // sawtooth between adjacent rows (which fragmented real text).
+        let (w, h) = (10u32, 8u32);
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        for y in 1..7 {
+            for x in 0..w {
+                let a: u8 = match x {
+                    3 => 64,
+                    4 | 5 => 255,
+                    6 => 64,
+                    _ => 0,
+                };
+                rgba[((y * w + x) * 4 + 3) as usize] = a;
+            }
+        }
+        let cs = vectorize_alpha(w, h, &rgba, 128, 0.0, 0, 0);
+        assert_eq!(cs.len(), 1, "expected 1 contour, got {}", cs.len());
+        let xs: Vec<f32> = cs[0].iter().map(|p| p[0]).filter(|&x| x > 3.0 && x < 4.0).collect();
+        assert!(xs.len() >= 2, "no left-edge crossing points");
+        let mn = xs.iter().cloned().fold(f32::MAX, f32::min);
+        let mx = xs.iter().cloned().fold(f32::MIN, f32::max);
+        assert!(mx - mn < 0.1, "left edge sawtooths: x in [{mn}, {mx}] (mirrored-crossing bug)");
+    }
+
+    #[test]
+    fn display_face_front_only_omits_back_and_tunnel() {
+        let sq = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+        let p = ExtrudeParams {
+            depth: 5.0,
+            bevel_type: 0,
+            bevel_depth: 0.0,
+            smoothness: 0,
+            front: true,
+            back: false,
+            tunnel: false,
+        };
+        let (pos, _n, faces) = extrude_glyph(&[sq], &p);
+        assert!(!faces.is_empty(), "front-only produced no faces");
+        // Every face must lie on the front cap plane (z≈0): no back cap, no walls.
+        for t in &faces {
+            for &i in t.iter() {
+                assert!(
+                    pos[i as usize][2].abs() < 1e-3,
+                    "front-only displayFace emitted non-front geometry at z={}",
+                    pos[i as usize][2]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn display_face_tunnel_only_has_no_cap_planes() {
+        let sq = vec![[0.0, 0.0], [10.0, 0.0], [10.0, 10.0], [0.0, 10.0]];
+        let p = ExtrudeParams {
+            depth: 5.0,
+            bevel_type: 0,
+            bevel_depth: 0.0,
+            smoothness: 0,
+            front: false,
+            back: false,
+            tunnel: true,
+        };
+        let (pos, _n, faces) = extrude_glyph(&[sq], &p);
+        assert!(!faces.is_empty(), "tunnel-only produced no faces");
+        // No face may be a flat cap (all three verts on z=0 or all on z=depth).
+        for t in &faces {
+            let zs: Vec<f32> = t.iter().map(|&i| pos[i as usize][2]).collect();
+            let all_front = zs.iter().all(|z| z.abs() < 1e-3);
+            let all_back = zs.iter().all(|z| (z - 5.0).abs() < 1e-3);
+            assert!(!all_front && !all_back, "tunnel-only emitted a cap face");
+        }
+    }
+}

--- a/vm-rust/src/director/chunks/w3d/types.rs
+++ b/vm-rust/src/director/chunks/w3d/types.rs
@@ -402,6 +402,11 @@ pub struct ModelResourceInfo {
     /// false, which is wrong for bottom_cap, so the creation site sets them).
     pub primitive_top_cap: bool,
     pub primitive_bottom_cap: bool,
+    /// newModelResource(name, #type, #facing) orientation: "" / "front" (outer
+    /// faces only), "back" (inner faces — e.g. a skybox cylinder you view from
+    /// inside), or "both". A "back"/"both" primitive must render two-sided so the
+    /// inward surface isn't backface-culled.
+    pub primitive_facing: String,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/vm-rust/src/director/chunks/xmedia_styled_text.rs
+++ b/vm-rust/src/director/chunks/xmedia_styled_text.rs
@@ -401,28 +401,23 @@ pub fn parse_xmed(data: &[u8]) -> Result<XmedStyledText, String> {
     };
     let doc_version = section1_data.doc_version;
 
-    // Parse text content - can be in Section 2 (possibly multi-chunk) OR Section 3
-    // Each Section 2 chunk represents one line of text. Join them with \r (Director's
-    // Mac-heritage line break character) to restore the original line structure.
-    // Compute chunk boundaries for adjusting character run positions later.
-    // When we join Section 2 chunks with \r, character run positions (which reference
-    // the original concatenated-without-\r text) need to be shifted forward.
-    // Each boundary is the cumulative length of chunks 0..i (without \r separators).
-    let section2_boundaries: Vec<u32> = if section2_texts.len() > 1 {
-        let mut boundaries = Vec::with_capacity(section2_texts.len() - 1);
-        let mut cumulative = 0u32;
-        for chunk_text in &section2_texts[..section2_texts.len() - 1] {
-            cumulative += chunk_text.len() as u32;
-            boundaries.push(cumulative);
-        }
-        boundaries
-    } else {
-        Vec::new()
-    };
+    // Parse text content - can be in Section 2 (possibly multi-chunk) OR Section 3.
+    // Section 0x0002 stores the text as one or more *byte-block* chunks (each block
+    // is `len,<bytes>\x03`, filled up to a size limit) — NOT one-line-per-chunk. The
+    // chunk bodies already contain their embedded \r line breaks (parse_section_3
+    // preserves them), so the full text is the byte-for-byte CONCATENATION of the
+    // chunk bodies. The previous code joined with "\r", which inserted a phantom
+    // line break at every chunk boundary: e.g. Rasterwerks' NAV.dm_acheron_bluffs
+    // nav-net (3 chunks) gained 2 empty lines, shifting every nav node after a
+    // boundary (node[44] read node 43's data, node[97] read node 95's) and breaking
+    // bot pathing. Because we concatenate without inserting separators, the Section 7
+    // character-run positions (which already reference the concatenated-without-\r
+    // text) line up as-is — so there are no boundaries to shift.
+    let section2_boundaries: Vec<u32> = Vec::new();
 
     let text_data = if !section2_texts.is_empty() {
         debug!("Found text in Section 2 ({} chunk(s))", section2_texts.len());
-        Section3Data { text: section2_texts.join("\r") }
+        Section3Data { text: section2_texts.concat() }
     } else if let Some(section3) = sections.get(&0x0003) {
         debug!("Found text in Section 3");
         parse_section_3(section3)?

--- a/vm-rust/src/director/enums.rs
+++ b/vm-rust/src/director/enums.rs
@@ -26,6 +26,12 @@ pub enum MemberType {
     Ole = (15),
     Font = (16),
     Shockwave3d = (17),
+    // Linked Movie (`#movie`). Standard Director numbers this 9, but this
+    // (reverse-engineered) enum already uses 9 for Shape, so the D5+ reader
+    // remaps a raw 9 to this variant explicitly (see chunks/cast_member.rs).
+    // The discriminant here is a sentinel that never appears as a real raw
+    // type id, so `from()` never produces Movie by accident.
+    Movie = (200),
     Unknown = (255),
 }
 

--- a/vm-rust/src/director/enums.rs
+++ b/vm-rust/src/director/enums.rs
@@ -456,10 +456,13 @@ impl From<&[u8]> for ShapeInfo {
 
         ShapeInfo {
             shape_type: match shape_type_raw {
+                // Director shape-member encoding: 1=rect, 2=roundRect, 3=oval,
+                // 4=line (matches the Lingo `shapeType` symbols #rect/#roundRect/
+                // #oval/#line). 0x0008 kept as an observed fallback for line.
                 0x0001 => ShapeType::Rect,
                 0x0002 => ShapeType::OvalRect,
                 0x0003 => ShapeType::Oval,
-                0x0008 => ShapeType::Line,
+                0x0004 | 0x0008 => ShapeType::Line,
                 _ => {
                     warn!("Unknown shape type: {:x}", shape_type_raw);
                     ShapeType::Unknown

--- a/vm-rust/src/director/enums.rs
+++ b/vm-rust/src/director/enums.rs
@@ -1213,8 +1213,24 @@ impl FlashInfo {
 
         let buffer_size = u32s[3];
         let direct_to_stage = u32s[4] != 0;
-        let reg_point = (u32s[6] as i32, u32s[7] as i32);
-        let flash_rect = (u32s[8] as i32, u32s[9] as i32, u32s[10] as i32, u32s[11] as i32);
+        // The FLSH struct stores geometry in classic QuickDraw order: a Point is
+        // (v, h) and a Rect is (top, left, bottom, right). Director's Lingo
+        // surface uses point(h, v) and rect(left, top, right, bottom), so swap
+        // the axes here. Verified against Director's Message window for
+        // bogey_nights' straw/longarm: raw u32s[6],[7] = (63, 109) →
+        // member.regPoint = point(109, 63); raw rect (0,0,86,138) →
+        // member width 138 × height 86 (matching the SWF's landscape FrameSize).
+        // Reading them un-swapped transposed the arm (86×138 portrait, reg 0,0).
+        let reg_point = (u32s[7] as i32, u32s[6] as i32); // (h, v) -> (x, y)
+        let flash_rect = (u32s[9] as i32, u32s[8] as i32, u32s[11] as i32, u32s[10] as i32); // (left, top, right, bottom)
+        // centerRegPoint lives in the FIXED section at u32s[5], NOT the variable
+        // section (the value read there — u32s[33] — is 1 for both centered and
+        // non-centered members, so it was the wrong field). Verified: pengapop's
+        // menuAdOnline (Director member.regPoint = center) has u32s[5]=1;
+        // bogey_nights' straw (Director member.regPoint = stored point) has
+        // u32s[5]=0. When set, Director resets the regPoint to the member rect's
+        // center — the getter AND the render use that center.
+        let center_reg_point = u32s[5] != 0;
         let bg_color = u32s[13];
         let image_enabled = u32s[14] != 0;
         let sound_enabled = u32s[15] != 0;
@@ -1255,7 +1271,10 @@ impl FlashInfo {
         let view_h = f32::from_bits(reader.read_u32().unwrap_or(0));
         let view_v = f32::from_bits(reader.read_u32().unwrap_or(0));
 
-        let center_reg_point = reader.read_u32().unwrap_or(0) != 0;
+        // This variable-section u32 is NOT centerRegPoint (that's u32s[5], read
+        // above) — it's 1 for both centered and non-centered members. Consume it
+        // to keep the reader aligned for the fields that follow.
+        let _var_unk = reader.read_u32().unwrap_or(0);
         let quality = match reader.read_u32().unwrap_or(3) {
             0 => FlashQuality::AutoHigh,
             1 => FlashQuality::AutoMedium,

--- a/vm-rust/src/director/file.rs
+++ b/vm-rust/src/director/file.rs
@@ -1259,7 +1259,10 @@ fn get_chunk_data(
                         .cached_chunk_views
                         .insert(id, uncomp_buf.to_vec());
                 } else if info.compression_id == FONTMAP_COMPRESSION_GUID {
-                    warn!(
+                    // Non-fatal: the chunk is stored raw and load continues.
+                    // debug!, not warn! — fires per FONTMAP chunk on load and
+                    // floods the browser console (which retains every entry).
+                    debug!(
                         "FONTMAP compression not implemented — skipping chunk {}",
                         id
                     );
@@ -1273,7 +1276,15 @@ fn get_chunk_data(
                     chunk_container.cached_chunk_views.insert(id, raw.clone());
                     return Ok(raw);
                 } else {
-                    if info.compression_id != NULL_COMPRESSION_GUID {
+                    // NULL = uncompressed; SWA = Shockwave Audio (MP3) members,
+                    // whose compressed bytes are correctly stored raw for the
+                    // sound decoder. Both are expected here — only warn for a
+                    // genuinely-unknown codec (and even then load continues with
+                    // the raw bytes, so it's non-fatal).
+                    if info.compression_id != NULL_COMPRESSION_GUID
+                        && info.compression_id != SWA_COMPRESSION_GUID
+                        && info.compression_id != SWA_COMPRESSION_GUID2
+                    {
                         warn!("Unhandled compression type {}", info.compression_id)
                     }
                     chunk_container

--- a/vm-rust/src/director/guid.rs
+++ b/vm-rust/src/director/guid.rs
@@ -58,6 +58,25 @@ pub const NULL_COMPRESSION_GUID: MoaID =
     MoaID::new(0xAC99982E, 0x005D, 0x0D50, 0x00080000, 0x347A3707);
 pub const SND_COMPRESSION_GUID: MoaID =
     MoaID::new(0x7204A889, 0xAFD0, 0x11CF, 0xA00022A2, 0x4C445323);
+// SWA (Shockwave Audio / MP3) compression, aka the "SWA Decompression Xtra"
+// codec. This is the SAME class as SND_COMPRESSION_GUID above, but with the
+// trailing 8 GUID bytes read in the other order (`from_reader` treats them as
+// endian-sensitive u32s, so a big-endian RIFX movie yields these values while a
+// little-endian XFIR movie yields the swapped SND_COMPRESSION_GUID form — the
+// same GUID/GUID2 split ZLIB needs). Verified from nomiss.dcr's Fcdr table:
+// `7204a889-afd0-11cf-a22200a0-2453444c` next to "requires the SWA Decompression
+// Xtra". SWA members store their MP3 bytes raw for the sound decoder, so this is
+// recognised only to store-raw-without-warning — NOT routed through the SND
+// (`from_snd_chunk`) path, which would corrupt the audio.
+pub const SWA_COMPRESSION_GUID: MoaID =
+    MoaID::new(0x7204A889, 0xAFD0, 0x11CF, 0xA22200A0, 0x2453444C);
+// Little-endian (XFIR) read of the same on-disk SWA GUID bytes — the trailing 8
+// bytes `A2 22 00 A0 24 53 44 4C` read as u32s give A00022A2 / 4C445324 under a
+// little-endian reader (XFIR) vs A22200A0 / 2453444C under big-endian (RIFX),
+// exactly like ZLIB_COMPRESSION_GUID vs …GUID2. Verified from 15love_hs.dcr
+// (XFIR/MDGF) whose Fcdr strings say "SWA Decompressor Xtra from Macromedia".
+pub const SWA_COMPRESSION_GUID2: MoaID =
+    MoaID::new(0x7204A889, 0xAFD0, 0x11CF, 0xA00022A2, 0x4C445324);
 pub const ZLIB_COMPRESSION_GUID: MoaID =
     MoaID::new(0xAC99E904, 0x0070, 0x0B36, 0x00080000, 0x347A3707);
 pub const ZLIB_COMPRESSION_GUID2: MoaID =

--- a/vm-rust/src/director/lingo/datum.rs
+++ b/vm-rust/src/director/lingo/datum.rs
@@ -884,6 +884,12 @@ impl Datum {
         match d {
             Datum::Int(n) => Ok((*n as f64, false)),
             Datum::Float(f) => Ok((*f, true)),
+            // Director coerces VOID to 0 in numeric contexts, so
+            // `point(h, V)` with an uninitialized property still builds a
+            // valid point. g349's "show treasure complete item bhv" relies on
+            // this: its `V` property is VOID until the item is activated, yet
+            // every exitFrame ends with `my.loc = point(h, V)`.
+            Datum::Void => Ok((0.0, false)),
             other => Err(ScriptError::new(format!(
                 "Point/Rect component must be numeric, got {}",
                 other.type_str()

--- a/vm-rust/src/director/lingo/datum.rs
+++ b/vm-rust/src/director/lingo/datum.rs
@@ -128,6 +128,14 @@ pub type XtraInstanceId = u32;
 #[derive(Clone, Debug)]
 pub struct FlashObjectRef {
     pub path: String,
+    /// Optional Director sprite binding (1-based sprite number, 0 = unbound).
+    /// When a Flash object handle is obtained via
+    /// `getVariable(sprite(N), path, 0)` we record N here so later calls
+    /// (`gDemoFlash.play()`) dispatch to that exact sprite's Ruffle instance —
+    /// even if the sprite's cast member wasn't resolvable when the handle was
+    /// taken (a beginSprite can run before the member is committed, which used
+    /// to yield a VOID handle and crash on the deferred `.play()`). When 0, the
+    /// sprite is resolved from cast_lib/cast_member via find_sprite_for_flash_member.
     pub instance_id: u32,
     pub cast_lib: i32,
     pub cast_member: i32,
@@ -188,6 +196,26 @@ impl FlashObjectRef {
             instance_id: 0,
             cast_lib: 0,
             cast_member: 0,
+        }
+    }
+
+    /// Build a handle bound to a specific Director sprite (see `instance_id`).
+    /// `sprite_num` should be the 1-based sprite/channel number; 0 means unbound.
+    pub fn from_path_with_sprite(path: &str, cast_lib: i32, cast_member: i32, sprite_num: i32) -> Self {
+        Self {
+            path: path.to_string(),
+            instance_id: if sprite_num > 0 { sprite_num as u32 } else { 0 },
+            cast_lib,
+            cast_member,
+        }
+    }
+
+    /// The bound sprite number, if this handle was taken from a specific sprite.
+    pub fn bound_sprite(&self) -> Option<i32> {
+        if self.instance_id != 0 {
+            Some(self.instance_id as i32)
+        } else {
+            None
         }
     }
 }

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -315,6 +315,22 @@ impl JsApi {
     /// Collects all chunk IDs that are transitive descendants of `root_id` in the KeyTable,
     /// plus root_id itself. This walks the parent→children relationship recursively:
     /// KeyTable entries map section_id (child) → cast_id (parent).
+    /// Movie-wide structural chunks that belong to the movie, not to any cast.
+    ///
+    /// In a RIFX file the movie-root owner id (1024) is *also* the first
+    /// internal cast's id, and these chunks are owned by 1024. Walking a
+    /// cast's KeyTable descendants from `cast.id` therefore sweeps them up,
+    /// which made `get_movie_top_level_chunks` exclude the entire movie (it
+    /// left only the ownerless ILS/KEY* — SpongeBob "JellyFishin'"). Treating
+    /// these fourccs as never-cast-content keeps them in the movie view and
+    /// out of the cast views.
+    fn is_movie_level_fourcc(fourcc: u32) -> bool {
+        matches!(
+            fourcc_to_string(fourcc).trim(),
+            "DRCF" | "VWCF" | "MCsL" | "Sord" | "VWFI" | "VWLB" | "VWSC" | "FXmp" | "XTRl" | "ccl"
+        )
+    }
+
     fn collect_cast_descendants(
         root_id: u32,
         children_map: &HashMap<u32, Vec<u32>>,
@@ -411,6 +427,17 @@ impl JsApi {
             cast_chunk_ids.insert(*section_id);
         }
 
+        // Drop movie-level structural chunks that got swept in via the
+        // owner-id-1024 collision (see is_movie_level_fourcc) so they don't
+        // show up under this cast.
+        cast_chunk_ids.retain(|id| {
+            chunk_container
+                .chunk_info
+                .get(id)
+                .map(|ci| !Self::is_movie_level_fourcc(ci.fourcc))
+                .unwrap_or(true)
+        });
+
         // Emit all chunks that belong to this cast
         for chunk_id in &cast_chunk_ids {
             let chunk_info = match chunk_container.chunk_info.get(chunk_id) {
@@ -481,6 +508,18 @@ impl JsApi {
                 cast_section_ids.insert(*section_id);
             }
         }
+
+        // Don't exclude movie-level structural chunks (config, score, cast
+        // list, etc.). They're owned by the movie-root id 1024 which collides
+        // with the first cast's id, so the descendant walk above wrongly
+        // captured them — leaving the movie view with only ILS/KEY*.
+        cast_section_ids.retain(|id| {
+            chunk_container
+                .chunk_info
+                .get(id)
+                .map(|ci| !Self::is_movie_level_fourcc(ci.fourcc))
+                .unwrap_or(true)
+        });
 
         // Build owner_map from KeyTable
         let owner_map: HashMap<u32, u32> = key_table

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -250,7 +250,7 @@ extern "C" {
     pub fn onDatumSnapshot(datum_id: DatumId, data: js_sys::Object);
     pub fn onScriptInstanceSnapshot(script_ref: ScriptInstanceId, data: js_sys::Object);
     pub fn onExternalEvent(event: &str);
-    pub fn onFlashMemberLoaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool);
+    pub fn onFlashMemberLoaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool, asserted_frame: i32);
     pub fn onFlashMemberUnloaded(sprite_num: i32);
     pub fn onStageSizeChanged(width: u32, height: u32, center: bool);
 }
@@ -285,8 +285,8 @@ impl JsApi {
     pub fn dispatch_clear_timeouts() {
         onClearTimeouts();
     }
-    pub fn dispatch_flash_member_loaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool) {
-        onFlashMemberLoaded(sprite_num, cast_lib, cast_member, swf_data, width, height, paused_at_start);
+    pub fn dispatch_flash_member_loaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool, asserted_frame: i32) {
+        onFlashMemberLoaded(sprite_num, cast_lib, cast_member, swf_data, width, height, paused_at_start, asserted_frame);
     }
     pub fn dispatch_flash_member_unloaded(sprite_num: i32) {
         onFlashMemberUnloaded(sprite_num);
@@ -1937,7 +1937,7 @@ impl JsApi {
     pub fn dispatch_clear_timeouts() {}
     pub fn dispatch_movie_loaded(_: &DirectorFile) {}
     pub fn dispatch_movie_load_failed(_: &str, _: &str) {}
-    pub fn dispatch_flash_member_loaded(_: i32, _: i32, _: i32, _: &[u8], _: u32, _: u32, _: bool) {}
+    pub fn dispatch_flash_member_loaded(_: i32, _: i32, _: i32, _: &[u8], _: u32, _: u32, _: bool, _: i32) {}
     pub fn dispatch_flash_member_unloaded(_: i32) {}
     pub fn dispatch_stage_size_changed(_: u32, _: u32, _: bool) {}
     pub fn dispatch_cast_name_changed(_: u32) {}

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -1167,6 +1167,16 @@ impl JsApi {
                 member_map.str_set("regX", &JsValue::from(bitmap_data.reg_point.0));
                 member_map.str_set("regY", &JsValue::from(bitmap_data.reg_point.1));
             }
+            CastMemberType::Sound(sound_member) => {
+                member_map.str_set("sampleRate", &JsValue::from(sound_member.info.sample_rate));
+                member_map.str_set("channels", &JsValue::from(sound_member.info.channels));
+                member_map.str_set("bitsPerSample", &JsValue::from(sound_member.info.sample_size));
+                member_map.str_set("sampleCount", &JsValue::from(sound_member.info.sample_count));
+                member_map.str_set("duration", &JsValue::from(sound_member.info.duration));
+                member_map.str_set("loop", &JsValue::from_bool(sound_member.info.loop_enabled));
+                member_map.str_set("codec", &safe_js_string(&sound_member.sound.codec()));
+                member_map.str_set("dataSize", &JsValue::from(sound_member.sound.data().len() as u32));
+            }
             CastMemberType::FilmLoop(film_loop_data) => {
                 member_map.str_set("width", &JsValue::from(film_loop_data.info.width));
                 member_map.str_set("height", &JsValue::from(film_loop_data.info.height));

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -300,6 +300,14 @@ impl JsApi {
         onFlashResetAll();
     }
     pub fn dispatch_stage_size_changed(width: u32, height: u32, center: bool) {
+        // Only the host player (id 0) owns the frontend stage. A nested `#movie`
+        // sub-player renders headless into a bitmap; if it sets `the stage.rect`
+        // / `drawRect` / `centerStage` it must NOT resize the real frontend stage
+        // (that caused the host stage to snap to the sub's dimensions → "zoomed"
+        // flicker, since the sub re-set its rect during play).
+        if unsafe { crate::player::ACTIVE_PLAYER_ID } != 0 {
+            return;
+        }
         onStageSizeChanged(width, height, center);
     }
     pub fn dispatch_movie_loaded(dir_file: &DirectorFile) {
@@ -921,16 +929,16 @@ impl JsApi {
     }
 
     pub fn dispatch_cast_name_changed(cast_number: u32) {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
             let cast = player.movie.cast_manager.get_cast(cast_number).unwrap();
             onCastLibNameChanged(cast_number, &cast.name);
         });
     }
 
     pub fn dispatch_cast_list_changed() {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
             let names = player
                 .movie
                 .cast_manager
@@ -949,8 +957,8 @@ impl JsApi {
     }
 
     pub fn dispatch_cast_member_list_changed(cast_number: u32) {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
             let cast = match player.movie.cast_manager.get_cast(cast_number) {
                 Ok(cast) => cast,
                 Err(_) => return,
@@ -968,8 +976,8 @@ impl JsApi {
     }
 
     pub fn dispatch_cast_member_changed(member_ref: CastMemberRef) {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
             let subscribed_members = &player.subscribed_member_refs;
             if !subscribed_members.contains(&member_ref) {
                 return;
@@ -994,8 +1002,8 @@ impl JsApi {
     }
 
     pub fn on_cast_member_name_changed(slot_number: u32) {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
 
             if player.is_subscribed_to_channel_names {
                 for channel in player.movie.score.channels.iter() {
@@ -1018,8 +1026,8 @@ impl JsApi {
     }
 
     pub fn dispatch_score_changed() {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
 
             let snapshot = Self::get_score_snapshot(player, &player.movie.score);
             onScoreChanged(snapshot.to_js_object());
@@ -1042,8 +1050,8 @@ impl JsApi {
         });
 
         if selected_channel == Some(channel) {
-            async_std::task::spawn_local(async move {
-                let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+            crate::player::spawn_player_local(async move {
+                let player = unsafe { crate::player::player_ref() };
                 let snapshot = Self::get_channel_snapshot(player, &channel);
                 onChannelChanged(channel, snapshot.to_js_object());
             });
@@ -1462,8 +1470,8 @@ impl JsApi {
     }
 
     pub fn dispatch_channel_name_changed(channel: i16) {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
 
             if player.is_subscribed_to_channel_names {
                 let display_name =
@@ -1906,8 +1914,8 @@ impl JsApi {
     }
 
     pub fn dispatch_breakpoint_list_changed() {
-        async_std::task::spawn_local(async move {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        crate::player::spawn_player_local(async move {
+            let player = unsafe { crate::player::player_ref() };
             let breakpoints = player
                 .breakpoint_manager
                 .breakpoints

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -252,6 +252,7 @@ extern "C" {
     pub fn onExternalEvent(event: &str);
     pub fn onFlashMemberLoaded(sprite_num: i32, cast_lib: i32, cast_member: i32, swf_data: &[u8], width: u32, height: u32, paused_at_start: bool, asserted_frame: i32);
     pub fn onFlashMemberUnloaded(sprite_num: i32);
+    pub fn onFlashResetAll();
     pub fn onStageSizeChanged(width: u32, height: u32, center: bool);
 }
 
@@ -290,6 +291,13 @@ impl JsApi {
     }
     pub fn dispatch_flash_member_unloaded(sprite_num: i32) {
         onFlashMemberUnloaded(sprite_num);
+    }
+    /// Tear down every live Flash/Ruffle instance. Called on movie reset so
+    /// a previous movie's Ruffle players (their per-frame capture RAF loops
+    /// and still-playing SWF audio) don't leak across a movie switch — the
+    /// per-sprite unload path only fires for sprites the new frame changed.
+    pub fn dispatch_flash_reset_all() {
+        onFlashResetAll();
     }
     pub fn dispatch_stage_size_changed(width: u32, height: u32, center: bool) {
         onStageSizeChanged(width, height, center);
@@ -1939,6 +1947,7 @@ impl JsApi {
     pub fn dispatch_movie_load_failed(_: &str, _: &str) {}
     pub fn dispatch_flash_member_loaded(_: i32, _: i32, _: i32, _: &[u8], _: u32, _: u32, _: bool, _: i32) {}
     pub fn dispatch_flash_member_unloaded(_: i32) {}
+    pub fn dispatch_flash_reset_all() {}
     pub fn dispatch_stage_size_changed(_: u32, _: u32, _: bool) {}
     pub fn dispatch_cast_name_changed(_: u32) {}
     pub fn dispatch_cast_list_changed() {}

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -472,12 +472,30 @@ pub fn player_print_filmloop_sprites(cast_lib: i32, cast_member: i32) {
     });
 }
 
+/// Resolve a canvas-space mouse event to movie coordinates — EXCEPT during FPS
+/// mouse-look (pointer lock). While the movie wants pointer lock it drives the
+/// camera from `mouse_move_delta` and recenters `mouse_loc` every frame; the
+/// browser also freezes the cursor at the lock-engage point, so a click's absolute
+/// position is meaningless and would slam `mouse_loc` away from that center — a
+/// one-frame delta spike that jolts the camera on EVERY click (left or right).
+/// In that mode keep the existing delta-managed `mouse_loc` so the click only
+/// registers the button, not a phantom move.
+fn mouse_event_loc(x: f64, y: f64) -> (i32, i32) {
+    reserve_player_ref(|p| {
+        if p.wants_pointer_lock {
+            p.mouse_loc
+        } else {
+            // Invert the stage auto-scale so mouseH/mouseV land in movie coordinates,
+            // matching where sprites live in Lingo-facing state. No-op when scale=1.
+            let (mx, my) = crate::player::stage::canvas_to_movie_coords(p, x, y);
+            (mx.to_i32().unwrap(), my.to_i32().unwrap())
+        }
+    })
+}
+
 #[wasm_bindgen]
 pub fn mouse_down(x: f64, y: f64) {
-    // Invert the stage auto-scale so mouseH/mouseV land in movie coordinates,
-    // matching where sprites live in Lingo-facing state. No-op when scale=1.
-    let (mx, my) = reserve_player_ref(|p| crate::player::stage::canvas_to_movie_coords(p, x, y));
-    let (ix, iy) = (mx.to_i32().unwrap(), my.to_i32().unwrap());
+    let (ix, iy) = mouse_event_loc(x, y);
     reserve_player_mut(|player| {
         player.mouse_loc = (ix, iy);
         player.movie.mouse_down = true;
@@ -487,8 +505,7 @@ pub fn mouse_down(x: f64, y: f64) {
 
 #[wasm_bindgen]
 pub fn mouse_up(x: f64, y: f64) {
-    let (mx, my) = reserve_player_ref(|p| crate::player::stage::canvas_to_movie_coords(p, x, y));
-    let (ix, iy) = (mx.to_i32().unwrap(), my.to_i32().unwrap());
+    let (ix, iy) = mouse_event_loc(x, y);
     reserve_player_mut(|player| {
         player.mouse_loc = (ix, iy);
         player.movie.mouse_down = false;
@@ -498,6 +515,15 @@ pub fn mouse_up(x: f64, y: f64) {
 
 #[wasm_bindgen]
 pub fn mouse_move(x: f64, y: f64) {
+    // During FPS mouse-look the camera is driven by `mouse_move_delta` and the movie
+    // recenters `mouse_loc` each frame. An absolute move here — e.g. right after
+    // pointer lock exits on Esc, before the movie disables mouse-look, when the cursor
+    // reappears far from center — would inject a large one-frame delta and snap the
+    // view ("camera tilts up on focus loss"). Ignore absolute moves while mouse-look
+    // is active; the delta path owns the camera.
+    if reserve_player_ref(|p| p.wants_pointer_lock) {
+        return;
+    }
     let (mx, my) = reserve_player_ref(|p| crate::player::stage::canvas_to_movie_coords(p, x, y));
     let (ix, iy) = (mx.to_i32().unwrap(), my.to_i32().unwrap());
     reserve_player_mut(|player| {
@@ -511,8 +537,7 @@ pub fn mouse_move(x: f64, y: f64) {
 /// is updated alongside so `the mouseLoc` reflects the click point.
 #[wasm_bindgen]
 pub fn right_mouse_down(x: f64, y: f64) {
-    let (mx, my) = reserve_player_ref(|p| crate::player::stage::canvas_to_movie_coords(p, x, y));
-    let (ix, iy) = (mx.to_i32().unwrap(), my.to_i32().unwrap());
+    let (ix, iy) = mouse_event_loc(x, y);
     reserve_player_mut(|player| {
         player.mouse_loc = (ix, iy);
         player.movie.right_mouse_down = true;
@@ -522,8 +547,7 @@ pub fn right_mouse_down(x: f64, y: f64) {
 
 #[wasm_bindgen]
 pub fn right_mouse_up(x: f64, y: f64) {
-    let (mx, my) = reserve_player_ref(|p| crate::player::stage::canvas_to_movie_coords(p, x, y));
-    let (ix, iy) = (mx.to_i32().unwrap(), my.to_i32().unwrap());
+    let (ix, iy) = mouse_event_loc(x, y);
     reserve_player_mut(|player| {
         player.mouse_loc = (ix, iy);
         player.movie.right_mouse_down = false;
@@ -537,12 +561,16 @@ pub fn wants_pointer_lock() -> bool {
     reserve_player_ref(|player| player.wants_pointer_lock)
 }
 
-/// Mouse move with delta values (for pointer lock mode)
-/// The delta is added to the current mouse_loc (which the game resets to center each frame)
+/// Mouse move with delta values (for pointer lock mode).
+/// The delta is added to the current mouse_loc (which the game resets to center each
+/// frame), so `the mouseH` tracks pointer-lock movementX. X must be ADDED, not
+/// subtracted: `the mouseH` increases to the right (screen coords), so moving the
+/// mouse right (movementX > 0) must increase mouseH → the movie yaws right. The
+/// previous `-= dx` inverted horizontal look (move left → turn right).
 #[wasm_bindgen]
 pub fn mouse_move_delta(dx: f64, dy: f64) {
     reserve_player_mut(|player| {
-        player.mouse_loc.0 -= dx.to_i32().unwrap();
+        player.mouse_loc.0 += dx.to_i32().unwrap();
         player.mouse_loc.1 += dy.to_i32().unwrap();
     });
     let (x, y) = reserve_player_ref(|player| player.mouse_loc);

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -331,6 +331,84 @@ pub fn player_print_member_bitmap_hex(cast_lib: i32, cast_member: i32) {
     }));
 }
 
+/// Dev UI sound preview: dump a sound member's decoded header fields plus the
+/// first 256 raw bytes (hex + ASCII) to the browser console. Lets a sound that
+/// "doesn't play" be identified by its real format magic (RIFF/WAV, FORM/AIFF,
+/// ID3 or 0xFF Ex = MP3, otherwise raw PCM) versus what the member metadata
+/// claims. Read-only, so it resolves the member synchronously.
+#[wasm_bindgen]
+pub fn player_print_member_sound_hex(cast_lib: i32, cast_member: i32) {
+    use crate::player::{cast_member::CastMemberType, reserve_player_ref};
+    reserve_player_ref(|player| {
+        let member_ref = CastMemberRef { cast_lib, cast_member };
+        let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) else {
+            web_sys::console::warn_1(
+                &format!("[sound-preview] member {}:{} not found", cast_lib, cast_member).into(),
+            );
+            return;
+        };
+        let CastMemberType::Sound(snd) = &member.member_type else {
+            web_sys::console::warn_1(
+                &format!(
+                    "[sound-preview] member {}:{} '{}' is not a sound member",
+                    cast_lib, cast_member, member.name
+                )
+                .into(),
+            );
+            return;
+        };
+        let data = snd.sound.data();
+        let info = &snd.info;
+        let codec = snd.sound.codec();
+        let big_endian = snd.sound.big_endian_data();
+        let magic = if data.len() >= 4 && &data[0..4] == b"RIFF" {
+            "RIFF/WAV"
+        } else if data.len() >= 4 && &data[0..4] == b"FORM" {
+            "AIFF (FORM)"
+        } else if data.len() >= 3 && &data[0..3] == b"ID3" {
+            "MP3 (ID3 tag)"
+        } else if data.len() >= 2 && data[0] == 0xFF && (data[1] & 0xE0) == 0xE0 {
+            "MP3 frame (FF Ex)"
+        } else {
+            "raw / PCM?"
+        };
+        web_sys::console::log_1(
+            &format!(
+                "🎧 SOUND {}:{} '{}' — {} Hz, {} ch, {}-bit, samples={}, dur={}ms, loop={}, codec='{}', big_endian={} — data={} bytes — magic={}",
+                cast_lib, cast_member, member.name,
+                info.sample_rate, info.channels, info.sample_size, info.sample_count,
+                info.duration, info.loop_enabled, codec, big_endian,
+                data.len(), magic
+            )
+            .into(),
+        );
+        let n = data.len().min(256);
+        let mut hex = String::with_capacity(n * 3 + n / 16);
+        let mut ascii = String::with_capacity(n + n / 16);
+        for (i, &b) in data[..n].iter().enumerate() {
+            hex.push_str(&format!("{:02X} ", b));
+            ascii.push(if (0x20..0x7F).contains(&b) { b as char } else { '.' });
+            if (i + 1) % 16 == 0 {
+                hex.push('\n');
+                ascii.push('\n');
+            }
+        }
+        web_sys::console::log_1(&format!("🎧 first {} bytes (hex):\n{}", n, hex).into());
+        web_sys::console::log_1(&format!("🎧 first {} bytes (ascii):\n{}", n, ascii).into());
+    });
+}
+
+/// Dev UI sound preview: play a sound member on channel 1 via the real
+/// puppetSound path. Routed through the command queue so playback starts at a
+/// safe point; the triggering button click satisfies the audio-gesture gate.
+#[wasm_bindgen]
+pub fn player_play_member_sound(cast_lib: i32, cast_member: i32) {
+    player_dispatch(PlayerVMCommand::PlayMemberSound(CastMemberRef {
+        cast_lib,
+        cast_member,
+    }));
+}
+
 /// Dump every authored child sprite inside a filmloop member to the browser
 /// console. Lingo can't reach a filmloop's child sprites directly (the
 /// member.media is opaque), so this exposes the parsed score state

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -1425,6 +1425,42 @@ pub fn dispatch_flash_event(cast_lib: i32, cast_member: i32, body: String) -> bo
     true
 }
 
+/// Execute a `getURL("lingo: …")` navigation body from a Flash SWF as a
+/// Lingo command, matching Director's Flash Asset Xtra convention.
+///
+/// Director's Flash sprite interprets a `getURL` whose URL begins with the
+/// `lingo:` scheme by evaluating the remainder as a Lingo command in the
+/// movie's global handler context — exactly like `do "…"`. Pengapop's
+/// titleScreen SWF uses this for every button: the Play button navigates to
+/// `lingo:startGameTimed`, the hover/click sounds to
+/// `lingo:bdPlaySound(#generalSound,"tink")`, etc.
+///
+/// The body is everything after the `lingo:` scheme; we run it through the
+/// same `eval_lingo_command` path the debugger console and `do` use, so it
+/// supports bare handler calls (`startGameTimed`) and calls with args
+/// (`bdPlaySound(#generalSound,"tink")`). Returns true so the JS caller can
+/// swallow the navigation (nothing should actually open a URL).
+#[wasm_bindgen]
+pub fn dispatch_flash_lingo(body: String) -> bool {
+    let trimmed = body.trim().to_string();
+    if trimmed.is_empty() {
+        warn!("[dispatch_flash_lingo] empty lingo body");
+        return false;
+    }
+    // Run asynchronously (like eval_command): the caller is inside a
+    // synchronous Flash mouse-event forward, so we must let the current
+    // command unwind before reserving the player to run the handler.
+    spawn_local(async move {
+        let result = eval_lingo_command(trimmed).await;
+        if let Err(err) = result {
+            reserve_player_ref(|player| {
+                JsApi::dispatch_script_error(player, &err);
+            });
+        }
+    });
+    true
+}
+
 #[wasm_bindgen]
 pub fn set_lingo_script_property(cast_lib: i32, cast_member: i32, prop_name: String, value: JsValue) -> bool {
     use director::lingo::datum::Datum;

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -579,6 +579,7 @@ pub fn mouse_down(x: f64, y: f64) {
         player.movie.mouse_down = true;
     });
     player_dispatch(PlayerVMCommand::MouseDown((ix, iy)));
+    forward_mouse_to_nested(0, ix, iy);
 }
 
 #[wasm_bindgen]
@@ -589,6 +590,92 @@ pub fn mouse_up(x: f64, y: f64) {
         player.movie.mouse_down = false;
     });
     player_dispatch(PlayerVMCommand::MouseUp((ix, iy)));
+    forward_mouse_to_nested(1, ix, iy);
+}
+
+/// Forward a mouse event to a nested `#movie` sub-player when the cursor is over
+/// its sprite: find the on-stage #movie sprite whose rect contains `(ix,iy)`, map
+/// the point into the sub-player's stage rect, set the sub's `mouse_loc`, and
+/// dispatch the event to the sub's own command queue so its behaviours
+/// (`checkMouse` / `on mouseDown`) respond. `kind`: 0=down, 1=up, 2=move.
+fn forward_mouse_to_nested(kind: u8, ix: i32, iy: i32) {
+    use crate::player::{
+        nested_player_id, reserve_player_mut, reserve_player_ref, ACTIVE_PLAYER_ID, NESTED_PLAYERS,
+    };
+    let target = reserve_player_ref(|host| {
+        for channel in &host.movie.score.channels {
+            let Some(member_ref) = channel.sprite.member.as_ref() else {
+                continue;
+            };
+            let Some(id) = nested_player_id(member_ref) else {
+                continue;
+            };
+            if !channel.sprite.visible {
+                continue;
+            }
+            let rect = crate::player::score::get_concrete_sprite_rect(host, &channel.sprite);
+            if ix >= rect.left && ix < rect.right && iy >= rect.top && iy < rect.bottom {
+                let sub_rect = unsafe {
+                    NESTED_PLAYERS
+                        .get(id - 1)
+                        .and_then(|o| o.as_ref())
+                        .map(|s| s.movie.rect.clone())
+                };
+                if let Some(sr) = sub_rect {
+                    let sw = rect.width().max(1);
+                    let sh = rect.height().max(1);
+                    // The sub renders 0-origin (the composite uses ortho at the
+                    // sub's WIDTH/HEIGHT, ignoring movie.rect's left/top — g349's
+                    // rect origin is (20,20) but its sprites live at 0..600). Map
+                    // the click to that same 0-origin space; adding sr.left/top
+                    // shifted every click ~20px and made small buttons (Restart /
+                    // Quit) miss.
+                    let sx = (ix - rect.left) * sr.width() / sw;
+                    let sy = (iy - rect.top) * sr.height() / sh;
+                    return Some((id, sx, sy));
+                }
+            }
+        }
+        None
+    });
+    let Some((id, sx, sy)) = target else {
+        return;
+    };
+    // Update the sub-player's mouse STATE synchronously (so polling handlers like
+    // the DGS `checkMouse` see `the mouseLoc`/`the mouseDown` immediately) AND
+    // dispatch the event into the sub's own command queue so its sprite
+    // behaviours fire — the Restart button is `on mouseDown me` and Quit is
+    // `on mouseUp me`, which only run on an actual event, not state polling.
+    // player_dispatch routes to the ACTIVE player's queue while ACTIVE_PLAYER_ID
+    // = id; the sub's command loop resolves instance ids against the sub's own
+    // allocator (de-globalization is in place, so the earlier cross-boundary
+    // concern no longer applies).
+    let prev = unsafe { ACTIVE_PLAYER_ID };
+    unsafe {
+        ACTIVE_PLAYER_ID = id;
+    }
+    reserve_player_mut(|sub| {
+        sub.mouse_loc = (sx, sy);
+        match kind {
+            0 => sub.movie.mouse_down = true,
+            1 => sub.movie.mouse_down = false,
+            _ => {}
+        }
+    });
+    match kind {
+        0 => player_dispatch(PlayerVMCommand::MouseDown((sx, sy))),
+        1 => player_dispatch(PlayerVMCommand::MouseUp((sx, sy))),
+        // MouseMove drives the sub's rollover events (mouseEnter / mouseWithin /
+        // mouseLeave) — dispatched in the MouseMove command handler by hover
+        // hit-testing. Without this the sub never fires mouseWithin, so
+        // hold-to-scroll behaviours ("scrolldisplay arrow bhv") highlight but
+        // never scroll.
+        2 => player_dispatch(PlayerVMCommand::MouseMove((sx, sy))),
+        _ => {}
+    }
+    unsafe {
+        ACTIVE_PLAYER_ID = prev;
+    }
 }
 
 #[wasm_bindgen]
@@ -608,6 +695,7 @@ pub fn mouse_move(x: f64, y: f64) {
         player.mouse_loc = (ix, iy);
     });
     player_dispatch(PlayerVMCommand::MouseMove((ix, iy)));
+    forward_mouse_to_nested(2, ix, iy);
 }
 
 /// Right-mouse-button down. Tracked via a separate flag because Director
@@ -662,6 +750,7 @@ pub fn key_down(key: String, code: u16) {
     reserve_player_mut(|player| {
         player.keyboard_manager.key_down(key.clone(), code);
     });
+    forward_key_to_nested(true, &key, code);
     player_dispatch(PlayerVMCommand::KeyDown(key, code));
 }
 
@@ -672,7 +761,48 @@ pub fn key_up(key: String, code: u16) {
     reserve_player_mut(|player| {
         player.keyboard_manager.key_up(&key, code);
     });
+    forward_key_to_nested(false, &key, code);
     player_dispatch(PlayerVMCommand::KeyUp(key, code));
+}
+
+/// Mirror the keyboard state into every on-stage nested `#movie` sub-player so
+/// its polling `keyPressed(code)` (e.g. g349's arrow-key list scrolling) sees
+/// the same keys as the host. State-only, like `forward_mouse_to_nested` — no
+/// event dispatch across the player boundary (that resolves instance ids against
+/// the wrong allocator). Keyboard has no cursor position, so it goes to all
+/// visible nested sub-players (typically one active game).
+fn forward_key_to_nested(is_down: bool, key: &str, code: u16) {
+    use crate::player::{nested_player_id, reserve_player_mut, reserve_player_ref, ACTIVE_PLAYER_ID};
+    let ids = reserve_player_ref(|host| {
+        let mut ids: Vec<usize> = Vec::new();
+        for channel in &host.movie.score.channels {
+            if !channel.sprite.visible {
+                continue;
+            }
+            if let Some(id) = channel.sprite.member.as_ref().and_then(nested_player_id) {
+                if !ids.contains(&id) {
+                    ids.push(id);
+                }
+            }
+        }
+        ids
+    });
+    for id in ids {
+        let prev = unsafe { ACTIVE_PLAYER_ID };
+        unsafe {
+            ACTIVE_PLAYER_ID = id;
+        }
+        reserve_player_mut(|sub| {
+            if is_down {
+                sub.keyboard_manager.key_down(key.to_string(), code);
+            } else {
+                sub.keyboard_manager.key_up(key, code);
+            }
+        });
+        unsafe {
+            ACTIVE_PLAYER_ID = prev;
+        }
+    }
 }
 
 // Picking mode commands bypass the command queue for synchronous access.
@@ -1098,8 +1228,8 @@ pub fn trigger_alert_hook() {
 
 #[wasm_bindgen]
 pub fn subscribe_to_channel_names() {
-    spawn_local(async {
-        let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+    crate::player::spawn_player_local(async {
+        let player = unsafe { crate::player::player_mut() };
 
         player.is_subscribed_to_channel_names = true;
         for channel in &player.movie.score.channels {
@@ -1110,8 +1240,8 @@ pub fn subscribe_to_channel_names() {
 
 #[wasm_bindgen]
 pub fn unsubscribe_from_channel_names() {
-    spawn_local(async {
-        let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+    crate::player::spawn_player_local(async {
+        let player = unsafe { crate::player::player_mut() };
 
         player.is_subscribed_to_channel_names = false;
     });
@@ -1121,7 +1251,7 @@ pub fn unsubscribe_from_channel_names() {
 pub fn provide_net_task_data(task_id: u32, data: Vec<u8>) {
     // Directly fulfill the task without going through the command queue to avoid deadlock
     // This is safe because we only access the shared state which is behind a mutex
-    async_std::task::spawn_local(async move {
+    crate::player::spawn_player_local(async move {
         let shared_state_arc =
             reserve_player_ref(|player| std::sync::Arc::clone(&player.net_manager.shared_state));
         let result = Ok(data);
@@ -1132,7 +1262,7 @@ pub fn provide_net_task_data(task_id: u32, data: Vec<u8>) {
 
 #[wasm_bindgen]
 pub fn provide_net_task_error(task_id: u32) {
-    async_std::task::spawn_local(async move {
+    crate::player::spawn_player_local(async move {
         let shared_state_arc =
             reserve_player_ref(|player| std::sync::Arc::clone(&player.net_manager.shared_state));
         let result: player::net_task::NetResult = Err(4);
@@ -1172,6 +1302,25 @@ pub fn update_flash_frame(sprite_num: i32, width: u32, height: u32, rgba_data: &
     bitmap.use_alpha = true;
 
     unsafe {
+        // Nested `#movie` sub-player Flash: a synthetic key encodes
+        // (player_id, local_channel). Route the captured frame into THAT sub's
+        // flash_frame_buffers so its own draw_frame composites it into the sub
+        // stage — not the host's buffers.
+        if let Some((pid, ch)) = crate::player::decode_nested_flash_key(sprite_num) {
+            if let Some(sub) = crate::player::NESTED_PLAYERS
+                .get_mut(pid.wrapping_sub(1))
+                .and_then(|o| o.as_mut())
+            {
+                if let Some(&existing_ref) = sub.flash_frame_buffers.get(&ch) {
+                    sub.bitmap_manager.replace_bitmap(existing_ref, bitmap);
+                } else {
+                    let bitmap_ref = sub.bitmap_manager.add_bitmap(bitmap);
+                    sub.flash_frame_buffers.insert(ch, bitmap_ref);
+                }
+            }
+            return;
+        }
+
         if let Some(player) = PLAYER_OPT.as_mut() {
             let key = sprite_num as i16;
 
@@ -1450,7 +1599,7 @@ pub fn dispatch_flash_lingo(body: String) -> bool {
     // Run asynchronously (like eval_command): the caller is inside a
     // synchronous Flash mouse-event forward, so we must let the current
     // command unwind before reserving the player to run the handler.
-    spawn_local(async move {
+    crate::player::spawn_player_local(async move {
         let result = eval_lingo_command(trimmed).await;
         if let Err(err) = result {
             reserve_player_ref(|player| {
@@ -1499,7 +1648,7 @@ fn player_dispatch_with_result(command: PlayerVMCommand) -> bool {
 
 #[wasm_bindgen]
 pub fn eval_command(command: String) {
-    spawn_local(async move {
+    crate::player::spawn_player_local(async move {
         JsApi::dispatch_debug_message(&command);
         let result = eval_lingo_command(command).await;
         if let Err(err) = result {

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -1513,6 +1513,55 @@ pub fn trigger_lingo_callback_on_script(cast_lib: i32, cast_member: i32, handler
     })
 }
 
+/// Flash `LocalConnection.send(connName, method, …args)` forwarded from the
+/// Ruffle fork's AVM1 hook. Routes to the Lingo handler a Director-created
+/// LocalConnection registered via `setCallback` (connName → lc_path →
+/// (handler, target)), dispatched to the exact target instance so `me` is
+/// correct. Returns false for a connection dirplayer doesn't own — the caller
+/// (fork) has already run Ruffle's normal routing, so a real SWF↔SWF
+/// LocalConnection is unaffected. Neopets DGS uses this for the encrypted-score
+/// / protocol channel (`send("gObjLC", "createESCORE", score)`).
+#[wasm_bindgen]
+pub fn local_connection_send(
+    connection_name: String,
+    method_name: String,
+    args_json: String,
+) -> bool {
+    use director::lingo::datum::Datum;
+
+    let params = player::reserve_player_ref(|player| {
+        let lc_path = player.flash_lc_connections.get(&connection_name)?.clone();
+        let cb = player.flash_lc_callbacks.get(&(lc_path, method_name.clone()))?;
+        Some(cb.clone())
+    });
+    let (handler, target) = match params {
+        Some(p) => p,
+        None => return false, // not dirplayer-owned — Ruffle handled it normally
+    };
+
+    let args_js_value = match js_sys::JSON::parse(&args_json) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+    let mut arg_refs = Vec::new();
+    // Director LocalConnection callback shape: `on <handler> me, aInfo, aMessage`.
+    // aInfo is a status/info arg Director supplies; pass VOID.
+    arg_refs.push(player::player_alloc_datum(Datum::Void));
+    if js_sys::Array::is_array(&args_js_value) {
+        let array = js_sys::Array::from(&args_js_value);
+        for i in 0..array.length() {
+            let item = array.get(i);
+            arg_refs.push(js_value_to_datum_ref(&item));
+        }
+    }
+
+    player_dispatch_with_result(PlayerVMCommand::TriggerLocalConnectionCallback {
+        target,
+        handler_name: handler,
+        args: arg_refs,
+    })
+}
+
 /// Dispatch a Flash `getURL("event: …")` body into Director's event chain.
 ///
 /// Called from the JS Flash bridge whenever a SWF tries to navigate to a

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -1068,6 +1068,35 @@ pub fn update_flash_frame(sprite_num: i32, width: u32, height: u32, rgba_data: &
     unsafe {
         if let Some(player) = PLAYER_OPT.as_mut() {
             let key = sprite_num as i16;
+
+            // Off-screen Flash-as-3D-texture (synthetic negative sprite number):
+            // route the captured frame into the named W3D texture rather than the
+            // on-stage frame buffer. The incremental texture upload skips re-upload
+            // when the byte length is unchanged, so re-pushing a static SWF frame
+            // every RAF is cheap. See player.flash_texture_targets.
+            if let Some((member_ref, tex_name)) = player.flash_texture_targets.get(&key).cloned() {
+                let mut tex_data = Vec::with_capacity(8 + rgba_data.len());
+                tex_data.extend_from_slice(&width.to_le_bytes());
+                tex_data.extend_from_slice(&height.to_le_bytes());
+                tex_data.extend_from_slice(rgba_data);
+                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                    if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                        if let Some(scene) = w3d.scene_mut() {
+                            // Only bump the content version when the pixels actually
+                            // change size (cheap static-SWF guard mirroring the
+                            // renderer's length-based incremental check).
+                            let changed = scene.texture_images.get(&tex_name)
+                                .map_or(true, |old| old.len() != tex_data.len());
+                            scene.texture_images.insert(tex_name.clone(), tex_data);
+                            if changed {
+                                scene.texture_content_version += 1;
+                            }
+                        }
+                    }
+                }
+                return;
+            }
+
             if let Some(&existing_ref) = player.flash_frame_buffers.get(&key) {
                 // Replace existing bitmap to reuse the BitmapRef.
                 player.bitmap_manager.replace_bitmap(existing_ref, bitmap);

--- a/vm-rust/src/lib.rs
+++ b/vm-rust/src/lib.rs
@@ -318,9 +318,32 @@ pub fn movie_required_xtras() -> js_sys::Array {
                     }
                 }
             }
+            // The 3D Groove engine is provided by an external plugin, but Groove
+            // movies call its commands as bare globals (`InitGroove()`), never
+            // `new(xtra "Groove")` — so nothing triggers an on-demand load. When
+            // the movie carries any `.3GM` model (a `Groove3gm` cast member),
+            // surface a synthetic "Groove" dependency so the JS resolver loads
+            // the plugin from the registry before Lingo runs. (The name may also
+            // appear in XTRl above; the JS side de-dupes by normalized key.)
+            if movie_has_groove3gm(player) {
+                let obj = js_sys::Object::new();
+                let _ = js_sys::Reflect::set(&obj, &"filename".into(), &"Groove".into());
+                let _ = js_sys::Reflect::set(&obj, &"displayName".into(), &"Groove".into());
+                result.push(&obj);
+            }
         }
     }
     result
+}
+
+/// True if any cast member of the loaded movie is a `.3GM` Groove model.
+fn movie_has_groove3gm(player: &crate::player::DirPlayer) -> bool {
+    use crate::player::cast_member::CastMemberType;
+    player.movie.cast_manager.casts.iter().any(|cast| {
+        cast.members
+            .values()
+            .any(|m| matches!(m.member_type, CastMemberType::Groove3gm(_)))
+    })
 }
 
 #[wasm_bindgen]
@@ -1899,12 +1922,17 @@ fn build_zip_with_glb(
         files.push((format!("{}.{}", tex_name, ext), image_data));
     }
 
+    build_zip_files(&files)
+}
+
+/// Build a minimal uncompressed (stored) ZIP from a list of (name, bytes).
+fn build_zip_files(files: &[(String, &[u8])]) -> Vec<u8> {
     let mut zip = Vec::new();
     let mut central_dir = Vec::new();
     let mut offsets: Vec<u32> = Vec::new();
 
     // Write local file headers + data
-    for (name, data) in &files {
+    for (name, data) in files {
         offsets.push(zip.len() as u32);
         let name_bytes = name.as_bytes();
         let crc = crc32(data);

--- a/vm-rust/src/player/bitmap/bitmap.rs
+++ b/vm-rust/src/player/bitmap/bitmap.rs
@@ -202,6 +202,20 @@ impl Bitmap {
             _ => 0,
         };
 
+        // Backstop against absurd allocations: a bad/oversized width×height (e.g.
+        // a nested sub-movie's mis-measured field height of ~15000 px, or a
+        // transient huge stage rect) makes the `vec![…]` below abort the whole
+        // WASM module with `handle_alloc_error` — an unrecoverable crash. Movie
+        // bitmaps are never larger than a few thousand px per side; clamp to 1×1
+        // (and log) rather than take down the player.
+        if (width as usize).saturating_mul(height as usize) > 8192 * 8192 {
+            warn!(
+                "[bitmap] refusing absurd Bitmap::new({}x{} depth={}) — clamped to 1x1",
+                width, height, bit_depth
+            );
+            return Self::new(1, 1, bit_depth, original_bit_depth, alpha_depth, palette_ref);
+        }
+
         // `bit_depth as usize / 8` truncates to 0 for sub-byte depths
         // (1, 2, 4), leaving `data` empty even though set_pixel does packed
         // bit/nibble arithmetic on it. Compute bytes from total bits so

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -458,6 +458,53 @@ impl Bitmap {
         }
     }
 
+    /// Write a raw palette index at (x, y) for indexed (<=8-bit) bitmaps, with
+    /// NO RGB round-trip. The copyPixels fast path uses this for same-depth,
+    /// same-palette indexed copies so index i stays index i — the general
+    /// per-pixel path resolves each index to RGB and re-quantizes on write,
+    /// which collapses distinct indices that fall in the same brightness bucket
+    /// (Tetris' 1-bit `game_plane` row-shift otherwise turned every occupied
+    /// cell empty, desyncing collision from the visual board).
+    pub fn set_pixel_index(&mut self, x: i32, y: i32, idx: u8) {
+        if x < 0 || y < 0 || x >= self.width as i32 || y >= self.height as i32 {
+            return;
+        }
+        let x = x as usize;
+        let y = y as usize;
+        let w = self.width as usize;
+        match self.bit_depth {
+            1 => {
+                let bit_index = y * w + x;
+                let byte_index = bit_index / 8;
+                let mask = 1u8 << (7 - (bit_index % 8));
+                if idx & 1 != 0 {
+                    self.data[byte_index] |= mask;
+                } else {
+                    self.data[byte_index] &= !mask;
+                }
+            }
+            2 => {
+                let pix = y * w + x;
+                let byte_index = pix / 4;
+                let shift = 6 - (pix % 4) * 2; // MSB-first: 6,4,2,0
+                self.data[byte_index] =
+                    (self.data[byte_index] & !(0b11 << shift)) | ((idx & 0b11) << shift);
+            }
+            4 => {
+                let byte_index = (y * w + x) / 2;
+                if x % 2 == 0 {
+                    self.data[byte_index] = (self.data[byte_index] & 0x0F) | ((idx & 0x0F) << 4);
+                } else {
+                    self.data[byte_index] = (self.data[byte_index] & 0xF0) | (idx & 0x0F);
+                }
+            }
+            8 => {
+                self.data[y * w + x] = idx;
+            }
+            _ => {}
+        }
+    }
+
     /// Like `set_pixel`, but uses a pre-resolved palette table for indexed formats.
     /// For 4-bit/8-bit bitmaps, this avoids calling `resolve_color_ref` 16/256 times per pixel.
     pub fn set_pixel_fast(&mut self, x: i32, y: i32, color: (u8, u8, u8), palette_cache: &[(u8, u8, u8)]) {
@@ -545,6 +592,21 @@ impl Bitmap {
         }
 
         match self.bit_depth {
+            1 => {
+                // 1-bit images pack 8 pixels per byte, MSB first — the same bit
+                // order set_pixel writes (`mask = 1 << (7 - bit_offset)`). Return
+                // the stored bit as the palette index so a 1-bit image used as an
+                // index bitmask round-trips: fill(paletteIndex(N)) / setPixel(N)
+                // -> getPixel().paletteIndex == N. Without this arm every 1-bit
+                // pixel fell through to `get_bg_color_ref()` (PaletteIndex 0), so
+                // Tetris' game board read as fully occupied and every piece
+                // reported game-over immediately.
+                let bit_index = y * self.width as usize + x;
+                let byte_index = bit_index / 8;
+                let bit_offset = bit_index % 8;
+                let bit = (self.data[byte_index] >> (7 - bit_offset)) & 1;
+                ColorRef::PaletteIndex(bit)
+            }
             4 => {
                 let bit_index = (y * self.width as usize + x) * 4;
                 let byte_index = bit_index / 8;
@@ -2357,6 +2419,64 @@ impl Bitmap {
                     }
                     return;
                 }
+            }
+        }
+
+        // -------- Index-preserving fast path: same-depth same-palette 1/4-bit --------
+        // A copyPixels between two indexed bitmaps of the SAME low bit depth and
+        // palette maps index i -> index i. The general per-pixel path below
+        // resolves each index to RGB and re-quantizes on write, collapsing
+        // distinct indices that share a brightness bucket (Tetris' 1-bit
+        // game_plane row-shift on a line clear turned every occupied cell empty,
+        // wiping the collision board). Copy the raw index straight across.
+        // (8-bit already handled by the byte-copy path above; 1/4-bit have a real
+        // get_pixel_color_ref index arm, 2-bit does not, so it's excluded.)
+        {
+            let sprite_bg = params.sprite.map_or(false, |sp| sp.has_back_color);
+            let sprite_fg = params.sprite.map_or(false, |sp| sp.has_fore_color);
+            let no_colorize = !(sprite_bg
+                || sprite_fg
+                || params.bg_color_explicit
+                || params.fore_color_explicit);
+            let unscaled = (max_dst_x - min_dst_x) == src_rect.width()
+                && (max_dst_y - min_dst_y) == src_rect.height();
+            if self.bit_depth == src.bit_depth
+                && (self.bit_depth == 1 || self.bit_depth == 4)
+                && src.palette_ref == self.palette_ref
+                && !has_sprite_rotation
+                && !has_skew_flip
+                && !flip_x
+                && !flip_y
+                && unscaled
+                && alpha >= 0.999
+                && mask_image.is_none()
+                && matte_mask.is_none()
+                && no_colorize
+                && ink == 0
+            {
+                self.matte = None;
+                let dst_w = self.width as i32;
+                let dst_h = self.height as i32;
+                let sw = src.width as i32;
+                let sh = src.height as i32;
+                for dst_y in min_dst_y.max(0)..max_dst_y.min(dst_h) {
+                    let src_y = src_rect.top + (dst_y - min_dst_y);
+                    if src_y < 0 || src_y >= sh {
+                        continue;
+                    }
+                    for dst_x in min_dst_x.max(0)..max_dst_x.min(dst_w) {
+                        let src_x = src_rect.left + (dst_x - min_dst_x);
+                        if src_x < 0 || src_x >= sw {
+                            continue;
+                        }
+                        if let ColorRef::PaletteIndex(idx) =
+                            src.get_pixel_color_ref(src_x as u16, src_y as u16)
+                        {
+                            self.set_pixel_index(dst_x, dst_y, idx);
+                        }
+                    }
+                }
+                return;
             }
         }
 

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -2265,6 +2265,101 @@ impl Bitmap {
             matte_mask = Some(mask);
         }
 
+        // ---------------- Fast path: unscaled, unrotated, same-palette 8-bit blit ----------------
+        // The dominant per-frame cost in tile/map compositing (drawmap terrain
+        // tiling, water copyPixels) is the O(256) nearest-color search inside
+        // set_pixel_fast, run once per destination pixel. When the source and
+        // destination are both 8-bit indexed sharing the same palette, index i
+        // maps to index i, so we can copy raw index bytes row-by-row and skip
+        // both the palette resolve AND the nearest-color search entirely.
+        {
+            let sprite_bg = params.sprite.map_or(false, |sp| sp.has_back_color);
+            let sprite_fg = params.sprite.map_or(false, |sp| sp.has_fore_color);
+            let no_colorize = !(sprite_bg
+                || sprite_fg
+                || params.bg_color_explicit
+                || params.fore_color_explicit);
+            let dst_span_w = max_dst_x - min_dst_x;
+            let dst_span_h = max_dst_y - min_dst_y;
+            let unscaled =
+                dst_span_w == src_rect.width() && dst_span_h == src_rect.height();
+            if self.bit_depth == 8
+                && src.bit_depth == 8
+                && src.palette_ref == self.palette_ref
+                && !has_sprite_rotation
+                && !has_skew_flip
+                && !flip_x
+                && !flip_y
+                && unscaled
+                && alpha >= 0.999
+                && mask_image.is_none()
+                && matte_mask.is_none()
+                && no_colorize
+                && (ink == 0 || ink == 2 || ink == 36)
+            {
+                // For color-key inks, precompute which source indices resolve to
+                // the transparent background color (mirrors the per-pixel
+                // `(r,g,b) == bg_color_resolved` skip).
+                let transparent: Option<[bool; 256]> = if ink == 2 || ink == 36 {
+                    let mut t = [false; 256];
+                    if let Some(cache) = &src_palette_cache {
+                        for (i, slot) in t.iter_mut().enumerate() {
+                            if let Some(&rgb) = cache.get(i) {
+                                *slot = rgb == bg_color_resolved;
+                            }
+                        }
+                    }
+                    Some(t)
+                } else {
+                    None
+                };
+
+                let dst_w = self.width as i32;
+                let dst_h = self.height as i32;
+                let sw = src.width as i32;
+                let sh = src.height as i32;
+
+                // Horizontal clip is constant across rows (no rotation/flip).
+                let dx0 = min_dst_x.max(0);
+                let dx1 = max_dst_x.min(dst_w);
+                let src_x_start = src_rect.left + (dx0 - min_dst_x);
+                let row_len = (dx1 - dx0).max(0) as usize;
+                if row_len > 0
+                    && src_x_start >= 0
+                    && src_x_start + row_len as i32 <= sw
+                {
+                    self.matte = None;
+                    let width = self.width as usize;
+                    let s_width = src.width as usize;
+                    for dst_y in min_dst_y.max(0)..max_dst_y.min(dst_h) {
+                        let src_y = src_rect.top + (dst_y - min_dst_y);
+                        if src_y < 0 || src_y >= sh {
+                            continue;
+                        }
+                        let d_row = dst_y as usize * width + dx0 as usize;
+                        let s_row = src_y as usize * s_width + src_x_start as usize;
+                        match &transparent {
+                            None => {
+                                // Ink 0 (Copy): fully opaque raw byte copy.
+                                self.data[d_row..d_row + row_len]
+                                    .copy_from_slice(&src.data[s_row..s_row + row_len]);
+                            }
+                            Some(t) => {
+                                // Ink 2/36: copy non-transparent indices only.
+                                for i in 0..row_len {
+                                    let idx = src.data[s_row + i];
+                                    if !t[idx as usize] {
+                                        self.data[d_row + i] = idx;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return;
+                }
+            }
+        }
+
         // ---------------- Pixel loop ----------------
         for dst_y in draw_min_y..draw_max_y {
             for dst_x in draw_min_x..draw_max_x {

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -3233,13 +3233,37 @@ impl Bitmap {
         top_spacing: i16,
     ) {
         let mut x = loc_h;
-        let mut y = loc_v + top_spacing as i32;
-        let line_height = font.char_height;
+        // Paige draws the baseline at lineTop + ascent. For PFR strikes, anchor
+        // the scanned cap-top at the sprite top so the baseline lands at the
+        // strike's real ascent instead of ~2px low (see pfr_strike_vertical_metrics).
+        let (cap_top, _desc_bottom) =
+            crate::player::font::pfr_strike_vertical_metrics(font, font_bitmap);
+        let mut y = match cap_top {
+            Some(t) => loc_v - t,
+            None => loc_v + top_spacing as i32,
+        };
+        // `line_spacing` is the member's fixedLineSpace. Director 11.5 defines
+        // it as the ABSOLUTE height of each line ("height in absolute pixels of
+        // each line"), NOT extra leading added on top of the glyph cell. This
+        // must agree with `measure_text()` — which sizes this very bitmap plus
+        // member.rect / member.height / charPosToLoc and uses `line_spacing` as
+        // the per-line stride when set. Adding `char_height` on top of it (the
+        // old behaviour) spaced lines ~1 glyph-cell too far apart, so text
+        // rasterized via `member.image` (e.g. Habbo's window Text Wrapper, which
+        // authors fixedLineSpace ≈ fontSize+1 and copyPixels the result into a
+        // bitmap) overflowed its measured box and rendered with huge gaps.
+        // Honour it as the absolute stride when set; fall back to the natural
+        // glyph cell only when unset (0).
+        let line_step = if line_spacing > 0 {
+            line_spacing as i32
+        } else {
+            font.char_height as i32
+        };
 
         for char_num in text.chars() {
             if char_num == '\r' || char_num == '\n' {
                 x = loc_h;
-                y += line_height as i32 + line_spacing as i32;
+                y += line_step;
                 continue;
             }
 
@@ -3274,12 +3298,25 @@ impl Bitmap {
         line_spacing: u16,
         top_spacing: i16,
     ) -> i32 {
-        let line_height = font.char_height as i32 + line_spacing as i32;
+        // fixedLineSpace is the absolute per-line height when set (see the note
+        // in `draw_text`); fall back to the natural glyph cell when unset.
+        let line_height = if line_spacing > 0 {
+            line_spacing as i32
+        } else {
+            font.char_height as i32
+        };
 
         // Break text into wrapped lines
         let lines = Self::wrap_text_lines(text, font, max_width);
 
-        let mut y = loc_v + top_spacing as i32;
+        // Paige baseline = lineTop + ascent; anchor the strike cap-top at the
+        // sprite top (see pfr_strike_vertical_metrics) so PFR text isn't ~2px low.
+        let (cap_top, _desc_bottom) =
+            crate::player::font::pfr_strike_vertical_metrics(font, font_bitmap);
+        let mut y = match cap_top {
+            Some(t) => loc_v - t,
+            None => loc_v + top_spacing as i32,
+        };
         for line in &lines {
             // Calculate x based on alignment
             let line_w: i32 = line.chars()

--- a/vm-rust/src/player/bitmap/manager.rs
+++ b/vm-rust/src/player/bitmap/manager.rs
@@ -28,6 +28,18 @@ impl BitmapManager {
         }
     }
 
+    /// Drop every stored bitmap when switching movies. Cast-member-owned
+    /// (anchored) bitmaps are never removed by the ephemeral refcount path, so
+    /// without this they orphan here forever: loading a new movie replaces the
+    /// cast list but leaks the previous movie's bitmaps (Infestation's ~363
+    /// bitmaps, ~10 MB+ decoded, on every load — memory that never comes back).
+    /// `ref_counter` is NOT reset so freshly-issued refs can't collide with any
+    /// `Datum::BitmapRef` that a persisted global still holds.
+    pub fn clear_movie_bitmaps(&mut self) {
+        self.bitmaps.clear();
+        self.ephemeral_refs.clear();
+    }
+
     /// Register an anchored bitmap (owned by a cast member or other long-lived
     /// holder). Will not be auto-freed when DatumRefs drop.
     pub fn add_bitmap(&mut self, bitmap: Bitmap) -> BitmapRef {

--- a/vm-rust/src/player/bytecode/flow_control.rs
+++ b/vm-rust/src/player/bytecode/flow_control.rs
@@ -26,7 +26,7 @@ impl FlowControlBytecodeHandler {
     ) -> Result<HandlerExecutionResult, ScriptError> {
         // let script = get_current_script(player.to_owned(), ctx.to_owned());
         let (name, arg_ref_list, is_no_ret) = {
-            let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+            let player = unsafe { crate::player::player_mut() };
             let player_cell = &player;
 
             let name_id = player.get_ctx_current_bytecode(&ctx).obj as u16;
@@ -67,6 +67,146 @@ impl FlowControlBytecodeHandler {
             });
         }
         return Ok(result_ctx);
+    }
+
+    /// `tell <target>` — pop the target and record which context the enclosed
+    /// `tellcall`s dispatch to. `tell sprite(#movieSprite)` targets that nested
+    /// sub-player (the loader→game command bridge); other targets run on THIS
+    /// player. Stack is a Vec so `tell` blocks can nest.
+    pub fn start_tell(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
+        reserve_player_mut(|player| {
+            let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
+            let target_ref = scope.stack.pop().ok_or_else(|| {
+                ScriptError::new("starttell: operand stack is empty".to_string())
+            })?;
+            let target = player.get_datum(&target_ref).clone();
+            let nested = match target {
+                Datum::SpriteRef(n) => player
+                    .movie
+                    .score
+                    .get_sprite(n as i16)
+                    .and_then(|s| s.member.clone())
+                    .and_then(|m| crate::player::nested_player_id(&m)),
+                Datum::CastMember(ref m) => crate::player::nested_player_id(m),
+                _ => None,
+            };
+            player.tell_target_stack.push(nested);
+            Ok(HandlerExecutionResult::Advance)
+        })
+    }
+
+    /// `end tell` — pop the current tell target.
+    pub fn end_tell(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
+        let _ = ctx;
+        reserve_player_mut(|player| {
+            player.tell_target_stack.pop();
+        });
+        Ok(HandlerExecutionResult::Advance)
+    }
+
+    /// `tellcall` — like `ext_call` but dispatches the command into the current
+    /// `tell` target. For a nested `#movie` target the args are marshaled into
+    /// the sub-player, the command runs there (with the active id pinned across
+    /// awaits), and the result is marshaled back. No nested target → runs here.
+    pub async fn tell_call(
+        ctx: &BytecodeHandlerContext,
+    ) -> Result<HandlerExecutionResult, ScriptError> {
+        let (name, arg_ref_list, is_no_ret, target) = {
+            let player = unsafe { crate::player::player_mut() };
+            let name_id = player.get_ctx_current_bytecode(&ctx).obj as u16;
+            let name = get_name(&player, &ctx, name_id).unwrap().to_owned();
+            let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
+            let arg_list_ref = scope.stack.pop().ok_or_else(|| {
+                ScriptError::new(format!("tell_call '{}': operand stack is empty", name))
+            })?;
+            let arg_list_datum = player.get_datum(&arg_list_ref);
+            let (args, is_no_ret) = if let Datum::List(list_type, list, _) = arg_list_datum {
+                (
+                    Vec::from(list.to_owned()),
+                    matches!(list_type, DatumType::ArgListNoRet),
+                )
+            } else {
+                return Err(ScriptError::new(format!(
+                    "tell_call '{}': expected arg list on stack",
+                    name
+                )));
+            };
+            let target = player.tell_target_stack.last().copied().flatten();
+            (name, args, is_no_ret, target)
+        };
+
+        let nested_id = match target {
+            Some(id) => id,
+            None => {
+                // No nested target — behave like ext_call on this player.
+                let (result_ctx, return_value) =
+                    player_ext_call(name.clone(), &arg_ref_list, ctx.scope_ref).await;
+                if !is_no_ret {
+                    reserve_player_mut(|player| {
+                        player.scopes.get_mut(ctx.scope_ref).unwrap().stack.push(return_value);
+                    });
+                }
+                return Ok(result_ctx);
+            }
+        };
+
+        // Marshal args from the host into the nested sub-player's allocator, and
+        // PAUSE the sub's own frame loop for the duration of the tell dispatch.
+        // Otherwise the sub's frame loop (a separate async task) runs its scripts
+        // concurrently with the tell's `sendAllSprites` — both push/pop scopes on
+        // the same player between awaits, corrupting its scope stack (observed as
+        // a hang). `command_handler_yielding` is the engine's existing "a command
+        // handler is running, don't advance the frame loop" gate.
+        let nested_args: Vec<DatumRef> = unsafe {
+            let host = crate::player::player_mut();
+            match crate::player::NESTED_PLAYERS
+                .get_mut(nested_id - 1)
+                .and_then(|o| o.as_mut())
+            {
+                Some(sub) => {
+                    sub.command_handler_yielding = true;
+                    arg_ref_list
+                        .iter()
+                        .map(|r| crate::player::marshal_datum(host, sub, r))
+                        .collect()
+                }
+                None => return Ok(HandlerExecutionResult::Advance),
+            }
+        };
+
+        // Run the command inside the nested player, active id pinned across awaits.
+        let (_result_ctx, nested_return) = crate::player::with_active_player(
+            nested_id,
+            player_ext_call(name.clone(), &nested_args, ctx.scope_ref),
+        )
+        .await;
+
+        // Resume the sub's frame loop.
+        unsafe {
+            if let Some(sub) = crate::player::NESTED_PLAYERS
+                .get_mut(nested_id - 1)
+                .and_then(|o| o.as_mut())
+            {
+                sub.command_handler_yielding = false;
+            }
+        }
+
+        if !is_no_ret {
+            let host_ret = unsafe {
+                let host = crate::player::player_mut();
+                match crate::player::NESTED_PLAYERS
+                    .get(nested_id - 1)
+                    .and_then(|o| o.as_ref())
+                {
+                    Some(sub) => crate::player::marshal_datum(sub, host, &nested_return),
+                    None => DatumRef::Void,
+                }
+            };
+            reserve_player_mut(|player| {
+                player.scopes.get_mut(ctx.scope_ref).unwrap().stack.push(host_ret);
+            });
+        }
+        Ok(HandlerExecutionResult::Advance)
     }
 
     pub async fn local_call(

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -102,7 +102,7 @@ impl GetSetBytecodeHandler {
     }
 
     pub fn get_prop(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
-        let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+        let player = unsafe { crate::player::player_mut() };
         let (receiver, script_ref, cached) = {
             let scope = player.scopes.get(ctx.scope_ref).unwrap();
             (scope.receiver.clone(), scope.script_ref.clone(), scope.cached_handler_instance.clone())
@@ -134,7 +134,7 @@ impl GetSetBytecodeHandler {
     }
 
     pub fn set_prop(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id).to_owned();
 
         reserve_player_mut(|player| {
@@ -174,7 +174,7 @@ impl GetSetBytecodeHandler {
     pub async fn set_obj_prop(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id).to_owned();
         let (value, obj_datum_ref) = reserve_player_mut(|player| {
             let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
@@ -189,7 +189,7 @@ impl GetSetBytecodeHandler {
     pub fn get_obj_prop(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id).to_owned();
         reserve_player_mut(|player| {
             // Pop the object reference from the stack
@@ -222,7 +222,7 @@ impl GetSetBytecodeHandler {
     pub fn get_movie_prop(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
             let result_ref = player.get_movie_prop(prop_name)?;
@@ -477,7 +477,7 @@ impl GetSetBytecodeHandler {
     }
 
     pub fn get_global(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
             let value_ref = player
@@ -492,7 +492,7 @@ impl GetSetBytecodeHandler {
     }
 
     pub fn set_global(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
             let value_ref = {
@@ -641,7 +641,7 @@ impl GetSetBytecodeHandler {
     pub fn set_movie_prop(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
             let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
@@ -655,7 +655,7 @@ impl GetSetBytecodeHandler {
     pub fn the_built_in(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
             let result_id = GetSetUtils::get_the_built_in_prop(player, ctx, prop_name)?;
@@ -670,7 +670,7 @@ impl GetSetBytecodeHandler {
     pub fn get_chained_prop(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id).to_owned();
         reserve_player_mut(|player| {
             let obj_ref = {
@@ -1257,7 +1257,7 @@ impl GetSetBytecodeHandler {
     pub fn get_top_level_prop(
         ctx: &BytecodeHandlerContext,
     ) -> Result<HandlerExecutionResult, ScriptError> {
-        let name_id = unsafe { PLAYER_OPT.as_ref().unwrap() }.get_ctx_current_bytecode(ctx).obj as u16;
+        let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
             let result = GetSetUtils::get_top_level_prop(player, prop_name)?;

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -480,11 +480,23 @@ impl GetSetBytecodeHandler {
         let name_id = unsafe { crate::player::player_ref() }.get_ctx_current_bytecode(ctx).obj as u16;
         let prop_name = ctx.get_name(name_id);
         reserve_player_mut(|player| {
-            let value_ref = player
-                .globals
-                .get(prop_name)
-                .unwrap_or(&DatumRef::Void)
-                .clone();
+            let value_ref = match player.globals.get(prop_name) {
+                Some(v) => v.clone(),
+                None => {
+                    // Lingo globals are case-insensitive. An Xtra may write a global
+                    // in a different case than a script reads it — 3D Groove's
+                    // GetCollide writes `collidez` while leo3d reads `CollideZ` — so
+                    // fall back to a case-insensitive match before yielding VOID.
+                    // Only runs on a miss, so exact hits (constants like PI) are
+                    // unaffected.
+                    player
+                        .globals
+                        .iter()
+                        .find(|(k, _)| k.eq_ignore_ascii_case(prop_name))
+                        .map(|(_, v)| v.clone())
+                        .unwrap_or(DatumRef::Void)
+                }
+            };
             let scope = player.scopes.get_mut(ctx.scope_ref).unwrap();
             scope.stack.push(value_ref);
             Ok(HandlerExecutionResult::Advance)

--- a/vm-rust/src/player/bytecode/get_set.rs
+++ b/vm-rust/src/player/bytecode/get_set.rs
@@ -950,7 +950,8 @@ impl GetSetBytecodeHandler {
                 }
             } else if prop_type == 0x07 {
                 // anim prop
-                Ok(player.alloc_datum(player.get_anim_prop(prop_id as u16)?))
+                let anim_datum = player.get_anim_prop(prop_id as u16)?;
+                Ok(player.alloc_datum(anim_datum))
             } else if prop_type == 0x08 {
                 // anim2 prop
                 let datum = if prop_id == 0x02 && player.movie.dir_version >= 500 {

--- a/vm-rust/src/player/bytecode/handler_manager.rs
+++ b/vm-rust/src/player/bytecode/handler_manager.rs
@@ -255,6 +255,8 @@ impl StaticBytecodeHandlerManager {
             OpCode::OntoSpr => SpriteCompareBytecodeHandler::onto_sprite(ctx),
             OpCode::IntoSpr => SpriteCompareBytecodeHandler::into_sprite(ctx),
             OpCode::CallJavaScript => FlowControlBytecodeHandler::call_javascript(ctx),
+            OpCode::StartTell => FlowControlBytecodeHandler::start_tell(ctx),
+            OpCode::EndTell => FlowControlBytecodeHandler::end_tell(ctx),
             _ => {
                 let prim = num::ToPrimitive::to_u16(&opcode).unwrap();
                 let name = get_opcode_name(opcode);
@@ -273,6 +275,7 @@ impl StaticBytecodeHandlerManager {
             OpCode::ObjCallV4 => true,
             OpCode::LocalCall => true,
             OpCode::SetObjProp => true,
+            OpCode::TellCall => true,
             _ => false,
         }
     }
@@ -289,6 +292,7 @@ impl StaticBytecodeHandlerManager {
             OpCode::ObjCallV4 => FlowControlBytecodeHandler::obj_call_v4(&ctx).await,
             OpCode::LocalCall => FlowControlBytecodeHandler::local_call(&ctx).await,
             OpCode::SetObjProp => GetSetBytecodeHandler::set_obj_prop(&ctx).await,
+            OpCode::TellCall => FlowControlBytecodeHandler::tell_call(&ctx).await,
             _ => {
                 let prim = num::ToPrimitive::to_u16(&opcode).unwrap();
                 let name = get_opcode_name(opcode);
@@ -305,7 +309,7 @@ pub async fn player_execute_bytecode<'a>(
     ctx: &BytecodeHandlerContext,
 ) -> Result<HandlerExecutionResult, ScriptError> {
     let (opcode, bytecode_text, should_trace) = {
-        let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+        let player = unsafe { crate::player::player_ref() };
         let scope = player.scopes.get(ctx.scope_ref).unwrap();
 
         let handler = unsafe { &*ctx.handler_def_ptr };
@@ -387,7 +391,7 @@ pub async fn player_execute_bytecode<'a>(
     // Trace bytecode execution before running
     if should_trace {
         let trace_file = {
-            let player = unsafe { PLAYER_OPT.as_ref().unwrap() };
+            let player = unsafe { crate::player::player_ref() };
             let msg = format!("--> {}", bytecode_text);
             trace_output(player, &msg);
             player.movie.trace_log_file.clone()

--- a/vm-rust/src/player/bytecode/stack.rs
+++ b/vm-rust/src/player/bytecode/stack.rs
@@ -83,7 +83,7 @@ impl StackBytecodeHandler {
     }
 
     pub fn push_symb(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
-        let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+        let player = unsafe { crate::player::player_mut() };
         let name_id = player.get_ctx_current_bytecode(ctx).obj;
         let symbol_name = get_name(&player, &ctx, name_id as u16).unwrap();
         let datum_ref = player.alloc_datum(Datum::Symbol(symbol_name.to_owned()));
@@ -94,7 +94,7 @@ impl StackBytecodeHandler {
     }
 
     pub fn push_var_ref(ctx: &BytecodeHandlerContext) -> Result<HandlerExecutionResult, ScriptError> {
-        let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+        let player = unsafe { crate::player::player_mut() };
         let name_id = player.get_ctx_current_bytecode(ctx).obj;
         let symbol_name = get_name(&player, &ctx, name_id as u16).unwrap();
         let datum_ref = player.alloc_datum(Datum::Symbol(symbol_name.to_owned()));

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -21,8 +21,8 @@ use super::{
         manager::BitmapManager,
     },
     cast_member::{
-        BitmapMember, CastMember, CastMemberType, FieldMember, FlashMember, PaletteMember,
-        SoundMember, TextMember, VectorShapeMember,
+        BitmapMember, CastMember, CastMemberType, FieldMember, FlashMember, MovieMember,
+        PaletteMember, SoundMember, TextMember, VectorShapeMember,
     },
     datum_ref::DatumRef,
     handlers::datum_handlers::cast_member_ref::CastMemberRefHandlers,
@@ -333,7 +333,7 @@ impl CastLib {
         }
         JsApi::dispatch_cast_member_list_changed(self.number);
         unsafe {
-            let player_mut = &mut PLAYER_OPT.as_mut().unwrap();
+            let player_mut = &mut crate::player::player_mut();
 
             player_mut.movie.cast_manager.clear_movie_script_cache();
             player_mut.movie.cast_manager.invalidate_member_name_cache();
@@ -500,6 +500,15 @@ impl CastLib {
                     flash_info: None,
                 }),
             )),
+            // `new(#movie)` creates an empty Linked Movie member; the script
+            // links it to an external .dir/.dcr via `member.fileName = <url>`
+            // and plays it by assigning the member to a sprite (Director 11.5
+            // Scripting Dictionary "Linked Movie"). Neopets' DGS loader
+            // (`showAndStartShockwaveGame`) uses this to run the downloaded game.
+            "movie" => Ok(CastMember::new(
+                number,
+                CastMemberType::Movie(MovieMember::new()),
+            )),
             _ => Err(ScriptError::new(format!(
                 "Cannot create member of type {}",
                 member_type
@@ -625,7 +634,7 @@ pub async fn player_cast_lib_set_prop(
     prop_name: &str,
     value: Datum,
 ) -> Result<(), ScriptError> {
-    let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+    let player = unsafe { crate::player::player_mut() };
 
     let cast_manager = &mut player.movie.cast_manager;
     let cast_lib_obj = cast_manager.get_cast_mut(cast_lib as u32);

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -21,8 +21,8 @@ use super::{
         manager::BitmapManager,
     },
     cast_member::{
-        BitmapMember, CastMember, CastMemberType, FieldMember, PaletteMember, SoundMember,
-        TextMember, VectorShapeMember,
+        BitmapMember, CastMember, CastMemberType, FieldMember, FlashMember, PaletteMember,
+        SoundMember, TextMember, VectorShapeMember,
     },
     datum_ref::DatumRef,
     handlers::datum_handlers::cast_member_ref::CastMemberRefHandlers,
@@ -484,6 +484,20 @@ impl CastLib {
                     script_id: 0,
                     script_type: ScriptType::Movie,
                     name: String::new(),
+                }),
+            )),
+            // `new(#flash)` creates an empty Flash cast member; the script then
+            // points it at a SWF, typically by setting `.linked = TRUE` and
+            // `.pathName = "http://…/foo.swf"`, or by assigning preloaded bytes
+            // (Director 11.5 Scripting Dictionary — `new()`, `#flash` member).
+            // Neopets' DGS loader (`mainClass.showPreLoader`) uses this to host
+            // the downloaded preloader SWF. Empty until its source is assigned.
+            "flash" => Ok(CastMember::new(
+                number,
+                CastMemberType::Flash(FlashMember {
+                    data: Vec::new(),
+                    reg_point: (0, 0),
+                    flash_info: None,
                 }),
             )),
             _ => Err(ScriptError::new(format!(

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -342,11 +342,25 @@ impl CastLib {
     }
 
     pub fn insert_member(&mut self, number: u32, member: CastMember) {
-        if let CastMemberType::Script(script_member) = &member.member_type {
+        // Which lctx script should we register under this member's slot, and as
+        // what type? A `Script` cast member registers its own script. A non-Script
+        // member (Field, Text, Bitmap, Button, Shape) may carry an ATTACHED script
+        // via `member_info.header.script_id` — Director lets `script("name")` and
+        // `new(script(...))` resolve to that attached script, and a movie can store
+        // a parent script AS a Field cast member (SpongeBob "JellyFishin'" stores
+        // its "hero parent" parent script as a Field). Register it at the member
+        // slot so `get_script_for_member(number)` finds it. (Member BEHAVIOR scripts
+        // for mouse events are dispatched separately via get_behavior_script_from_lctx.)
+        let registration: Option<(u32, ScriptType)> = match &member.member_type {
+            CastMemberType::Script(s) => Some((s.script_id, s.script_type)),
+            _ => member.get_script_id().map(|sid| (sid, ScriptType::Parent)),
+        };
+
+        if let Some((reg_script_id, reg_script_type)) = registration {
             let script_def = self
                 .lctx
                 .as_ref()
-                .and_then(|lctx| lctx.scripts.get(&script_member.script_id));
+                .and_then(|lctx| lctx.scripts.get(&reg_script_id));
 
             if let Some(script_def) = script_def {
                 let mut handler_names = Vec::new();
@@ -382,7 +396,7 @@ impl CastLib {
                     member_ref: cast_member_ref(self.number as i32, number as i32),
                     name: (&member.name).to_owned(),
                     chunk: script_def.clone(),
-                    script_type: script_member.script_type,
+                    script_type: reg_script_type,
                     handlers: handler_name_map,
                     handler_names,
                     properties: RefCell::new(properties),

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -638,6 +638,13 @@ pub async fn player_cast_lib_set_prop(
                 &mut player.dir_cache,
             )
             .await;
+        // The external cast was reloaded in place — any Flash member it holds
+        // now has new SWF bytes behind the same member ref. Tear down the stale
+        // Ruffle instances so the renderer re-creates them from the new bytes
+        // (Storyscramble swaps `castLib("story").fileName` to load the next
+        // story; member 2:1's SWF changes but the tile sprites keep pointing at
+        // it). `cast_lib_obj`'s borrow ends here (NLL), freeing `player`.
+        player.invalidate_flash_for_cast_lib(cast_lib as i32);
     }
     // TODO handle preload error
     Ok(())

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1237,6 +1237,45 @@ pub struct Shockwave3dRuntimeState {
     /// fired (their producers aren't wired up). `unregisterAllEvents`
     /// truncates this Vec.
     pub registered_events: Vec<RegisteredW3dEvent>,
+
+    // ─── Native #collision modifier (addModifier(#collision)) ───
+    /// Per-model collision modifier state, keyed by model node name. Drives
+    /// native W3D collision detection in `events::tick_w3d_collisions`.
+    pub collision_modifiers: std::collections::HashMap<String, W3dCollisionModifier>,
+}
+
+/// Native Shockwave3D #collision modifier state (Director 11.5 collision
+/// modifier). Attached to a model via `model.addModifier(#collision)` and
+/// exposed through the `model.collision` property. Detection runs each frame
+/// in `events::tick_w3d_collisions`; only detection + callback dispatch are
+/// implemented — resolution is a no-op (every consumer so far sets `resolve = 0`).
+#[derive(Clone, Debug)]
+pub struct W3dCollisionModifier {
+    /// `collision.enabled` — whether collisions with this model are detected.
+    pub enabled: bool,
+    /// `collision.resolve` — whether collisions are auto-resolved. Stored, not applied.
+    pub resolve: bool,
+    /// `collision.immovable` — stored only.
+    pub immovable: bool,
+    /// `collision.mode` — #box / #sphere / #mesh. Detection uses an axis-aligned
+    /// bounding box for every mode (sufficient for the gameplay callbacks).
+    pub mode: String,
+    /// Handler registered via `collision.setCollisionCallback(#handler, instance)`.
+    pub callback_handler: Option<String>,
+    pub callback_instance: Option<crate::player::script_ref::ScriptInstanceRef>,
+}
+
+impl Default for W3dCollisionModifier {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            resolve: true,
+            immovable: false,
+            mode: "mesh".to_string(),
+            callback_handler: None,
+            callback_instance: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -2642,6 +2642,14 @@ impl PhysXPhysicsMember {
     pub fn new() -> Self { Self { state: PhysXPhysicsState::default() } }
 }
 
+/// A 3D Groove `.3GM` model cast member (type-15 Xtra media whose XMED payload
+/// begins with the `3DGM` magic). Holds the raw bytes; the Groove Xtra parses
+/// them into a model when the movie calls `LoadShape(memberName)`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Groove3gmMember {
+    pub data: Vec<u8>,
+}
+
 #[allow(dead_code)]
 #[derive(Clone)]
 pub enum CastMemberType {
@@ -2661,6 +2669,7 @@ pub enum CastMemberType {
     Shockwave3d(Shockwave3dMember),
     HavokPhysics(HavokPhysicsMember),
     PhysXPhysics(PhysXPhysicsMember),
+    Groove3gm(Groove3gmMember),
     Unknown,
 }
 
@@ -2682,6 +2691,7 @@ pub enum CastMemberTypeId {
     Shockwave3d,
     HavokPhysics,
     PhysXPhysics,
+    Groove3gm,
     Unknown,
 }
 
@@ -2736,6 +2746,9 @@ impl fmt::Debug for CastMemberType {
             Self::PhysXPhysics(_) => {
                 write!(f, "PhysXPhysics")
             }
+            Self::Groove3gm(_) => {
+                write!(f, "Groove3gm")
+            }
             Self::Unknown => {
                 write!(f, "Unknown")
             }
@@ -2762,6 +2775,7 @@ impl CastMemberTypeId {
             Self::Shockwave3d => Ok("shockwave3d"),
             Self::HavokPhysics => Ok("havok"),
             Self::PhysXPhysics => Ok("physics"),
+            Self::Groove3gm => Ok("groove"),
             Self::Unknown => Ok("unknown"),
         };
     }
@@ -2786,6 +2800,7 @@ impl CastMemberType {
             Self::Shockwave3d(_) => CastMemberTypeId::Shockwave3d,
             Self::HavokPhysics(_) => CastMemberTypeId::HavokPhysics,
             Self::PhysXPhysics(_) => CastMemberTypeId::PhysXPhysics,
+            Self::Groove3gm(_) => CastMemberTypeId::Groove3gm,
             Self::Unknown => CastMemberTypeId::Unknown,
         };
     }
@@ -4007,6 +4022,22 @@ impl CastMember {
                     name: chunk.member_info.as_ref().map(|x| x.name.to_owned()).unwrap_or_default(),
                     comments: chunk.member_info.as_ref().map(|x| x.comments.to_owned()).unwrap_or_default(),
                     member_type: CastMemberType::HavokPhysics(HavokPhysicsMember::new(hke_data)),
+                    color: ColorRef::PaletteIndex(255),
+                    bg_color: ColorRef::PaletteIndex(0),
+                    reg_point: (0, 0),
+                });
+            }
+
+            // 1b) 3D Groove `.3GM` model — XMED payload starts with the `3DGM` magic.
+            // Retain the raw bytes so the Groove Xtra can build a shape from them
+            // when the movie calls `LoadShape(memberName)`.
+            if xm.raw_data.len() >= 4 && &xm.raw_data[0..4] == b"3DGM" {
+                debug!("Groove .3GM member #{} detected ({} bytes)", number, xm.raw_data.len());
+                return Some(CastMember {
+                    number,
+                    name: chunk.member_info.as_ref().map(|x| x.name.to_owned()).unwrap_or_default(),
+                    comments: chunk.member_info.as_ref().map(|x| x.comments.to_owned()).unwrap_or_default(),
+                    member_type: CastMemberType::Groove3gm(Groove3gmMember { data: xm.raw_data.clone() }),
                     color: ColorRef::PaletteIndex(255),
                     bg_color: ColorRef::PaletteIndex(0),
                     reg_point: (0, 0),

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -3540,6 +3540,75 @@ impl CastMember {
         Some((width, height))
     }
 
+    /// Parse the SWF header's FrameCount (the root timeline's total frame
+    /// count) straight from the movie bytes — the authoritative value for
+    /// Director's Flash `member.frameCount` property. Reading it from the SWF
+    /// header (always present in `data`) is correct even while the Ruffle
+    /// instance is still (re)loading; asking Ruffle returns 0 during that
+    /// window, which poisons movies that seed state from `frameCount`
+    /// (bogey_nights' #hiding does `sprite.frame = member.frameCount`, and a 0
+    /// there pins the SWF root at frame 0 and stalls the grab machine).
+    ///
+    /// Header layout after the 8-byte prefix (FWS): RECT (variable), then u16
+    /// FrameRate (8.8 fixed), then u16 FrameCount. Only uncompressed FWS is
+    /// handled here (bogey_nights' straw/longarm are FWS); compressed CWS/ZWS
+    /// fall back to the Ruffle query at the call site.
+    pub fn parse_swf_frame_count(data: &[u8]) -> Option<u16> {
+        if data.len() < 9 || &data[0..3] != b"FWS" {
+            return None;
+        }
+        let rect_start = 8;
+        let nbits = (data[rect_start] >> 3) as usize;
+        let total_bits = 5 + nbits * 4;
+        let rect_bytes = (total_bits + 7) / 8;
+        // rect, then FrameRate (2), then FrameCount (2)
+        let fc_off = rect_start + rect_bytes + 2;
+        if data.len() < fc_off + 2 {
+            return None;
+        }
+        Some(u16::from_le_bytes([data[fc_off], data[fc_off + 1]]))
+    }
+
+    /// Resolve a Flash member's registration point, matching Director's
+    /// `member.regPoint`:
+    /// - `centerRegPoint == true` → the CENTER of the member rect. Director
+    ///   resets the regPoint to center and returns that (pengapop's
+    ///   menuAdOnline: 380×413 → point(190, 206)).
+    /// - `centerRegPoint == false` → the stored authored regPoint
+    ///   (QuickDraw-swapped in FlashInfo::from) — bogey_nights' straw/longarm:
+    ///   point(109, 63).
+    /// `swf_data` is the SWF bytes, used only as a size fallback when the member
+    /// rect is empty. Returns (0, 0) when no FlashInfo is available.
+    fn flash_reg_point(
+        flash_info: Option<&crate::director::enums::FlashInfo>,
+        swf_data: &[u8],
+    ) -> (i16, i16) {
+        match flash_info {
+            Some(info) if info.center_reg_point => {
+                let (l, t, r, b) = info.flash_rect;
+                if r - l > 0 && b - t > 0 {
+                    (((r - l) / 2) as i16, ((b - t) / 2) as i16)
+                } else if let Some((w, h)) = Self::parse_swf_dimensions(swf_data) {
+                    ((w / 2) as i16, (h / 2) as i16)
+                } else {
+                    (0, 0)
+                }
+            }
+            Some(info) if info.reg_point != (0, 0) => {
+                (info.reg_point.0 as i16, info.reg_point.1 as i16)
+            }
+            Some(info) => (info.origin_h as i16, info.origin_v as i16),
+            None => {
+                // No FlashInfo: default to center registration from SWF dims.
+                if let Some((w, h)) = Self::parse_swf_dimensions(swf_data) {
+                    ((w / 2) as i16, (h / 2) as i16)
+                } else {
+                    (0, 0)
+                }
+            }
+        }
+    }
+
     fn make_swf_member(number: u32, chunk: &CastMemberChunk, data: Vec<u8>) -> CastMember {
         // For native Flash members the FlashInfo was parsed during chunk
         // ingest (cast_member.rs:140 `MemberType::Flash` branch). For
@@ -3566,25 +3635,7 @@ impl CastMember {
         // wrong (the old code halved it, getting quarter-size offsets),
         // while parse_swf_dimensions reads straight from the SWF's
         // FrameSize record so it always matches what Ruffle renders.
-        let reg_point = if let Some(ref info) = flash_info {
-            if info.center_reg_point {
-                if let Some((w, h)) = Self::parse_swf_dimensions(&data) {
-                    ((w / 2) as i16, (h / 2) as i16)
-                } else {
-                    (info.reg_point.0 as i16, info.reg_point.1 as i16)
-                }
-            } else {
-                (info.origin_h as i16, info.origin_v as i16)
-            }
-        } else {
-            // OLE-wrapped SWF without a parseable FlashInfo header:
-            // default to center registration from SWF dimensions
-            if let Some((w, h)) = Self::parse_swf_dimensions(&data) {
-                ((w / 2) as i16, (h / 2) as i16)
-            } else {
-                (0, 0)
-            }
-        };
+        let reg_point = Self::flash_reg_point(flash_info.as_ref(), &data);
 
         CastMember {
             number,
@@ -3593,7 +3644,7 @@ impl CastMember {
             member_type: CastMemberType::Flash(FlashMember { data, reg_point, flash_info }),
             color: ColorRef::PaletteIndex(255),
             bg_color: ColorRef::PaletteIndex(0),
-            reg_point: (0, 0),
+            reg_point: (reg_point.0 as i32, reg_point.1 as i32),
         }
     }
 
@@ -5042,30 +5093,40 @@ impl CastMember {
                 // make_swf_member site for the same rationale —
                 // FlashInfo.reg_point can be stale; parse_swf_dimensions
                 // reads the SWF FrameSize header directly).
-                let flash_info = chunk.specific_data.flash_info().cloned();
+                // Mirror make_swf_member: the FLSH payload is sometimes in the
+                // parsed specific_data and sometimes only in specific_data_raw.
+                // Without the raw fallback, native Flash members got flash_info
+                // = None → reg_point defaulted to (0,0) (bogey_nights' arm read
+                // regPoint point(0,0) instead of Director's point(109,63)).
+                let flash_info = chunk
+                    .specific_data
+                    .flash_info()
+                    .cloned()
+                    .or_else(|| crate::director::enums::FlashInfo::from(&chunk.specific_data_raw));
                 let bytes_opt = Self::get_first_child_bytes(member_def);
-                let reg_point = if let Some(ref info) = flash_info {
-                    if info.center_reg_point {
-                        if let Some((w, h)) = bytes_opt
-                            .as_deref()
-                            .and_then(Self::parse_swf_dimensions)
-                        {
-                            ((w / 2) as i16, (h / 2) as i16)
-                        } else {
-                            (info.reg_point.0 as i16, info.reg_point.1 as i16)
-                        }
-                    } else {
-                        (info.origin_h as i16, info.origin_v as i16)
-                    }
-                } else {
-                    (0, 0)
-                };
-                if let Some(bytes) = bytes_opt {
+                let reg_point = Self::flash_reg_point(
+                    flash_info.as_ref(),
+                    bytes_opt.as_deref().unwrap_or(&[]),
+                );
+                let flash_member_type = if let Some(bytes) = bytes_opt {
                     CastMemberType::Flash(FlashMember { data: bytes, reg_point, flash_info })
                 } else {
                     warn!("Flash cast member has no data chunk or it is invalid.");
                     CastMemberType::Flash(FlashMember { data: vec![], reg_point, flash_info })
-                }
+                };
+                // Early-return a full CastMember so the computed reg point lands
+                // on CastMember.reg_point too — `member.regPoint` reads that
+                // (CastMember-level) value, not the FlashMember's. Matches the
+                // make_swf_member (OLE) path.
+                return CastMember {
+                    number,
+                    name: chunk.member_info.as_ref().map(|x| x.name.to_owned()).unwrap_or_default(),
+                    comments: chunk.member_info.as_ref().map(|x| x.comments.to_owned()).unwrap_or_default(),
+                    member_type: flash_member_type,
+                    color: ColorRef::PaletteIndex(255),
+                    bg_color: ColorRef::PaletteIndex(0),
+                    reg_point: (reg_point.0 as i32, reg_point.1 as i32),
+                };
             }
             MemberType::Ole => {
                 Self::log_ole_start(number, cast_lib, chunk);

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -2775,7 +2775,11 @@ impl CastMemberTypeId {
             Self::Shockwave3d => Ok("shockwave3d"),
             Self::HavokPhysics => Ok("havok"),
             Self::PhysXPhysics => Ok("physics"),
-            Self::Groove3gm => Ok("groove"),
+            // Director/Groove report .3GM shape members as #G3D — the Groove
+            // Lingo gates shape loading on `member.type = #G3D`
+            // (gGroove: LoadShape only if #G3D), so returning #groove made every
+            // shape get skipped → ShapeID -1 → no 3D world.
+            Self::Groove3gm => Ok("g3d"),
             Self::Unknown => Ok("unknown"),
         };
     }

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -158,6 +158,14 @@ pub struct TextMember {
     pub bottom_spacing: i16,
     pub width: u16,
     pub height: u16,
+    /// True once Lingo explicitly sets `member.rect`/`member.height` at runtime
+    /// (e.g. Habbo's Text-Wrapper does `member.rect = rect(0,0,w,h)`). Director
+    /// honors such an explicit size even for `#adjust` members, and crucially
+    /// `member.image.height` must then equal `member.rect.height` — otherwise the
+    /// `pimage.copyPixels(member.image, dest=image-height, src=member.rect)` bake
+    /// stretches the text vertically. Distinguishes the runtime-set case from a
+    /// stale single-line authored height (wrap-only #adjust must still measure).
+    pub rect_set_at_runtime: bool,
     pub char_spacing: i32,
     pub tab_stops: Vec<TabStop>,
     pub html_styled_spans: Vec<StyledSpan>,
@@ -446,6 +454,7 @@ impl TextMember {
             anti_alias: false,
             width: 100,
             height: 20,
+            rect_set_at_runtime: false,
             char_spacing: 0,
             tab_stops: Vec::new(),
             html_styled_spans: Vec::new(),
@@ -4240,6 +4249,7 @@ impl CastMember {
             bottom_spacing: styled_text.bottom_spacing as i16,
             width: box_w,
             height: box_h,
+            rect_set_at_runtime: false,
             char_spacing: styled_text.styled_spans.first()
                 .map(|s| s.style.char_spacing as i32)
                 .unwrap_or(0),

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -2218,10 +2218,6 @@ pub struct HavokPhysicsState {
     /// Disabled for HKE scene games where bodies are auto-created from W3D nodes,
     /// because those scenes need proper GJK collision instead of a simple ground clamp.
     pub use_ground_constraint: bool,
-    /// Persistent body-pair contact manifolds for the GJK narrow phase, warm-started
-    /// across substeps/frames. Key is `(min_index, max_index)`. Rebuilt by refresh
-    /// each step; not cloned (transient).
-    pub manifolds: std::collections::HashMap<(usize, usize), crate::player::handlers::datum_handlers::cast_member::havok_physics::Manifold>,
 }
 
 impl Clone for HavokPhysicsState {
@@ -2252,7 +2248,6 @@ impl Clone for HavokPhysicsState {
             collision_meshes: Vec::new(), // Not cloned — rebuilt on initialize
             collision_list_cache: Vec::new(),
             use_ground_constraint: self.use_ground_constraint,
-            manifolds: std::collections::HashMap::new(), // transient — rebuilt by refresh
         }
     }
 }
@@ -2294,7 +2289,6 @@ impl Default for HavokPhysicsState {
             collision_meshes: Vec::new(),
             collision_list_cache: Vec::new(),
             use_ground_constraint: true,
-            manifolds: std::collections::HashMap::new(),
         }
     }
 }

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -2639,6 +2639,94 @@ impl CastMemberType {
     }
 }
 
+/// Decode an RTE member's RTE2 pre-rendered bitmap into 32-bit RGBA.
+///
+/// Format (matches ScummVM's Director `RTE2::createSurface`):
+/// - Header: width (BE u16), height (BE u16), bpp (BE u16, =4), flags (2) = 8B.
+/// - Body, scanned per row left-to-right. Each step reads a `check` byte:
+///   - `check == 0x1f`: color-change escape — the next 3 bytes are r,g,b for
+///     subsequent pixels.
+///   - otherwise alpha = `check * 255 / max` where `max = (1<<bpp)-1` (15).
+///     - if `check == 0` or `check == max` (the run-coded extremes): read a
+///       `count` byte and emit `count` pixels of that alpha. The special
+///       `check==0, count==0` means end-of-line (rest stays transparent).
+///     - else (intermediate alpha): a single pixel.
+///
+/// `fg` is the default foreground color (from the cast member's info); inline
+/// `0x1f` escapes override it. Returns (width, height, rgba) or None.
+fn decode_rte2_bitmap(data: &[u8], fg: (u8, u8, u8)) -> Option<(u16, u16, Vec<u8>)> {
+    if data.len() < 8 {
+        return None;
+    }
+    let w = ((data[0] as usize) << 8) | data[1] as usize;
+    let h = ((data[2] as usize) << 8) | data[3] as usize;
+    if w == 0 || h == 0 || w > 4096 || h > 4096 {
+        return None;
+    }
+    let mut bpp = ((data[4] as u32) << 8) | data[5] as u32;
+    if bpp == 0 || bpp > 8 {
+        bpp = 4;
+    }
+    let max = (1u32 << bpp) - 1;
+    let p = &data[8..];
+    let mut rgba = vec![0u8; w * h * 4];
+    let (mut r, mut g, mut b) = fg;
+    let mut i = 0usize;
+    for y in 0..h {
+        let mut x = 0usize;
+        while x < w {
+            if i >= p.len() {
+                break;
+            }
+            let check = p[i] as u32;
+            i += 1;
+            if check == 0x1f {
+                // Color-change escape: next 3 bytes are r,g,b.
+                if i + 2 < p.len() {
+                    r = p[i];
+                    g = p[i + 1];
+                    b = p[i + 2];
+                    i += 3;
+                }
+                continue;
+            }
+            let alpha = (check * 255 / max) as u8;
+            if check == 0 || check == max {
+                // Run-coded extreme: a count byte follows.
+                if i >= p.len() {
+                    break;
+                }
+                let count = p[i];
+                i += 1;
+                if count == 0 && check == 0 {
+                    // End of line — remaining pixels stay transparent.
+                    break;
+                }
+                for _ in 0..count {
+                    if x >= w {
+                        break;
+                    }
+                    let idx = (y * w + x) * 4;
+                    rgba[idx] = r;
+                    rgba[idx + 1] = g;
+                    rgba[idx + 2] = b;
+                    rgba[idx + 3] = alpha;
+                    x += 1;
+                }
+            } else {
+                // Intermediate alpha: single pixel.
+                let idx = (y * w + x) * 4;
+                rgba[idx] = r;
+                rgba[idx + 1] = g;
+                rgba[idx + 2] = b;
+                rgba[idx + 3] = alpha;
+                x += 1;
+            }
+        }
+    }
+    Some((w as u16, h as u16, rgba))
+}
+
 impl CastMember {
     fn chunk_type_name(c: &Chunk) -> &'static str {
         match c {
@@ -2658,6 +2746,8 @@ impl CastMember {
             Chunk::ScoreOrder(_) => "ScoreOrder",
             Chunk::TileList(_) => "TileList",
             Chunk::Text(_) => "Text",
+            Chunk::RteText(_) => "RteText",
+            Chunk::RteBitmap(_) => "RteBitmap",
             Chunk::Bitmap(_) => "Bitmap",
             Chunk::Palette(_) => "Palette",
             Chunk::Sound(_) => "Sound",
@@ -3699,7 +3789,7 @@ impl CastMember {
                 text_member.script_id = xmed_script_id;
                 text_member.member_script_ref = Some(CastMemberRef {
                     cast_lib: cast_lib as i32,
-                    cast_member: xmed_script_id as i32,
+                    cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
                 });
             }
             return Some(CastMember {
@@ -4120,7 +4210,7 @@ impl CastMember {
         let xmed_member_script_ref = if xmed_script_id > 0 {
             Some(CastMemberRef {
                 cast_lib: cast_lib as i32,
-                cast_member: xmed_script_id as i32,
+                cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
             })
         } else {
             None
@@ -4556,7 +4646,7 @@ impl CastMember {
                     field_member.script_id = field_script_id;
                     field_member.member_script_ref = Some(CastMemberRef {
                         cast_lib: cast_lib as i32,
-                        cast_member: field_script_id as i32,
+                        cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
                     });
                 }
 
@@ -4613,7 +4703,7 @@ impl CastMember {
                         .map(|info| info.header.script_id)
                         .unwrap_or(0);
                     let member_script_ref = if script_id > 0 {
-                        Some(CastMemberRef { cast_lib: cast_lib as i32, cast_member: script_id as i32 })
+                        Some(CastMemberRef { cast_lib: cast_lib as i32, cast_member: number as i32 })
                     } else { None };
                     debug!("Flash member {} is a Shape (via shape_info), script_id={}", number, script_id);
                     return CastMember {
@@ -4650,7 +4740,7 @@ impl CastMember {
                             .map(|info| info.header.script_id)
                             .unwrap_or(0);
                         let member_script_ref = if script_id > 0 {
-                            Some(CastMemberRef { cast_lib: cast_lib as i32, cast_member: script_id as i32 })
+                            Some(CastMemberRef { cast_lib: cast_lib as i32, cast_member: number as i32 })
                         } else { None };
                         debug!("Flash member {} is actually a Shape! script_id={}", number, script_id);
                         return CastMember {
@@ -4906,7 +4996,7 @@ impl CastMember {
                     // Create the behavior script reference
                     Some(CastMemberRef {
                         cast_lib: cast_lib as i32,
-                        cast_member: script_id as i32,
+                        cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
                     })
                 } else {
                     None
@@ -5023,7 +5113,7 @@ impl CastMember {
                 let member_script_ref = if script_id > 0 {
                     Some(CastMemberRef {
                         cast_lib: cast_lib as i32,
-                        cast_member: script_id as i32,
+                        cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
                     })
                 } else {
                     None
@@ -5326,7 +5416,7 @@ impl CastMember {
                     let _script_chunk = &lctx.as_ref().unwrap().scripts[&script_id];
                     Some(CastMemberRef {
                         cast_lib: cast_lib as i32,
-                        cast_member: script_id as i32,
+                        cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
                     })
                 } else {
                     None
@@ -5345,6 +5435,119 @@ impl CastMember {
                     script_id,
                     member_script_ref: behavior_script_ref,
                 })
+            }
+            MemberType::RTE => {
+                // Rich Text Editor cast member (Director type 12). Children:
+                // RTE0 = style runs (commonly empty), RTE1 = plain text,
+                // RTE2 = a pre-rendered anti-aliased bitmap. Director displays
+                // the RTE2 bitmap, so we decode it and surface the member as a
+                // Bitmap — that gives the exact authored visual (anti-aliased,
+                // correctly colored) AND reuses Bitmap members' existing
+                // cast-member-attached script support (header.script_id), so an
+                // `on mouseUp` navigation handler fires just like Field/Bitmap
+                // buttons. These scripts are not stored as separate Script cast
+                // members. Previously RTE fell through to `_` and became
+                // CastMemberType::Unknown, so the labels were invisible and the
+                // buttons dead (SpongeBob JellyFishin' "next"/"play"/
+                // "instructions").
+
+                let script_id = chunk
+                    .member_info
+                    .as_ref()
+                    .map(|info| info.header.script_id)
+                    .unwrap_or(0);
+                let member_script_ref = if script_id > 0 {
+                    Some(CastMemberRef {
+                        cast_lib: cast_lib as i32,
+                        cast_member: number as i32, // member's own slot; attached script registered at scripts[number]
+                    })
+                } else {
+                    None
+                };
+
+                // Foreground color from cast info specific_data. Layout (34
+                // bytes): rect(0..8), pageRect(8..16), misc(16..25), then an
+                // RGB triple. RTE0 style runs are empty so this is the only
+                // color source. Default to white (visible) if absent.
+                let raw = chunk.specific_data_raw.as_slice();
+                let fg = if raw.len() >= 28 {
+                    (raw[25], raw[26], raw[27])
+                } else {
+                    (255, 255, 255)
+                };
+
+                let rte2 = member_def
+                    .children
+                    .iter()
+                    .find_map(|c| c.as_ref().and_then(|ch| ch.as_rte_bitmap()));
+
+                if let Some((w, h, rgba)) = rte2.and_then(|d| decode_rte2_bitmap(d, fg)) {
+                    let bitmap = Bitmap {
+                        width: w,
+                        height: h,
+                        bit_depth: 32,
+                        original_bit_depth: 32,
+                        data: rgba,
+                        palette_ref: PaletteRef::Default,
+                        matte: None,
+                        use_alpha: true,
+                        trim_white_space: false,
+                        was_trimmed: false,
+                        version: 0,
+                    };
+                    let image_ref = bitmap_manager.add_bitmap(bitmap);
+                    let info = crate::director::enums::BitmapInfo {
+                        width: w,
+                        height: h,
+                        // RTE members register top-left like text (reg point 0,0),
+                        // not bitmap-center, so the score sprite lands correctly.
+                        reg_x: 0,
+                        reg_y: 0,
+                        bit_depth: 32,
+                        use_alpha: true,
+                        ..Default::default()
+                    };
+                    debug!(
+                        "RTE member #{} name='{}' -> Bitmap {}x{} fg={:?} script_id={}",
+                        number,
+                        chunk.member_info.as_ref().map(|x| x.name.as_str()).unwrap_or(""),
+                        w, h, fg, script_id,
+                    );
+                    CastMemberType::Bitmap(BitmapMember {
+                        image_ref,
+                        reg_point: (0, 0),
+                        script_id,
+                        member_script_ref,
+                        info,
+                    })
+                } else {
+                    // No decodable RTE2 — fall back to a TextMember from RTE1
+                    // so text/clicks still work.
+                    let rte_text = member_def
+                        .children
+                        .iter()
+                        .find_map(|c| c.as_ref().and_then(|ch| ch.as_rte_text()))
+                        .unwrap_or_default()
+                        .to_string();
+                    let mut text_member = TextMember::new();
+                    text_member.text = rte_text;
+                    if raw.len() >= 8 {
+                        let be = |i: usize| ((raw[i] as u16) << 8) | (raw[i + 1] as u16);
+                        let w = be(6).saturating_sub(be(2));
+                        let h = be(4).saturating_sub(be(0));
+                        if w > 0 { text_member.width = w; }
+                        if h > 0 { text_member.height = h; }
+                    }
+                    text_member.script_id = script_id;
+                    text_member.member_script_ref = member_script_ref;
+                    debug!(
+                        "RTE member #{} name='{}' (no RTE2) -> TextMember text='{}' script_id={}",
+                        number,
+                        chunk.member_info.as_ref().map(|x| x.name.as_str()).unwrap_or(""),
+                        text_member.text, script_id,
+                    );
+                    CastMemberType::Text(text_member)
+                }
             }
             _ => {
                 // Assuming `chunk.member_type` is an enum backed by a numeric ID

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -996,6 +996,64 @@ pub struct FilmLoopMember {
     pub cached_total_frames: Option<u32>,
 }
 
+/// A Linked Movie cast member (`#movie`) — references an external Director
+/// movie (.dir/.dcr) that plays inside a sprite (Director 11.5 Scripting
+/// Dictionary "Linked Movie" media type). Created at runtime via
+/// `new(#movie)`, linked via `member.fileName = <path/url>`, and played by
+/// assigning it to a sprite. The parsed movie is held behind an `Rc` so the
+/// member stays cheap to clone and the (large) file isn't deep-copied.
+///
+/// Phase 1 stores the parsed `DirectorFile` + the linked-movie properties;
+/// nested score advancement + script execution + compositing into the host
+/// sprite are Phase 2 (modelled on `FilmLoopMember`).
+#[derive(Clone)]
+pub struct MovieMember {
+    /// The linked file path/URL (`the fileName of member`).
+    pub file_name: String,
+    /// Whether the linked movie's Lingo runs (`scriptsEnabled`). Director
+    /// defaults linked-movie scripts OFF; callers opt in (DGS sets it to 1).
+    pub scripts_enabled: bool,
+    /// Crop (TRUE) vs scale-to-fit (FALSE) within the sprite rect.
+    pub crop: bool,
+    /// Center the movie within the sprite rect when cropping.
+    pub center: bool,
+    /// Play the linked movie's sound.
+    pub sound: bool,
+    /// Loop the linked movie's playback.
+    pub loops: bool,
+    /// Member width/height (from the authored rect: right-left, bottom-top).
+    pub width: u16,
+    pub height: u16,
+    pub reg_point: (i16, i16),
+    /// Raw .dir/.dcr bytes of the linked movie, captured by the `fileName`
+    /// setter from the net preload cache. `None` until linked. Held behind an
+    /// `Rc` so the member stays cheap to clone; the live nested `Movie` is
+    /// parsed/built from these bytes at activation into the player's nested
+    /// registry (a built `Movie` isn't `Clone`, so it can't live on the member).
+    pub bytes: Option<std::rc::Rc<Vec<u8>>>,
+    /// Base URL the linked movie's own relative references resolve against
+    /// (derived from the resolved net-task URL at fileName time).
+    pub base_url: String,
+}
+
+impl MovieMember {
+    pub fn new() -> Self {
+        Self {
+            file_name: String::new(),
+            scripts_enabled: false,
+            crop: true,
+            center: true,
+            sound: true,
+            loops: true,
+            width: 0,
+            height: 0,
+            reg_point: (0, 0),
+            bytes: None,
+            base_url: String::new(),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct SoundMember {
     pub info: SoundInfo,
@@ -2599,6 +2657,7 @@ pub enum CastMemberType {
     Sound(SoundMember),
     Font(FontMember),
     Flash(FlashMember),
+    Movie(MovieMember),
     Shockwave3d(Shockwave3dMember),
     HavokPhysics(HavokPhysicsMember),
     PhysXPhysics(PhysXPhysicsMember),
@@ -2619,6 +2678,7 @@ pub enum CastMemberTypeId {
     Sound,
     Font,
     Flash,
+    Movie,
     Shockwave3d,
     HavokPhysics,
     PhysXPhysics,
@@ -2664,6 +2724,9 @@ impl fmt::Debug for CastMemberType {
             Self::Flash(_) => {
                 write!(f, "Flash")
             }
+            Self::Movie(_) => {
+                write!(f, "Movie")
+            }
             Self::Shockwave3d(_) => {
                 write!(f, "Shockwave3d")
             }
@@ -2695,6 +2758,7 @@ impl CastMemberTypeId {
             Self::Sound => Ok("sound"),
             Self::Font => Ok("font"),
             Self::Flash => Ok("flash"),
+            Self::Movie => Ok("movie"),
             Self::Shockwave3d => Ok("shockwave3d"),
             Self::HavokPhysics => Ok("havok"),
             Self::PhysXPhysics => Ok("physics"),
@@ -2718,6 +2782,7 @@ impl CastMemberType {
             Self::Sound(_) => CastMemberTypeId::Sound,
             Self::Font(_) => CastMemberTypeId::Font,
             Self::Flash(_) => CastMemberTypeId::Flash,
+            Self::Movie(_) => CastMemberTypeId::Movie,
             Self::Shockwave3d(_) => CastMemberTypeId::Shockwave3d,
             Self::HavokPhysics(_) => CastMemberTypeId::HavokPhysics,
             Self::PhysXPhysics(_) => CastMemberTypeId::PhysXPhysics,
@@ -2739,6 +2804,7 @@ impl CastMemberType {
             Self::Sound(_) => "sound",
             Self::Font(_) => "font",
             Self::Flash(_) => "flash",
+            Self::Movie(_) => "movie",
             Self::Shockwave3d(w3d) => if w3d.converted_from_text { "text" } else { "shockwave3d" },
             Self::HavokPhysics(_) => "havok",
             Self::PhysXPhysics(_) => "physics",
@@ -2862,6 +2928,20 @@ impl CastMemberType {
     pub fn as_flash_mut(&mut self) -> Option<&mut FlashMember> {
         return match self {
             Self::Flash(data) => { Some(data) }
+            _ => { None }
+        }
+    }
+
+    pub fn as_movie(&self) -> Option<&MovieMember> {
+        return match self {
+            Self::Movie(data) => { Some(data) }
+            _ => { None }
+        }
+    }
+
+    pub fn as_movie_mut(&mut self) -> Option<&mut MovieMember> {
+        return match self {
+            Self::Movie(data) => { Some(data) }
             _ => { None }
         }
     }
@@ -5520,6 +5600,50 @@ impl CastMember {
                         cached_total_frames: None,
                     })
                 }
+            }
+            MemberType::Movie => {
+                // Linked Movie (`#movie`) member. The linked .dir/.dcr path is
+                // stored in the member info's file_name; content is fetched at
+                // play time (linked, not embedded), so `bytes` stay None until
+                // the fileName setter / activation loads them. Playback flags
+                // share the FilmLoop specific-data layout (reg_point + a flags
+                // byte: center=bit0, crop=1-bit1, sound=bit3, loop=1-bit5);
+                // scriptsEnabled is a Movie-only extra flag (bit TBD, mapped via
+                // the hex dump below).
+                let mut mv = MovieMember::new();
+                if let Some(info) = chunk.member_info.as_ref() {
+                    mv.file_name = info.file_name.clone();
+                }
+                // Specific-data layout (big-endian), fully verified by toggling
+                // each property in Director MX 2004 and diffing the flags byte:
+                //   [0..8]  QuickDraw rect: top, left, bottom, right (u16 each)
+                //   [8..11] reserved (0)
+                //   [11]    flags byte:
+                //             bit0 (0x01) center
+                //             bit1 (0x02) crop        (inverted: crop = !bit1)
+                //             bit3 (0x08) sound
+                //             bit4 (0x10) scriptsEnabled
+                //             bit5 (0x20) loop        (inverted: loop = !bit5)
+                //           (bit2 0x04 is an always-set flag, ignored)
+                //   [12..14] reserved (0)
+                // place_holder.dcr: rect(200,150,300,250) -> 100x100, regPoint
+                // center (50,50); flags 0x0E -> center=F crop=F sound=T
+                // scriptsEnabled=F loop=T (and 0x3E -> scriptsEnabled=T loop=F).
+                let sd = chunk.specific_data_raw.as_slice();
+                let be16 = |i: usize| -> u16 {
+                    if i + 1 < sd.len() { u16::from_be_bytes([sd[i], sd[i + 1]]) } else { 0 }
+                };
+                let (top, left, bottom, right) = (be16(0), be16(2), be16(4), be16(6));
+                let flags = sd.get(11).copied().unwrap_or(0);
+                mv.width = right.saturating_sub(left);
+                mv.height = bottom.saturating_sub(top);
+                mv.reg_point = ((mv.width / 2) as i16, (mv.height / 2) as i16);
+                mv.center = (flags & 0x01) != 0;
+                mv.crop = (flags & 0x02) == 0;
+                mv.sound = (flags & 0x08) != 0;
+                mv.scripts_enabled = (flags & 0x10) != 0;
+                mv.loops = (flags & 0x20) == 0;
+                CastMemberType::Movie(mv)
             }
             MemberType::Sound => {
                 // Log children

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1256,6 +1256,12 @@ pub struct Shockwave3dRuntimeState {
     // ─── Detached nodes (parent set to VOID) ───
     pub detached_nodes: std::collections::HashSet<String>,
 
+    /// Manual per-bone LOCAL transform overrides from `bonesPlayer.bone[i].transform = t`.
+    /// Keyed by "modelname:boneindex" (lowercase). The skeleton build substitutes these
+    /// (resolving the bone's rest length for a zero translation), letting procedural
+    /// scripts like updateBoneRotation drive bones — the SweeTarts snake's S-wiggle.
+    pub bone_transform_overrides: std::collections::HashMap<String, [f32; 16]>,
+
     // ─── pointAtOrientation per node ───
     /// Per-node pointAtOrientation: node_name -> (front_axis, up_axis)
     /// Default: ([0,0,1], [0,1,0]) — +Z front, +Y up

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1851,6 +1851,11 @@ pub struct HavokRigidBody {
     pub friction: f64,
     pub active: bool,
     pub pinned: bool,
+    /// HKE `COLLISIONS_DISABLED`: body integrates but is never registered for
+    /// collision detection (skipped by the narrow phase).
+    pub collisions_disabled: bool,
+    /// HKE `CASTS_SHADOWS`: render metadata (display-body shadow); physics no-op.
+    pub casts_shadows: bool,
     pub linear_velocity: [f64; 3],
     pub angular_velocity: [f64; 3],
     pub linear_momentum: [f64; 3],
@@ -1863,10 +1868,23 @@ pub struct HavokRigidBody {
     pub is_convex: bool,
     /// Half-extents of the mesh bounding box, for box inertia computation.
     pub inertia_half_extents: [f64; 3],
-    /// True once the body has received a hover/drive force (applyForce /
-    /// applyForceAtPoint). Such bodies (e.g. the SuperSonic car) keep the
-    /// original collision path; force-free objects use the box-stacking path.
+    /// A Lingo-created movable body defaults to the script-driven vehicle path
+    /// (raycast cars: held up by hover forces, off the box-stacking path). HKE
+    /// bodies load as `false` (passive). A force-free body that is positioned
+    /// kinematically (interpolatingMoveTo) is reclassified to `false` so the
+    /// add-cubes demo box-stacks — see `received_force`.
     pub driven: bool,
+    /// Set once any applied force/torque (applyForce/applyForceAtPoint/
+    /// applyTorque) hits this body. A raycast car hovers every frame, so this is
+    /// true before its recovery interpolatingMoveTo runs — which is how we tell a
+    /// hover vehicle (keep `driven`) from a kinematically-placed stacking block
+    /// (clear `driven`). Never set for the falling cubes.
+    pub received_force: bool,
+    /// True for #box-primitive bodies. A box must not be given the sphere
+    /// "rolling" (ω = v/r) the resting-surface constraint applies to round
+    /// bodies — it slides/tumbles instead. Spheres, cylinders/coins, cars and
+    /// meshes leave this false and keep rolling.
+    pub is_box: bool,
     /// Authored per-axis model scale from the W3D transform, preserved so the
     /// rendered model keeps its size when physics writes back its transform
     /// (the finaldrive car is authored at 0.296×; losing it makes the RaycastCar
@@ -1933,6 +1951,8 @@ impl HavokRigidBody {
             friction: 0.5,
             active: true,
             pinned: false,
+            collisions_disabled: false,
+            casts_shadows: false,
             linear_velocity: [0.0; 3],
             angular_velocity: [0.0; 3],
             linear_momentum: [0.0; 3],
@@ -1945,6 +1965,8 @@ impl HavokRigidBody {
             is_convex,
             inertia_half_extents: [10.0; 3],
             driven: false,
+            received_force: false,
+            is_box: false,
             sync_scale: [1.0; 3],
             orientation: [1.0, 0.0, 0.0, 0.0],
             inverse_mass: if mass > 0.0 { 1.0 / mass } else { 0.0 },
@@ -1977,6 +1999,8 @@ impl HavokRigidBody {
             friction: 0.5,
             active: false,
             pinned: true,
+            collisions_disabled: false,
+            casts_shadows: false,
             linear_velocity: [0.0; 3],
             angular_velocity: [0.0; 3],
             linear_momentum: [0.0; 3],
@@ -1989,6 +2013,8 @@ impl HavokRigidBody {
             is_convex,
             inertia_half_extents: [10.0; 3],
             driven: false,
+            received_force: false,
+            is_box: false,
             sync_scale: [1.0; 3],
             orientation: [1.0, 0.0, 0.0, 0.0],
             inverse_mass: 0.0,
@@ -2192,6 +2218,10 @@ pub struct HavokPhysicsState {
     /// Disabled for HKE scene games where bodies are auto-created from W3D nodes,
     /// because those scenes need proper GJK collision instead of a simple ground clamp.
     pub use_ground_constraint: bool,
+    /// Persistent body-pair contact manifolds for the GJK narrow phase, warm-started
+    /// across substeps/frames. Key is `(min_index, max_index)`. Rebuilt by refresh
+    /// each step; not cloned (transient).
+    pub manifolds: std::collections::HashMap<(usize, usize), crate::player::handlers::datum_handlers::cast_member::havok_physics::Manifold>,
 }
 
 impl Clone for HavokPhysicsState {
@@ -2222,6 +2252,7 @@ impl Clone for HavokPhysicsState {
             collision_meshes: Vec::new(), // Not cloned — rebuilt on initialize
             collision_list_cache: Vec::new(),
             use_ground_constraint: self.use_ground_constraint,
+            manifolds: std::collections::HashMap::new(), // transient — rebuilt by refresh
         }
     }
 }
@@ -2263,6 +2294,7 @@ impl Default for HavokPhysicsState {
             collision_meshes: Vec::new(),
             collision_list_cache: Vec::new(),
             use_ground_constraint: true,
+            manifolds: std::collections::HashMap::new(),
         }
     }
 }

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1307,7 +1307,7 @@ pub struct Shockwave3dRuntimeState {
 /// exposed through the `model.collision` property. Detection runs each frame
 /// in `events::tick_w3d_collisions`; only detection + callback dispatch are
 /// implemented — resolution is a no-op (every consumer so far sets `resolve = 0`).
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct W3dCollisionModifier {
     /// `collision.enabled` — whether collisions with this model are detected.
     pub enabled: bool,
@@ -1321,6 +1321,27 @@ pub struct W3dCollisionModifier {
     /// Handler registered via `collision.setCollisionCallback(#handler, instance)`.
     pub callback_handler: Option<String>,
     pub callback_instance: Option<crate::player::script_ref::ScriptInstanceRef>,
+    /// The raw 2nd arg of `setCollisionCallback(#handler, target)`. Director
+    /// invokes a non-instance target's handler as `on handler target, collisionData`
+    /// (the object is the handler's FIRST param), so we keep it to pass through.
+    /// For a script-instance target this is unused (that path binds `me`).
+    pub callback_target: Option<crate::director::lingo::datum::Datum>,
+}
+
+// Manual Debug: `Datum` doesn't implement Debug (it uses `format_datum`), so
+// derive can't cover `callback_target`; just report whether one is set.
+impl std::fmt::Debug for W3dCollisionModifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("W3dCollisionModifier")
+            .field("enabled", &self.enabled)
+            .field("resolve", &self.resolve)
+            .field("immovable", &self.immovable)
+            .field("mode", &self.mode)
+            .field("callback_handler", &self.callback_handler)
+            .field("callback_instance", &self.callback_instance)
+            .field("callback_target", &self.callback_target.is_some())
+            .finish()
+    }
 }
 
 impl Default for W3dCollisionModifier {
@@ -1332,6 +1353,7 @@ impl Default for W3dCollisionModifier {
             mode: "mesh".to_string(),
             callback_handler: None,
             callback_instance: None,
+            callback_target: None,
         }
     }
 }

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1893,6 +1893,13 @@ pub struct HavokRigidBody {
     /// Set by the Lingo apply*/velocity setters each step so a per-frame-forced
     /// body (a driven car) never auto-sleeps. Cleared after the sleep check.
     pub lingo_disturbed: bool,
+    /// Authored initial state, snapshotted when the body is created, so
+    /// `havok.reset()` can revert the scene to the .hke-defined state.
+    pub initial_position: [f64; 3],
+    pub initial_orientation: [f64; 4],
+    pub initial_linear_velocity: [f64; 3],
+    pub initial_angular_velocity: [f64; 3],
+    pub initial_active: bool,
 }
 
 impl HavokRigidBody {
@@ -1945,6 +1952,11 @@ impl HavokRigidBody {
             resting_normal: None,
             sleep_countdown: 0.5,
             lingo_disturbed: false,
+            initial_position: [0.0; 3],
+            initial_orientation: [1.0, 0.0, 0.0, 0.0],
+            initial_linear_velocity: [0.0; 3],
+            initial_angular_velocity: [0.0; 3],
+            initial_active: true,
         }
     }
 
@@ -1984,7 +1996,39 @@ impl HavokRigidBody {
             resting_normal: None,
             sleep_countdown: 0.5,
             lingo_disturbed: false,
+            initial_position: [0.0; 3],
+            initial_orientation: [1.0, 0.0, 0.0, 0.0],
+            initial_linear_velocity: [0.0; 3],
+            initial_angular_velocity: [0.0; 3],
+            initial_active: true,
         }
+    }
+
+    /// Record the current transform/velocity as the authored initial state,
+    /// so `havok.reset()` can revert to it.
+    pub fn snapshot_initial(&mut self) {
+        self.initial_position = self.position;
+        self.initial_orientation = self.orientation;
+        self.initial_linear_velocity = self.linear_velocity;
+        self.initial_angular_velocity = self.angular_velocity;
+        self.initial_active = self.active;
+    }
+
+    /// Revert to the snapshotted initial state and clear all accumulated/derived
+    /// runtime state (forces, momenta, resting + sleep state). `havok.reset()`.
+    pub fn restore_initial(&mut self) {
+        self.position = self.initial_position;
+        self.orientation = self.initial_orientation;
+        self.linear_velocity = self.initial_linear_velocity;
+        self.angular_velocity = self.initial_angular_velocity;
+        self.active = self.initial_active;
+        self.force = [0.0; 3];
+        self.torque = [0.0; 3];
+        self.linear_momentum = [0.0; 3];
+        self.angular_momentum = [0.0; 3];
+        self.resting_normal = None;
+        self.sleep_countdown = 0.5;
+        self.lingo_disturbed = false;
     }
 }
 

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1093,6 +1093,59 @@ pub struct QueuedMotion {
     pub offset: f32,       // seconds, -1.0 = #synchronized
 }
 
+/// Per-MODEL bonesPlayer/keyframePlayer animation state.
+///
+/// Director keeps animation state PER MODEL (each model carries its own
+/// #bonesPlayer modifier), but the single fields on `Shockwave3dRuntimeState`
+/// are per-MEMBER. When several skinned models are cloned into one 3D member
+/// (e.g. Rasterwerks clones 5 bots into the single G3D world), they all shared
+/// one motion + one clock — the last `play()` won, so every bot was posed with
+/// the same motion's root rotation (wrong facing, frozen clock). The renderer
+/// skinning and the `bone[]` getters read this per-model map instead; the
+/// member-level single fields remain for the keyframe (motion_transforms) path.
+#[derive(Clone, Debug)]
+pub struct BonesPlayerState {
+    pub animation_time: f32,
+    pub animation_playing: bool,
+    pub current_motion: Option<String>,
+    pub play_rate: f32,
+    pub animation_loop: bool,
+    pub motion_queue: Vec<QueuedMotion>,
+    pub animation_start_time: f32,
+    pub animation_end_time: f32,
+    pub animation_blend_time: f32,
+    pub root_lock: bool,
+    pub animation_scale: f32,
+    pub motion_ended: bool,
+    pub previous_motion: Option<String>,
+    pub blend_weight: f32,
+    pub blend_duration: f32,
+    pub blend_elapsed: f32,
+}
+
+impl Default for BonesPlayerState {
+    fn default() -> Self {
+        Self {
+            animation_time: 0.0,
+            animation_playing: false,
+            current_motion: None,
+            play_rate: 1.0,
+            animation_loop: true,
+            motion_queue: Vec::new(),
+            animation_start_time: 0.0,
+            animation_end_time: -1.0,
+            animation_blend_time: 0.0,
+            root_lock: false,
+            animation_scale: 1.0,
+            motion_ended: false,
+            previous_motion: None,
+            blend_weight: 1.0,
+            blend_duration: 0.0,
+            blend_elapsed: 0.0,
+        }
+    }
+}
+
 /// Mutable runtime state for a Shockwave 3D member (animation, transforms, etc.)
 #[derive(Clone, Debug, Default)]
 pub struct Shockwave3dRuntimeState {
@@ -1116,6 +1169,11 @@ pub struct Shockwave3dRuntimeState {
     pub blend_weight: f32,       // 0.0 = all previous, 1.0 = all current
     pub blend_duration: f32,     // total blend time in seconds
     pub blend_elapsed: f32,      // time spent blending
+    /// Per-model animation state, keyed by model node name (lowercase). The
+    /// SOURCE OF TRUTH for skinned models — the single fields above are kept
+    /// for the keyframe (motion_transforms / non-skinned) path. See
+    /// [`BonesPlayerState`]. Access via `bones_player` / `bones_player_mut`.
+    pub bones_players: std::collections::HashMap<String, BonesPlayerState>,
 
     // ─── Per-node overrides (keyed by node name) ───
     /// Transform overrides for nodes (set via Lingo) — used by renderer
@@ -1465,6 +1523,45 @@ pub struct ParticleSystemState {
 }
 
 impl Shockwave3dRuntimeState {
+    /// Per-model bonesPlayer state (read), case-insensitive by model node name.
+    pub fn bones_player(&self, model: &str) -> Option<&BonesPlayerState> {
+        self.bones_players.get(&model.to_ascii_lowercase())
+    }
+
+    /// Per-model bonesPlayer state (mutable), creating a default entry on first
+    /// use. Director attaches a #bonesPlayer per model; play()/queue()/setters
+    /// route here so each model animates independently.
+    pub fn bones_player_mut(&mut self, model: &str) -> &mut BonesPlayerState {
+        self.bones_players.entry(model.to_ascii_lowercase()).or_default()
+    }
+
+    /// Mirror a model's per-node animation state into the member-level single
+    /// fields. The renderer skinning + bone getters read per-node, but the
+    /// keyframe (motion_transforms) block, auto-play, and legacy queue-pop
+    /// still read the single fields — so we keep them pointed at the most
+    /// recently-acted model (historical per-member behavior). Harmless for
+    /// skinned models (which never consult the single fields).
+    pub fn sync_legacy_from_bones_player(&mut self, model: &str) {
+        if let Some(bp) = self.bones_players.get(&model.to_ascii_lowercase()).cloned() {
+            self.animation_time = bp.animation_time;
+            self.animation_playing = bp.animation_playing;
+            self.current_motion = bp.current_motion;
+            self.play_rate = bp.play_rate;
+            self.animation_loop = bp.animation_loop;
+            self.motion_queue = bp.motion_queue;
+            self.animation_start_time = bp.animation_start_time;
+            self.animation_end_time = bp.animation_end_time;
+            self.animation_blend_time = bp.animation_blend_time;
+            self.root_lock = bp.root_lock;
+            self.animation_scale = bp.animation_scale;
+            self.motion_ended = bp.motion_ended;
+            self.previous_motion = bp.previous_motion;
+            self.blend_weight = bp.blend_weight;
+            self.blend_duration = bp.blend_duration;
+            self.blend_elapsed = bp.blend_elapsed;
+        }
+    }
+
     /// Create runtime state initialized with camera data from the 3DPR info
     /// and optionally auto-start animation if animationEnabled is set.
     pub fn from_info(info: &Shockwave3dInfo, scene: Option<&crate::director::chunks::w3d::types::W3dScene>) -> Self {

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -2089,6 +2089,10 @@ pub struct HavokCollisionInfo {
     pub body_b: String,
     pub point: [f64; 3],
     pub normal: [f64; 3],
+    /// Impact speed (|normal relative velocity|) at the contact. Passed to Lingo
+    /// collision callbacks as the 5th argument and gated against the
+    /// registerInterest threshold.
+    pub normal_rel_vel: f64,
 }
 
 pub struct HavokPhysicsState {

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1886,6 +1886,13 @@ pub struct HavokRigidBody {
     /// Set on first collision with a rigid-body-owned mesh. Used each
     /// substep to keep the body on the surface analytically.
     pub resting_normal: Option<RestingContact>,
+    /// Auto-sleep: seconds of continuous stillness left before the body
+    /// deactivates (so resting stacks stop jittering). Reset whenever the body
+    /// moves above threshold or is disturbed by Lingo.
+    pub sleep_countdown: f64,
+    /// Set by the Lingo apply*/velocity setters each step so a per-frame-forced
+    /// body (a driven car) never auto-sleeps. Cleared after the sleep check.
+    pub lingo_disturbed: bool,
 }
 
 impl HavokRigidBody {
@@ -1936,6 +1943,8 @@ impl HavokRigidBody {
             saved_linear_velocity: [0.0; 3],
             saved_angular_velocity: [0.0; 3],
             resting_normal: None,
+            sleep_countdown: 0.5,
+            lingo_disturbed: false,
         }
     }
 
@@ -1973,6 +1982,8 @@ impl HavokRigidBody {
             saved_linear_velocity: [0.0; 3],
             saved_angular_velocity: [0.0; 3],
             resting_normal: None,
+            sleep_countdown: 0.5,
+            lingo_disturbed: false,
         }
     }
 }

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -191,16 +191,18 @@ pub async fn run_command_loop(rx: Receiver<PlayerVMExecutionItem>) {
 }
 
 pub fn player_dispatch(command: PlayerVMCommand) {
-    if let Some(tx) = unsafe { PLAYER_TX.clone() } {
-        if let Err(e) = tx.try_send(PlayerVMExecutionItem {
-            command,
-            completer: None,
-        }) {
-            // The channel is closed or full
-            eprintln!("Failed to send command to player: {:?}", e);
-        }
-    } else {
-        eprintln!("PLAYER_TX not initialized");
+    // Route to the ACTIVE player's own command channel (not the global
+    // PLAYER_TX) so a nested `#movie` sub-player's commands land in its own
+    // queue, processed by its own command loop with its own active-player id.
+    // For the main player this is identical (main.queue_tx == the PLAYER_TX
+    // channel). Fall back to PLAYER_TX before any player exists (early boot).
+    let tx = reserve_player_ref(|p| p.queue_tx.clone());
+    if let Err(e) = tx.try_send(PlayerVMExecutionItem {
+        command,
+        completer: None,
+    }) {
+        // The channel is closed or full
+        eprintln!("Failed to send command to player: {:?}", e);
     }
 }
 
@@ -261,7 +263,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             player_load_system_font(&path).await;
         }
         PlayerVMCommand::LoadMovieFromFile(file_path, autoplay) => {
-            let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+            let player = unsafe { crate::player::player_mut() };
             match player.load_movie_from_file(&file_path).await {
                 Ok(()) => {
                     if autoplay {

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -69,6 +69,14 @@ pub enum PlayerVMCommand {
         handler_name: String,
         args: Vec<DatumRef>,
     },
+    /// Flash `LocalConnection.send` → the Lingo handler registered via
+    /// `setCallback` on a Director-created LocalConnection, dispatched to the
+    /// EXACT target instance (so `me` in `on myOnStatus me, ...` is correct).
+    TriggerLocalConnectionCallback {
+        target: ScriptInstanceRef,
+        handler_name: String,
+        args: Vec<DatumRef>,
+    },
     SetLingoScriptProperty {
         cast_lib: i32,
         cast_member: i32,
@@ -118,6 +126,9 @@ pub fn _format_player_cmd(command: &PlayerVMCommand) -> String {
         }
         PlayerVMCommand::TriggerLingoCallbackOnScript { cast_lib, cast_member, handler_name, .. } => {
             format!("TriggerLingoCallbackOnScript(cast_lib: {}, cast_member: {}, handler: {})", cast_lib, cast_member, handler_name)
+        }
+        PlayerVMCommand::TriggerLocalConnectionCallback { handler_name, .. } => {
+            format!("TriggerLocalConnectionCallback(handler: {})", handler_name)
         }
         PlayerVMCommand::SetLingoScriptProperty { cast_lib, cast_member, prop_name, .. } => {
             format!("SetLingoScriptProperty(cast_lib: {}, cast_member: {}, prop: {})", cast_lib, cast_member, prop_name)
@@ -1263,6 +1274,23 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                     &receiver_datum,
                     &handler.1,
                     &args
+                ).await;
+            }
+        }
+        PlayerVMCommand::TriggerLocalConnectionCallback { target, handler_name, args } => {
+            use super::handlers::datum_handlers::script_instance::ScriptInstanceDatumHandlers;
+            // Dispatch to the EXACT registered instance so `me` is right.
+            let handler_ref = reserve_player_ref(|player| {
+                let si = player.allocator.get_script_instance_opt(&target)?;
+                let script = player.movie.cast_manager.get_script_by_ref(&si.script)?;
+                script.get_own_handler_ref(&handler_name)
+            });
+            if let Some(handler) = handler_ref {
+                let receiver_datum = player_alloc_datum(Datum::ScriptInstanceRef(target));
+                let _ = ScriptInstanceDatumHandlers::call_async(
+                    &receiver_datum,
+                    &handler.1,
+                    &args,
                 ).await;
             }
         }

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -554,7 +554,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                 }
                 let rect = super::score::get_concrete_sprite_rect(player, sprite);
                 (
-                    Some((any_sprite as i32, x - rect.left, y - rect.top)),
+                    Some((any_sprite as i32, x - rect.left, y - rect.top, rect.right - rect.left, rect.bottom - rect.top)),
                     format!("Flash sprite#{} member={}:{} rect=({},{})-({},{})",
                         any_sprite, member_ref.cast_lib, member_ref.cast_member,
                         rect.left, rect.top, rect.right, rect.bottom),
@@ -604,7 +604,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                 }
             });
             debug!("[click sprite scripts] {}", sprite_scripts_dump);
-            if let Some((sn, lx, ly)) = flash_forward {
+            if let Some((sn, lx, ly, sw, sh)) = flash_forward {
                 // AVM1 button hit-testing reads the stage-mouse position
                 // that's last updated by MouseMove. A real browser always
                 // emits pointermove before pointerdown, so the position is
@@ -613,10 +613,10 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                 // input ever reached the SWF), and Ruffle's button test
                 // misses the click. Send a MouseMove first to seed it.
                 let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
-                    sn, "move", lx, ly,
+                    sn, "move", lx, ly, sw, sh,
                 );
                 let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
-                    sn, "down", lx, ly,
+                    sn, "down", lx, ly, sw, sh,
                 );
             }
 
@@ -858,15 +858,15 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                     return None;
                 }
                 let rect = super::score::get_concrete_sprite_rect(player, sprite);
-                Some((any_sprite as i32, x - rect.left, y - rect.top))
+                Some((any_sprite as i32, x - rect.left, y - rect.top, rect.right - rect.left, rect.bottom - rect.top))
             });
-            if let Some((sn, lx, ly)) = flash_forward_up {
+            if let Some((sn, lx, ly, sw, sh)) = flash_forward_up {
                 // Same MouseMove-before-MouseUp seeding as the down handler.
                 let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
-                    sn, "move", lx, ly,
+                    sn, "move", lx, ly, sw, sh,
                 );
                 let _ = super::handlers::datum_handlers::flash_object::ruffle_dispatch_mouse_event_global(
-                    sn, "up", lx, ly,
+                    sn, "up", lx, ly, sw, sh,
                 );
             }
 

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -45,6 +45,10 @@ pub enum PlayerVMCommand {
     SetStageSize(u32, u32),
     TimeoutTriggered(TimeoutRef),
     PrintMemberBitmapHex(CastMemberRef),
+    /// Dev UI sound preview: play a sound member through channel 1 (the real
+    /// puppetSound path) so it exercises the same decode/playback code a movie
+    /// would. Triggered by a user gesture so the AudioContext can resume.
+    PlayMemberSound(CastMemberRef),
     MouseDown((i32, i32)),
     MouseUp((i32, i32)),
     MouseMove((i32, i32)),
@@ -100,6 +104,7 @@ pub fn _format_player_cmd(command: &PlayerVMCommand) -> String {
             format!("TimeoutTriggered({})", timeout_ref)
         }
         PlayerVMCommand::PrintMemberBitmapHex(..) => "PrintMemberBitmapHex(..)".to_string(),
+        PlayerVMCommand::PlayMemberSound(..) => "PlayMemberSound(..)".to_string(),
         PlayerVMCommand::MouseDown((x, y)) => format!("MouseDown({}, {})", x, y),
         PlayerVMCommand::MouseUp((x, y)) => format!("MouseUp({}, {})", x, y),
         PlayerVMCommand::MouseMove((x, y)) => format!("MouseMove({}, {})", x, y),
@@ -329,6 +334,38 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
                 let bitmap = player.bitmap_manager.get_bitmap(bitmap.image_ref).unwrap();
                 let bitmap = &bitmap.data;
                 warn!("Bitmap hex: {}", bitmap.to_hex_string());
+            });
+        }
+        PlayerVMCommand::PlayMemberSound(member_ref) => {
+            use crate::player::handlers::datum_handlers::sound_channel::SoundChannelDatumHandlers;
+            let (cl, cm) = (member_ref.cast_lib, member_ref.cast_member);
+            reserve_player_mut(|player| {
+                let is_sound = player
+                    .movie
+                    .cast_manager
+                    .find_member_by_ref(&member_ref)
+                    .map(|m| matches!(m.member_type, CastMemberType::Sound(_)))
+                    .unwrap_or(false);
+                if !is_sound {
+                    console_warn!("[sound-preview] member {}:{} is not a sound member", cl, cm);
+                    return;
+                }
+                let member_datum = player.alloc_datum(Datum::CastMember(member_ref));
+                // Preview on channel 1 (Director's default puppetSound channel).
+                // Always play ONCE here, ignoring the member's loop flag, so a
+                // looping member doesn't run forever from the dev-UI preview.
+                let channel = match player.get_sound_channel(1) {
+                    Ok(ch) => ch,
+                    Err(e) => {
+                        console_warn!("[sound-preview] no channel for {}:{}: {}", cl, cm, e.message);
+                        return;
+                    }
+                };
+                if let Err(e) =
+                    SoundChannelDatumHandlers::handle_play_file(player, &channel, &member_datum, 1)
+                {
+                    console_warn!("[sound-preview] play failed for {}:{}: {}", cl, cm, e.message);
+                }
             });
         }
         PlayerVMCommand::MouseDown((x, y)) => {

--- a/vm-rust/src/player/compare.rs
+++ b/vm-rust/src/player/compare.rs
@@ -328,6 +328,19 @@ pub fn datum_equals(
             _ => false
         }),
 
+        // Two W3D scene-object refs (model/group/light/camera/collision/...)
+        // are the same Director object when they point to the same member,
+        // object type and (case-insensitive) name. Without this the catch-all
+        // returns false and `collisionData.modelA = s.model("ft")` — the heart
+        // of every native #collision callback — never matches.
+        (Shockwave3dObjectRef(a), o) | (o, Shockwave3dObjectRef(a)) => Ok(match o {
+            Shockwave3dObjectRef(b) => a.cast_lib == b.cast_lib
+                && a.cast_member == b.cast_member
+                && a.object_type.eq_ignore_ascii_case(&b.object_type)
+                && a.name.eq_ignore_ascii_case(&b.name),
+            _ => false
+        }),
+
         (Media(a), o) | (o, Media(a)) => Ok(match o {
             // TODO: is equality based on value?
             _ => false

--- a/vm-rust/src/player/compare.rs
+++ b/vm-rust/src/player/compare.rs
@@ -391,6 +391,27 @@ pub fn datum_equals_member(
 
 #[allow(dead_code)]
 pub fn datum_greater_than(left: &Datum, right: &Datum, allocator: &DatumAllocator) -> Result<bool, ScriptError> {
+    // See `datum_less_than`: a string chunk compares by its resolved text, and
+    // a sprite reference compares by its sprite (channel) number.
+    if let Datum::StringChunk(_, _, s) = left {
+        return datum_greater_than(&Datum::String(s.clone()), right, allocator);
+    }
+    if let Datum::StringChunk(_, _, s) = right {
+        return datum_greater_than(left, &Datum::String(s.clone()), allocator);
+    }
+    if let Datum::SpriteRef(n) = left {
+        return datum_greater_than(&Datum::Int(*n as i32), right, allocator);
+    }
+    if let Datum::SpriteRef(n) = right {
+        return datum_greater_than(left, &Datum::Int(*n as i32), allocator);
+    }
+    // A symbol compares as its string name (see `datum_less_than`).
+    if let Datum::Symbol(s) = left {
+        return datum_greater_than(&Datum::String(s.clone()), right, allocator);
+    }
+    if let Datum::Symbol(s) = right {
+        return datum_greater_than(left, &Datum::String(s.clone()), allocator);
+    }
     match (left, right) {
         // Int comparisons
         (Datum::Int(left), Datum::Int(right)) => Ok(*left > *right),
@@ -447,6 +468,26 @@ pub fn datum_greater_than(left: &Datum, right: &Datum, allocator: &DatumAllocato
             Ok(*n > (vals[0] as i32) || *n > (vals[1] as i32))
         }
 
+        // Linear list comparison — element-wise, mirroring `datum_less_than`
+        // (and the 11.5 dictionary's rect/point-as-list rule). True only if
+        // every corresponding element of the left is > the right's.
+        (Datum::List(_, left_items, _), Datum::List(_, right_items, _)) => {
+            if left_items.is_empty() || right_items.is_empty() {
+                return Ok(false);
+            }
+            for (l, r) in left_items.iter().zip(right_items.iter()) {
+                let ld = allocator.get_datum(l);
+                let rd = allocator.get_datum(r);
+                if !datum_greater_than(ld, rd, allocator)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+
+        // Script instances compare by allocation id (see `datum_less_than`).
+        (Datum::ScriptInstanceRef(l), Datum::ScriptInstanceRef(r)) => Ok(l.id() > r.id()),
+
         // Catch-all
         _ => {
             warn!(
@@ -460,6 +501,34 @@ pub fn datum_greater_than(left: &Datum, right: &Datum, allocator: &DatumAllocato
 }
 
 pub fn datum_less_than(left: &Datum, right: &Datum, allocator: &DatumAllocator) -> Result<bool, ScriptError> {
+    // A string chunk (`char/word/item/line N of x`) evaluates to a plain
+    // string — compare by its resolved text. Without this, `char 1 of x < "m"`
+    // (and any chunk poll in a per-frame loop) falls through to the catch-all,
+    // returning a wrong result AND warning every frame.
+    if let Datum::StringChunk(_, _, s) = left {
+        return datum_less_than(&Datum::String(s.clone()), right, allocator);
+    }
+    if let Datum::StringChunk(_, _, s) = right {
+        return datum_less_than(left, &Datum::String(s.clone()), allocator);
+    }
+    // A sprite reference compares by its sprite (channel) number, so a movie
+    // that sorts/compares `sprite(a) < sprite(b)` works instead of hitting the
+    // catch-all (wrong result + per-frame warn).
+    if let Datum::SpriteRef(n) = left {
+        return datum_less_than(&Datum::Int(*n as i32), right, allocator);
+    }
+    if let Datum::SpriteRef(n) = right {
+        return datum_less_than(left, &Datum::Int(*n as i32), allocator);
+    }
+    // A symbol compares as its string name (Director treats `#foo` like "foo" in
+    // ordered comparisons), so route symbols through the string logic below. This
+    // covers int-vs-symbol, symbol-vs-symbol, etc. without dedicated arms.
+    if let Datum::Symbol(s) = left {
+        return datum_less_than(&Datum::String(s.clone()), right, allocator);
+    }
+    if let Datum::Symbol(s) = right {
+        return datum_less_than(left, &Datum::String(s.clone()), allocator);
+    }
     match (left, right) {
         // Int comparisons
         (Datum::Int(left), Datum::Int(right)) => Ok(*left < *right),
@@ -538,6 +607,30 @@ pub fn datum_less_than(left: &Datum, right: &Datum, allocator: &DatumAllocator) 
                 Ok(false)
             }
         }
+
+        // Linear list comparison. Per the 11.5 dictionary `<` entry, rects/points
+        // (and by extension lists) compare "with each element of the first list
+        // compared to the corresponding element of the second list" — the same
+        // all-components rule the Point arm above uses. True only if every
+        // corresponding element of the left is < the right's.
+        (Datum::List(_, left_items, _), Datum::List(_, right_items, _)) => {
+            if left_items.is_empty() || right_items.is_empty() {
+                return Ok(false);
+            }
+            for (l, r) in left_items.iter().zip(right_items.iter()) {
+                let ld = allocator.get_datum(l);
+                let rd = allocator.get_datum(r);
+                if !datum_less_than(ld, rd, allocator)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+
+        // Script instances have no meaningful ordering in Director, but a movie
+        // that sorts or compares them needs a stable result — compare by their
+        // allocation id.
+        (Datum::ScriptInstanceRef(l), Datum::ScriptInstanceRef(r)) => Ok(l.id() < r.id()),
 
         // Catch-all
         _ => {

--- a/vm-rust/src/player/compare.rs
+++ b/vm-rust/src/player/compare.rs
@@ -488,6 +488,12 @@ pub fn datum_greater_than(left: &Datum, right: &Datum, allocator: &DatumAllocato
         // Script instances compare by allocation id (see `datum_less_than`).
         (Datum::ScriptInstanceRef(l), Datum::ScriptInstanceRef(r)) => Ok(l.id() > r.id()),
 
+        // Two strings compare lexicographically, case-insensitively — the mirror of
+        // `datum_less_than`. (Symbols are pre-converted to strings above.) Director
+        // uses this for text/version checks like `GrooveVersion() >= "1.7"`.
+        (Datum::String(left), Datum::String(right)) =>
+            Ok(left.to_ascii_lowercase() > right.to_ascii_lowercase()),
+
         // Catch-all
         _ => {
             warn!(

--- a/vm-rust/src/player/compare.rs
+++ b/vm-rust/src/player/compare.rs
@@ -432,6 +432,21 @@ pub fn datum_greater_than(left: &Datum, right: &Datum, allocator: &DatumAllocato
             Ok(left_x > right_x && left_y > right_y)
         }
 
+        // Point vs scalar: Director compares the point against the scalar
+        // component-wise; the result is true when ANY component satisfies the
+        // comparison. Summer Resort's room-scroll clamp relies on this — it
+        // tests an axis-aligned delta `point(0,16) > 0` / `point(0,-16) < 0`
+        // (one component is 0, the other ±16) to decide the scroll direction
+        // and clamp the player to the room edge. Without this the clamp never
+        // fired, the player over-scrolled past the screen bottom, and the next
+        // move bounced straight back into the previous room.
+        (Datum::Point(vals, _), Datum::Int(n)) => {
+            Ok((vals[0] as i32) > *n || (vals[1] as i32) > *n)
+        }
+        (Datum::Int(n), Datum::Point(vals, _)) => {
+            Ok(*n > (vals[0] as i32) || *n > (vals[1] as i32))
+        }
+
         // Catch-all
         _ => {
             warn!(
@@ -474,6 +489,15 @@ pub fn datum_less_than(left: &Datum, right: &Datum, allocator: &DatumAllocator) 
             let right_x = right_vals[0] as i32;
             let right_y = right_vals[1] as i32;
             Ok(left_x < right_x && left_y < right_y)
+        }
+
+        // Point vs scalar — see the note in `datum_greater_than`. Any component
+        // satisfying the comparison makes it true (axis-aligned scroll deltas).
+        (Datum::Point(vals, _), Datum::Int(n)) => {
+            Ok((vals[0] as i32) < *n || (vals[1] as i32) < *n)
+        }
+        (Datum::Int(n), Datum::Point(vals, _)) => {
+            Ok(*n < (vals[0] as i32) || *n < (vals[1] as i32))
         }
 
         // String vs number: Director coerces strings to numbers (empty string = 0)

--- a/vm-rust/src/player/datum_operations.rs
+++ b/vm-rust/src/player/datum_operations.rs
@@ -658,58 +658,39 @@ pub fn multiply_datums(
             let (vals, flags) = inline_binop_2(av, af, *b, *bf, |x, y| x * y);
             Datum::Point(vals, flags)
         }
-        // List (2 elements) as Point multiplication — result stays as List
-        (Datum::List(_, list, _), Datum::Int(right)) if list.len() == 2 => {
-            let mut ref_list = VecDeque::with_capacity(2);
-            for item in list {
-                let d = player.get_datum(item).clone();
-                let result_datum = match &d {
-                    Datum::Int(n) => Datum::Int(n * right),
-                    Datum::Float(n) => Datum::Float(n * *right as f64),
-                    _ => return Err(ScriptError::new("List element must be numeric".to_string())),
+        // List * Int, ANY length. Int elements stay Int (Director only widens to
+        // float when a float is involved); nested lists/points/rects/vectors
+        // recurse, mirroring the List * Float arm above.
+        (Datum::List(_, list, _), Datum::Int(right)) => {
+            let item_refs: Vec<DatumRef> = list.iter().cloned().collect();
+            let right_val = *right;
+            let mut ref_list = VecDeque::new();
+            for item in &item_refs {
+                let item_datum = player.get_datum(item).clone();
+                let result_datum = match &item_datum {
+                    Datum::Int(n) => Datum::Int(n * right_val),
+                    Datum::Float(n) => Datum::Float(*n * right_val as f64),
+                    Datum::List(..) | Datum::Point(..) | Datum::Rect(..) | Datum::Vector(_) => {
+                        multiply_datums(item.clone(), right_ref.clone(), player)?
+                    }
+                    _ => {
+                        return Err(ScriptError::new(format!(
+                            "Mul operator in list only works with ints and floats. Given: {}",
+                            format_datum(item, player)
+                        )))
+                    }
                 };
                 ref_list.push_back(player.alloc_datum(result_datum));
             }
             Datum::List(DatumType::List, ref_list, false)
         }
-        (Datum::List(_, list, _), Datum::Float(right)) if list.len() == 2 => {
-            let mut ref_list = VecDeque::with_capacity(2);
-            for item in list {
-                let d = player.get_datum(item).clone();
-                let result_datum = match &d {
-                    Datum::Int(n) => Datum::Float(*n as f64 * right),
-                    Datum::Float(n) => Datum::Float(n * right),
-                    _ => return Err(ScriptError::new("List element must be numeric".to_string())),
-                };
-                ref_list.push_back(player.alloc_datum(result_datum));
-            }
-            Datum::List(DatumType::List, ref_list, false)
-        }
-        (Datum::Int(left), Datum::List(_, list, _)) if list.len() == 2 => {
-            let mut ref_list = VecDeque::with_capacity(2);
-            for item in list {
-                let d = player.get_datum(item).clone();
-                let result_datum = match &d {
-                    Datum::Int(n) => Datum::Int(left * n),
-                    Datum::Float(n) => Datum::Float(*left as f64 * n),
-                    _ => return Err(ScriptError::new("List element must be numeric".to_string())),
-                };
-                ref_list.push_back(player.alloc_datum(result_datum));
-            }
-            Datum::List(DatumType::List, ref_list, false)
-        }
-        (Datum::Float(left), Datum::List(_, list, _)) if list.len() == 2 => {
-            let mut ref_list = VecDeque::with_capacity(2);
-            for item in list {
-                let d = player.get_datum(item).clone();
-                let result_datum = match &d {
-                    Datum::Int(n) => Datum::Float(left * *n as f64),
-                    Datum::Float(n) => Datum::Float(left * n),
-                    _ => return Err(ScriptError::new("List element must be numeric".to_string())),
-                };
-                ref_list.push_back(player.alloc_datum(result_datum));
-            }
-            Datum::List(DatumType::List, ref_list, false)
+        // scalar * List — Director's element-wise multiply is commutative, so
+        // reuse the List * scalar arms above rather than keeping a second, subtly
+        // different copy. These were previously limited to 2-element lists, so a
+        // 3-element vector (`-1.9 * [-25.2, -43.2, 0]`, as the physics code in
+        // Hey Arnold! Runaway Bus writes it) fell through to a type error.
+        (Datum::Int(_) | Datum::Float(_), Datum::List(..)) => {
+            multiply_datums(right_ref.clone(), left_ref.clone(), player)?
         }
 
         // Transform3d * Vector = apply transform to point

--- a/vm-rust/src/player/datum_operations.rs
+++ b/vm-rust/src/player/datum_operations.rs
@@ -597,12 +597,23 @@ pub fn multiply_datums(
             Datum::Point(vals, flags)
         }
         (Datum::List(_, list, _), Datum::Float(right)) => {
+            // Collect the element refs up front so the recursive multiply (for
+            // nested lists) can borrow the player mutably without aliasing the
+            // outer list's borrow.
+            let item_refs: Vec<DatumRef> = list.iter().cloned().collect();
+            let right_val = *right;
             let mut ref_list = VecDeque::new();
-            for item in list {
+            for item in &item_refs {
                 let item_datum = player.get_datum(item).clone();
                 let result_datum = match &item_datum {
-                    Datum::Int(n) => Datum::Float((*n as f64) * right),
-                    Datum::Float(n) => Datum::Float(n * right),
+                    Datum::Int(n) => Datum::Float((*n as f64) * right_val),
+                    Datum::Float(n) => Datum::Float(*n * right_val),
+                    // Director recurses into nested lists / points / rects /
+                    // vectors, scaling each sub-element by the scalar
+                    // (e.g. gspeed[1] * 1.5 where gspeed[1] is a list of lists).
+                    Datum::List(..) | Datum::Point(..) | Datum::Rect(..) | Datum::Vector(_) => {
+                        multiply_datums(item.clone(), right_ref.clone(), player)?
+                    }
                     _ => {
                         return Err(ScriptError::new(format!(
                             "Mul operator in list only works with ints and floats. Given: {}",

--- a/vm-rust/src/player/datum_ref.rs
+++ b/vm-rust/src/player/datum_ref.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use super::{allocator::{DatumAllocatorTrait, ALLOCATOR_RESETTING}, PLAYER_OPT};
+use super::{allocator::{DatumAllocatorTrait, ALLOCATOR_RESETTING}, ACTIVE_PLAYER_ID, NESTED_PLAYERS, PLAYER_OPT};
 
 pub type DatumId = usize;
 
@@ -80,7 +80,23 @@ impl Drop for DatumRef {
                 }
                 *rc -= 1;
                 if *rc == 0 {
-                    if let Some(player) = PLAYER_OPT.as_mut() {
+                    // Route the dealloc to the ACTIVE player's allocator, not
+                    // always the host. A nested `#movie` sub-player allocates and
+                    // drops its datums under its own active id; freeing them from
+                    // PLAYER_OPT (the host) left every sub datum unreclaimed —
+                    // g349's `beginSprite` alone leaked ~8000 datums/frame,
+                    // ballooning WASM memory and eventually OOM-crashing the datum
+                    // arena. (The ref_count above is decremented through the
+                    // DatumRef's own raw pointer into the owner arena, so it stays
+                    // correct regardless of which player is active.)
+                    let player_opt = if ACTIVE_PLAYER_ID == 0 {
+                        PLAYER_OPT.as_mut()
+                    } else {
+                        NESTED_PLAYERS
+                            .get_mut(ACTIVE_PLAYER_ID - 1)
+                            .and_then(|o| o.as_mut())
+                    };
+                    if let Some(player) = player_opt {
                         let bitmap_to_decref = player.allocator.on_datum_ref_dropped(*id);
                         // If the freed entry held an ephemeral Datum::BitmapRef
                         // we now own a decref. Apply it AFTER the allocator hop

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -984,6 +984,48 @@ pub fn parse_lingo_rule_runtime(
 
             Ok(LingoExpr::HandlerCall(handler_name.to_owned(), args))
         }
+        Rule::sound_statement => {
+            // `sound fadeIn 2, 60` → HandlerCall("sound", [#fadeIn, 2, 60]).
+            // The verb word is a literal keyword (a #symbol), NOT a variable —
+            // TypeHandlers::sound reads args[0] as the #verb and dispatches to the
+            // sound-channel op (same backend as `sound(2).fadeIn(60)`).
+            // Skip the `sound_kw` keyword node (carries no data), like if_inline.
+            let mut inner = pair
+                .into_inner()
+                .filter(|p| !matches!(p.as_rule(), Rule::sound_kw));
+            let verb = inner
+                .next()
+                .ok_or_else(|| ScriptError::new("Expected sound verb".to_string()))?
+                .as_str();
+            let mut args = vec![LingoExpr::SymbolLiteral(verb.to_owned())];
+            if let Some(args_container) = inner.next() {
+                match args_container.as_rule() {
+                    Rule::command_inline_args_comma => {
+                        for arg_pair in args_container.into_inner() {
+                            args.push(parse_lingo_expr_runtime(arg_pair.into_inner(), pratt)?);
+                        }
+                    }
+                    Rule::command_inline_args_space => {
+                        for arg_pair in args_container.into_inner() {
+                            args.push(parse_lingo_rule_runtime(arg_pair, pratt)?);
+                        }
+                    }
+                    Rule::command_inline_args_single => {
+                        let expr_pair = args_container.into_inner().next().ok_or_else(|| {
+                            ScriptError::new("Expected expr in single arg".to_string())
+                        })?;
+                        args.push(parse_lingo_expr_runtime(expr_pair.into_inner(), pratt)?);
+                    }
+                    other => {
+                        return Err(ScriptError::new(format!(
+                            "Unexpected sound args rule: {:?}",
+                            other
+                        )));
+                    }
+                }
+            }
+            Ok(LingoExpr::HandlerCall("sound".to_owned(), args))
+        }
         Rule::lang_ident | Rule::ident => {
             Ok(LingoExpr::Identifier(pair.as_str().to_owned()))
         }

--- a/vm-rust/src/player/eval.rs
+++ b/vm-rust/src/player/eval.rs
@@ -894,7 +894,17 @@ pub fn parse_lingo_rule_runtime(
             let mut args = vec![];
             for child in pair.into_inner() {
                 if let Rule::term_arg = child.as_rule() {
-                    args.push(parse_lingo_rule_runtime(child, pratt)?);
+                    // Director marker-navigation keywords: `go next` / `go
+                    // previous` / `go loop`. As a bareword these parse as an
+                    // undefined variable (→ VOID) and the go handler rejects
+                    // it (mixmaster does `do("go next")`), so pass the keyword
+                    // as a string literal for go() to resolve to the marker.
+                    let low = child.as_str().trim().to_ascii_lowercase();
+                    if low == "next" || low == "previous" || low == "loop" {
+                        args.push(LingoExpr::StringLiteral(low));
+                    } else {
+                        args.push(parse_lingo_rule_runtime(child, pratt)?);
+                    }
                 }
             }
             Ok(LingoExpr::HandlerCall("go".to_owned(), args))

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -568,14 +568,64 @@ pub async fn tick_w3d_animations() {
         for cast in player.movie.cast_manager.casts.iter_mut() {
             for (_, member) in cast.members.iter_mut() {
                 if let CastMemberType::Shockwave3d(w3d) = &mut member.member_type {
-                    if !w3d.runtime_state.animation_playing { continue; }
-                    let rate = w3d.runtime_state.play_rate;
-                    let scale = w3d.runtime_state.animation_scale;
-                    w3d.runtime_state.animation_time += dt_seconds * rate * scale;
-                    if w3d.runtime_state.blend_weight < 1.0 && w3d.runtime_state.blend_duration > 0.0 {
-                        w3d.runtime_state.blend_elapsed += dt_seconds;
-                        w3d.runtime_state.blend_weight =
-                            (w3d.runtime_state.blend_elapsed / w3d.runtime_state.blend_duration).min(1.0);
+                    // ── Per-MODEL bonesPlayer clocks ──
+                    // Each model animates independently (Rasterwerks clones N bots into
+                    // one member; sharing a single clock froze/cross-posed them). Snapshot
+                    // motion durations first (immutable scene borrow) for end-detection.
+                    let motion_durations: Vec<(String, f32)> = w3d.parsed_scene.as_ref()
+                        .map(|s| s.motions.iter()
+                            .map(|m| (m.name.to_ascii_lowercase(), m.duration()))
+                            .collect())
+                        .unwrap_or_default();
+                    let dur_of = |name: &str| -> f32 {
+                        let nl = name.to_ascii_lowercase();
+                        motion_durations.iter().find(|(n, _)| *n == nl).map(|(_, d)| *d).unwrap_or(0.0)
+                    };
+                    for bp in w3d.runtime_state.bones_players.values_mut() {
+                        if !bp.animation_playing || bp.motion_ended { continue; }
+                        bp.animation_time += dt_seconds * bp.play_rate * bp.animation_scale;
+                        if bp.blend_weight < 1.0 && bp.blend_duration > 0.0 {
+                            bp.blend_elapsed += dt_seconds;
+                            bp.blend_weight = (bp.blend_elapsed / bp.blend_duration).min(1.0);
+                        }
+                        // Non-looping end: advance the per-model queue, else hold last frame.
+                        if !bp.animation_loop {
+                            if let Some(cur) = bp.current_motion.clone() {
+                                let duration = dur_of(&cur);
+                                let eff_end = if bp.animation_end_time >= 0.0 {
+                                    bp.animation_end_time.min(duration)
+                                } else { duration };
+                                if eff_end > 0.0 && bp.animation_time >= eff_end {
+                                    if !bp.motion_queue.is_empty() {
+                                        let q = bp.motion_queue.remove(0);
+                                        bp.current_motion = Some(q.name);
+                                        bp.animation_loop = q.looped;
+                                        bp.animation_start_time = q.start_time;
+                                        bp.animation_end_time = q.end_time;
+                                        bp.animation_scale = q.scale;
+                                        bp.animation_time = if q.offset >= 0.0 { q.offset } else { q.start_time };
+                                        bp.motion_ended = false;
+                                        bp.previous_motion = None;
+                                        bp.blend_weight = 1.0;
+                                    } else {
+                                        bp.animation_time = eff_end; // hold final frame
+                                        bp.motion_ended = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // ── Legacy member clock (keyframe / motion_transforms path) ──
+                    if w3d.runtime_state.animation_playing {
+                        let rate = w3d.runtime_state.play_rate;
+                        let scale = w3d.runtime_state.animation_scale;
+                        w3d.runtime_state.animation_time += dt_seconds * rate * scale;
+                        if w3d.runtime_state.blend_weight < 1.0 && w3d.runtime_state.blend_duration > 0.0 {
+                            w3d.runtime_state.blend_elapsed += dt_seconds;
+                            w3d.runtime_state.blend_weight =
+                                (w3d.runtime_state.blend_elapsed / w3d.runtime_state.blend_duration).min(1.0);
+                        }
                     }
                 }
             }

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -1702,7 +1702,7 @@ pub async fn dispatch_event_to_all_behaviors(
                     return;
                 }
                 web_sys::console::error_1(
-                    &format!("Error in {} for sprite {}: {}", handler_name, sprite_number, err.message).into()
+                    &format!("Error in {} for sprite {} behavior '{}': {}", handler_name, sprite_number, ascii_safe(&script_name.to_string()), err.message).into()
                 );
                 reserve_player_mut(|player| {
                     player.on_script_error(&err);

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -321,6 +321,23 @@ pub async fn player_invoke_static_event(
             continue;
         }
         
+        // Re-entrancy guard: don't re-invoke this frame/movie-script handler if
+        // it's already active on the call stack for the SAME event. Director
+        // won't re-dispatch a message to a handler already processing it —
+        // fish's movie `on keyDown` calls `sendSprite(4, #keyDown)`, which (when
+        // sprite 4 has no keyDown behavior) propagates back up to the movie
+        // script per the sendSprite hierarchy and would otherwise recurse into
+        // this same handler forever.
+        let already_active = reserve_player_ref(|player| {
+            player
+                .active_static_event_handlers
+                .iter()
+                .any(|(m, h)| *m == script_member_ref && h == handler_name)
+        });
+        if already_active {
+            continue;
+        }
+
         // NEW: Check if this is the frame script
         let receiver = reserve_player_ref(|player| {
             if player.movie.frame_script_member.as_ref() == Some(&script_member_ref) {
@@ -329,13 +346,22 @@ pub async fn player_invoke_static_event(
                 None
             }
         });
-        
-        let result = player_call_script_handler(
+
+        reserve_player_mut(|player| {
+            player
+                .active_static_event_handlers
+                .push((script_member_ref.clone(), handler_name.to_owned()));
+        });
+        let call_result = player_call_script_handler(
             receiver,  // Changed from None to receiver
             (script_member_ref, handler_name.to_owned()),
             args
-        ).await?;
-        
+        ).await;
+        reserve_player_mut(|player| {
+            player.active_static_event_handlers.pop();
+        });
+        let result = call_result?;
+
         if !result.passed {
             handled = true;
             break;

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -763,11 +763,13 @@ pub async fn tick_w3d_collisions() {
         max: [f32; 3],
         handler: Option<String>,
         instance: Option<ScriptInstanceRef>,
+        target: Option<crate::director::lingo::datum::Datum>,
     }
     struct Fire {
         instance: Option<ScriptInstanceRef>,
         handler: String,
         data: DatumRef,
+        target: Option<DatumRef>,
     }
 
     let fires: Vec<Fire> = reserve_player_mut(|player| {
@@ -903,6 +905,7 @@ pub async fn tick_w3d_collisions() {
                             max,
                             handler: cmod.callback_handler.clone(),
                             instance: cmod.callback_instance.clone(),
+                            target: cmod.callback_target.clone(),
                         });
                     }
                     out
@@ -954,10 +957,12 @@ pub async fn tick_w3d_collisions() {
                                 (k_n, normal),
                             ]);
                             let data = player.alloc_datum(Datum::PropList(pairs, false));
+                            let target = selfm.target.clone().map(|t| player.alloc_datum(t));
                             fires.push(Fire {
                                 instance: selfm.instance.clone(),
                                 handler,
                                 data,
+                                target,
                             });
                         }
                     }
@@ -971,9 +976,20 @@ pub async fn tick_w3d_collisions() {
     player_wait_available().await;
     for fire in fires {
         if let Some(inst) = fire.instance {
+            // Script-instance target: `me` is the instance, collisionData is the
+            // single explicit arg (`on handler me, collisionData`).
             let _ = player_invoke_event_to_instances(&fire.handler, &vec![fire.data], &vec![inst]).await;
         } else {
-            let _ = player_invoke_static_event(&fire.handler, &vec![fire.data]).await;
+            // Non-instance target (e.g. `setCollisionCallback(#collision, member("scene"))`):
+            // Director passes the registered object as the handler's FIRST arg and
+            // collisionData as the SECOND (`on collision target, collisionData`).
+            // Without the target, collisionData lands in the first param and the
+            // collisionData param is VOID (Splat's `on collision s, collisionData`).
+            let args = match fire.target {
+                Some(target) => vec![target, fire.data],
+                None => vec![fire.data],
+            };
+            let _ = player_invoke_static_event(&fire.handler, &args).await;
         }
     }
 }

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -1542,7 +1542,7 @@ pub async fn dispatch_event_to_all_behaviors(
         }
         // Prevent re-entrant event dispatch (this can cause infinite loops)
         if player.is_dispatching_events {
-            warn!(
+            debug!(
                 "Blocking re-entrant event dispatch for '{}'",
                 handler_name
             );

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -664,6 +664,270 @@ pub async fn tick_w3d_particles() {
     });
 }
 
+// ─── Native Shockwave3D #collision modifier helpers ───
+const W3D_COL_IDENTITY: [f32; 16] = [
+    1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+];
+
+/// Column-major 4x4 multiply (m[col*4+row]).
+fn w3d_col_mat_mul(a: &[f32; 16], b: &[f32; 16]) -> [f32; 16] {
+    let mut r = [0.0f32; 16];
+    for col in 0..4 {
+        for row in 0..4 {
+            r[col * 4 + row] = a[row] * b[col * 4]
+                + a[4 + row] * b[col * 4 + 1]
+                + a[8 + row] * b[col * 4 + 2]
+                + a[12 + row] * b[col * 4 + 3];
+        }
+    }
+    r
+}
+
+/// Transform a point by a column-major 4x4 (w = 1).
+fn w3d_col_xform_point(m: &[f32; 16], p: [f32; 3]) -> [f32; 3] {
+    [
+        m[0] * p[0] + m[4] * p[1] + m[8] * p[2] + m[12],
+        m[1] * p[0] + m[5] * p[1] + m[9] * p[2] + m[13],
+        m[2] * p[0] + m[6] * p[1] + m[10] * p[2] + m[14],
+    ]
+}
+
+/// Per-frame native W3D collision detection (Director #collision modifier).
+///
+/// `addModifier(#collision)` registers a `W3dCollisionModifier` per model; this
+/// sweeps every enabled collision model in each 3D member, builds a world-space
+/// AABB for each (from the model resource's primitive dimensions and the node's
+/// accumulated world transform), tests all pairs for overlap, and fires each
+/// colliding model's `setCollisionCallback` handler with a `collisionData`
+/// property list (`#modelA / #modelB / #pointOfContact / #collisionNormal`).
+/// Only detection + dispatch are implemented; resolution is intentionally a
+/// no-op (every consumer so far sets `collision.resolve = 0`).
+pub async fn tick_w3d_collisions() {
+    use crate::director::lingo::datum::Shockwave3dObjectRef;
+    use crate::player::cast_member::CastMemberType;
+    use std::collections::VecDeque;
+
+    struct ColModel {
+        name: String,
+        min: [f32; 3],
+        max: [f32; 3],
+        handler: Option<String>,
+        instance: Option<ScriptInstanceRef>,
+    }
+    struct Fire {
+        instance: Option<ScriptInstanceRef>,
+        handler: String,
+        data: DatumRef,
+    }
+
+    let fires: Vec<Fire> = reserve_player_mut(|player| {
+        // Flush any live transform datums (model.transform.position = ...) into
+        // the node_transforms cache so collision reads current positions rather
+        // than the previous render's snapshot.
+        crate::player::handlers::datum_handlers::shockwave3d_object::sync_persistent_transforms(player);
+
+        let mut fires: Vec<Fire> = Vec::new();
+        let cast_count = player.movie.cast_manager.casts.len();
+        for cast_idx in 0..cast_count {
+            let member_numbers: Vec<u32> = player
+                .movie
+                .cast_manager
+                .casts
+                .get(cast_idx)
+                .map(|c| c.members.keys().copied().collect())
+                .unwrap_or_default();
+            for member_num in member_numbers {
+                let member_ref = CastMemberRef {
+                    cast_lib: cast_idx as i32,
+                    cast_member: member_num as i32,
+                };
+
+                // Gather world AABBs + callbacks for every enabled collision
+                // model in this member (owned, so the borrow ends before alloc).
+                let models: Vec<ColModel> = {
+                    let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref)
+                    else { continue };
+                    let CastMemberType::Shockwave3d(w3d) = &member.member_type else { continue };
+                    if w3d.runtime_state.collision_modifiers.is_empty() { continue; }
+                    let Some(scene) = w3d.parsed_scene.as_ref() else { continue };
+                    let rs = &w3d.runtime_state;
+
+                    // Local transform of a node: runtime override (case-insensitive)
+                    // falling back to the parsed scene node.
+                    let local_tf = |nm: &str| -> [f32; 16] {
+                        rs.node_transforms
+                            .get(nm)
+                            .copied()
+                            .or_else(|| {
+                                rs.node_transforms
+                                    .iter()
+                                    .find(|(k, _)| k.eq_ignore_ascii_case(nm))
+                                    .map(|(_, v)| *v)
+                            })
+                            .or_else(|| {
+                                scene
+                                    .nodes
+                                    .iter()
+                                    .find(|n| n.name.eq_ignore_ascii_case(nm))
+                                    .map(|n| n.transform)
+                            })
+                            .unwrap_or(W3D_COL_IDENTITY)
+                    };
+
+                    let mut out: Vec<ColModel> = Vec::new();
+                    for (mname, cmod) in rs.collision_modifiers.iter() {
+                        if !cmod.enabled { continue; }
+                        if rs.detached_nodes.iter().any(|d| d.eq_ignore_ascii_case(mname)) { continue; }
+                        let Some(node) = scene.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(mname))
+                        else { continue };
+
+                        // Local half-extents from the model resource's primitive dims.
+                        let res_key = if !node.model_resource_name.is_empty() {
+                            &node.model_resource_name
+                        } else {
+                            &node.resource_name
+                        };
+                        let he = scene
+                            .model_resources
+                            .get(res_key.as_str())
+                            .map(|r| match r.primitive_type.as_deref().unwrap_or("") {
+                                // box: width=X, height=Y, length=Z (see primitive build).
+                                "box" => [
+                                    r.primitive_width * 0.5,
+                                    r.primitive_height * 0.5,
+                                    r.primitive_length * 0.5,
+                                ],
+                                "sphere" => {
+                                    let s = r.primitive_radius.max(0.01);
+                                    [s, s, s]
+                                }
+                                // cylinder axis is Y; radius spans X/Z.
+                                "cylinder" => {
+                                    let rad = r.primitive_radius.max(r.primitive_top_radius).max(0.01);
+                                    [rad, r.primitive_height * 0.5, rad]
+                                }
+                                "plane" => [r.primitive_width * 0.5, 0.05, r.primitive_length * 0.5],
+                                _ => [
+                                    r.primitive_width.max(0.5) * 0.5,
+                                    r.primitive_height.max(0.5) * 0.5,
+                                    r.primitive_length.max(0.5) * 0.5,
+                                ],
+                            })
+                            .unwrap_or([0.5, 0.5, 0.5]);
+
+                        // Accumulate the world transform up the parent chain.
+                        let mut world = local_tf(&node.name);
+                        let mut cur_parent = node.parent_name.clone();
+                        for _ in 0..32 {
+                            if cur_parent.is_empty() || cur_parent.eq_ignore_ascii_case("World") {
+                                break;
+                            }
+                            let pm = local_tf(&cur_parent);
+                            world = w3d_col_mat_mul(&pm, &world);
+                            cur_parent = scene
+                                .nodes
+                                .iter()
+                                .find(|n| n.name.eq_ignore_ascii_case(&cur_parent))
+                                .map(|n| n.parent_name.clone())
+                                .unwrap_or_default();
+                        }
+
+                        // World AABB from the 8 transformed local-box corners.
+                        let mut min = [f32::MAX; 3];
+                        let mut max = [f32::MIN; 3];
+                        for &sx in &[-he[0], he[0]] {
+                            for &sy in &[-he[1], he[1]] {
+                                for &sz in &[-he[2], he[2]] {
+                                    let wp = w3d_col_xform_point(&world, [sx, sy, sz]);
+                                    for k in 0..3 {
+                                        if wp[k] < min[k] { min[k] = wp[k]; }
+                                        if wp[k] > max[k] { max[k] = wp[k]; }
+                                    }
+                                }
+                            }
+                        }
+
+                        out.push(ColModel {
+                            name: node.name.clone(),
+                            min,
+                            max,
+                            handler: cmod.callback_handler.clone(),
+                            instance: cmod.callback_instance.clone(),
+                        });
+                    }
+                    out
+                };
+
+                // Test all pairs; for each overlapping pair, fire the callback of
+                // every model in the pair that has one, with that model as modelA.
+                for i in 0..models.len() {
+                    for j in (i + 1)..models.len() {
+                        let a = &models[i];
+                        let b = &models[j];
+                        let overlap = a.min[0] <= b.max[0] && a.max[0] >= b.min[0]
+                            && a.min[1] <= b.max[1] && a.max[1] >= b.min[1]
+                            && a.min[2] <= b.max[2] && a.max[2] >= b.min[2];
+                        if !overlap { continue; }
+
+                        let mid = [
+                            ((a.min[0] + a.max[0] + b.min[0] + b.max[0]) * 0.25) as f64,
+                            ((a.min[1] + a.max[1] + b.min[1] + b.max[1]) * 0.25) as f64,
+                            ((a.min[2] + a.max[2] + b.min[2] + b.max[2]) * 0.25) as f64,
+                        ];
+                        for (selfm, otherm) in [(a, b), (b, a)] {
+                            let Some(handler) = selfm.handler.clone() else { continue };
+                            // collisionData property list: modelA is the model whose
+                            // callback is firing; the handlers check both modelA and
+                            // modelB, so this is consistent with Director.
+                            let model_a = player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                                cast_lib: member_ref.cast_lib,
+                                cast_member: member_ref.cast_member,
+                                object_type: "model".to_string(),
+                                name: selfm.name.clone(),
+                            }));
+                            let model_b = player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                                cast_lib: member_ref.cast_lib,
+                                cast_member: member_ref.cast_member,
+                                object_type: "model".to_string(),
+                                name: otherm.name.clone(),
+                            }));
+                            let poc = player.alloc_datum(Datum::Vector(mid));
+                            let normal = player.alloc_datum(Datum::Vector([1.0, 0.0, 0.0]));
+                            let k_a = player.alloc_datum(Datum::Symbol("modelA".to_string()));
+                            let k_b = player.alloc_datum(Datum::Symbol("modelB".to_string()));
+                            let k_poc = player.alloc_datum(Datum::Symbol("pointOfContact".to_string()));
+                            let k_n = player.alloc_datum(Datum::Symbol("collisionNormal".to_string()));
+                            let pairs: VecDeque<(DatumRef, DatumRef)> = VecDeque::from(vec![
+                                (k_a, model_a),
+                                (k_b, model_b),
+                                (k_poc, poc),
+                                (k_n, normal),
+                            ]);
+                            let data = player.alloc_datum(Datum::PropList(pairs, false));
+                            fires.push(Fire {
+                                instance: selfm.instance.clone(),
+                                handler,
+                                data,
+                            });
+                        }
+                    }
+                }
+            }
+        }
+        fires
+    });
+
+    if fires.is_empty() { return; }
+    player_wait_available().await;
+    for fire in fires {
+        if let Some(inst) = fire.instance {
+            let _ = player_invoke_event_to_instances(&fire.handler, &vec![fire.data], &vec![inst]).await;
+        } else {
+            let _ = player_invoke_static_event(&fire.handler, &vec![fire.data]).await;
+        }
+    }
+}
+
 /// Drain queued PhysX collision reports across all PhysX members and
 /// dispatch them to the script's registered `collisionCallback` handler.
 ///

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -761,9 +761,15 @@ pub async fn tick_w3d_collisions() {
         name: String,
         min: [f32; 3],
         max: [f32; 3],
+        immovable: bool,
         handler: Option<String>,
         instance: Option<ScriptInstanceRef>,
         target: Option<crate::director::lingo::datum::Datum>,
+    }
+    // A member-level #collideAny registration (registerForEvent(#collideAny, …)).
+    struct CollideAnyReg {
+        handler: String,
+        instance: Option<ScriptInstanceRef>,
     }
     struct Fire {
         instance: Option<ScriptInstanceRef>,
@@ -796,7 +802,7 @@ pub async fn tick_w3d_collisions() {
 
                 // Gather world AABBs + callbacks for every enabled collision
                 // model in this member (owned, so the borrow ends before alloc).
-                let models: Vec<ColModel> = {
+                let (models, collide_any_regs): (Vec<ColModel>, Vec<CollideAnyReg>) = {
                     let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref)
                     else { continue };
                     let CastMemberType::Shockwave3d(w3d) = &member.member_type else { continue };
@@ -839,33 +845,62 @@ pub async fn tick_w3d_collisions() {
                         } else {
                             &node.resource_name
                         };
-                        let he = scene
+                        let prim_he = scene
                             .model_resources
                             .get(res_key.as_str())
-                            .map(|r| match r.primitive_type.as_deref().unwrap_or("") {
+                            .and_then(|r| match r.primitive_type.as_deref().unwrap_or("") {
                                 // box: width=X, height=Y, length=Z (see primitive build).
-                                "box" => [
+                                "box" => Some([
                                     r.primitive_width * 0.5,
                                     r.primitive_height * 0.5,
                                     r.primitive_length * 0.5,
-                                ],
+                                ]),
                                 "sphere" => {
                                     let s = r.primitive_radius.max(0.01);
-                                    [s, s, s]
+                                    Some([s, s, s])
                                 }
                                 // cylinder axis is Y; radius spans X/Z.
                                 "cylinder" => {
                                     let rad = r.primitive_radius.max(r.primitive_top_radius).max(0.01);
-                                    [rad, r.primitive_height * 0.5, rad]
+                                    Some([rad, r.primitive_height * 0.5, rad])
                                 }
-                                "plane" => [r.primitive_width * 0.5, 0.05, r.primitive_length * 0.5],
-                                _ => [
-                                    r.primitive_width.max(0.5) * 0.5,
-                                    r.primitive_height.max(0.5) * 0.5,
-                                    r.primitive_length.max(0.5) * 0.5,
-                                ],
-                            })
-                            .unwrap_or([0.5, 0.5, 0.5]);
+                                "plane" => Some([r.primitive_width * 0.5, 0.05, r.primitive_length * 0.5]),
+                                // Mesh model (no primitive dims): fall through to mesh bounds.
+                                _ => None,
+                            });
+                        // For mesh models, size the collision box from the actual
+                        // geometry so #collision matches the visible model. (The old
+                        // 0.5-unit fallback never reached On the Run's bonuses, which
+                        // float ~1.5 above the road.) Half-extents are taken about the
+                        // model origin (max |min|,|max| per axis), matching the
+                        // origin-centred ±he box used below.
+                        let he = prim_he.unwrap_or_else(|| {
+                            let (mut mn, mut mx) = ([f32::MAX; 3], [f32::MIN; 3]);
+                            let mut any = false;
+                            if let Some(meshes) = scene.clod_meshes.get(res_key.as_str()) {
+                                for m in meshes {
+                                    for p in &m.positions {
+                                        any = true;
+                                        for k in 0..3 { if p[k] < mn[k] { mn[k] = p[k]; } if p[k] > mx[k] { mx[k] = p[k]; } }
+                                    }
+                                }
+                            }
+                            for rm in scene.raw_meshes.iter().filter(|m| m.name.eq_ignore_ascii_case(res_key.as_str())) {
+                                for p in &rm.positions {
+                                    any = true;
+                                    for k in 0..3 { if p[k] < mn[k] { mn[k] = p[k]; } if p[k] > mx[k] { mx[k] = p[k]; } }
+                                }
+                            }
+                            if any {
+                                [
+                                    mn[0].abs().max(mx[0].abs()).max(0.05),
+                                    mn[1].abs().max(mx[1].abs()).max(0.05),
+                                    mn[2].abs().max(mx[2].abs()).max(0.05),
+                                ]
+                            } else {
+                                [0.5, 0.5, 0.5]
+                            }
+                        });
 
                         // Accumulate the world transform up the parent chain.
                         let mut world = local_tf(&node.name);
@@ -903,12 +938,23 @@ pub async fn tick_w3d_collisions() {
                             name: node.name.clone(),
                             min,
                             max,
+                            immovable: cmod.immovable,
                             handler: cmod.callback_handler.clone(),
                             instance: cmod.callback_instance.clone(),
                             target: cmod.callback_target.clone(),
                         });
                     }
-                    out
+                    // Member-level #collideAny handlers (registerForEvent(#collideAny,
+                    // handler, scriptInstance)) — fired once per colliding pair below.
+                    let collide_any: Vec<CollideAnyReg> = rs.registered_events.iter()
+                        .filter(|e| e.event_name.eq_ignore_ascii_case("collideAny")
+                            && !e.handler_name.is_empty())
+                        .map(|e| CollideAnyReg {
+                            handler: e.handler_name.clone(),
+                            instance: e.script_instance.clone(),
+                        })
+                        .collect();
+                    (out, collide_any)
                 };
 
                 // Test all pairs; for each overlapping pair, fire the callback of
@@ -964,6 +1010,49 @@ pub async fn tick_w3d_collisions() {
                                 data,
                                 target,
                             });
+                        }
+
+                        // Member-level #collideAny handlers (registerForEvent) fire
+                        // once per colliding pair. Director 11.5 `collisionData`:
+                        // modelA / modelB / pointOfContact / collisionNormal — modelA
+                        // and modelB are "one"/"the other" of the pair. Order the
+                        // immovable model as modelB, the convention On the Run's bonus
+                        // pickup relies on (collisionData.modelB = the bonus hit).
+                        if !collide_any_regs.is_empty() {
+                            let (ma, mb) = if a.immovable && !b.immovable { (b, a) } else { (a, b) };
+                            for reg in &collide_any_regs {
+                                let model_a = player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                                    cast_lib: member_ref.cast_lib,
+                                    cast_member: member_ref.cast_member,
+                                    object_type: "model".to_string(),
+                                    name: ma.name.clone(),
+                                }));
+                                let model_b = player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                                    cast_lib: member_ref.cast_lib,
+                                    cast_member: member_ref.cast_member,
+                                    object_type: "model".to_string(),
+                                    name: mb.name.clone(),
+                                }));
+                                let poc = player.alloc_datum(Datum::Vector(mid));
+                                let normal = player.alloc_datum(Datum::Vector([1.0, 0.0, 0.0]));
+                                let k_a = player.alloc_datum(Datum::Symbol("modelA".to_string()));
+                                let k_b = player.alloc_datum(Datum::Symbol("modelB".to_string()));
+                                let k_poc = player.alloc_datum(Datum::Symbol("pointOfContact".to_string()));
+                                let k_n = player.alloc_datum(Datum::Symbol("collisionNormal".to_string()));
+                                let pairs: VecDeque<(DatumRef, DatumRef)> = VecDeque::from(vec![
+                                    (k_a, model_a),
+                                    (k_b, model_b),
+                                    (k_poc, poc),
+                                    (k_n, normal),
+                                ]);
+                                let data = player.alloc_datum(Datum::PropList(pairs, false));
+                                fires.push(Fire {
+                                    instance: reg.instance.clone(),
+                                    handler: reg.handler.clone(),
+                                    data,
+                                    target: None,
+                                });
+                            }
                         }
                     }
                 }

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -24,7 +24,7 @@ pub enum PlayerVMEvent {
 }
 
 pub fn player_dispatch_global_event(handler_name: &str, args: &Vec<DatumRef>) {
-    if let Some(tx) = unsafe { PLAYER_EVENT_TX.clone() } {
+    if let Some(tx) = crate::player::active_event_tx() {
         let _ = tx.try_send(PlayerVMEvent::Global(
             handler_name.to_owned(),
             args.to_owned(),
@@ -37,7 +37,7 @@ pub fn player_dispatch_callback_event(
     handler_name: &str,
     args: &Vec<DatumRef>,
 ) {
-    if let Some(tx) = unsafe { PLAYER_EVENT_TX.clone() } {
+    if let Some(tx) = crate::player::active_event_tx() {
         let _ = tx.try_send(PlayerVMEvent::Callback(
             receiver,
             handler_name.to_owned(),
@@ -51,7 +51,7 @@ pub fn player_dispatch_targeted_event(
     args: &Vec<DatumRef>,
     instance_ids: Option<&Vec<ScriptInstanceRef>>,
 ) {
-    if let Some(tx) = unsafe { PLAYER_EVENT_TX.clone() } {
+    if let Some(tx) = crate::player::active_event_tx() {
         let _ = tx.try_send(PlayerVMEvent::Targeted(
             handler_name.to_owned(),
             args.to_owned(),
@@ -81,7 +81,7 @@ pub fn player_dispatch_event_to_sprite(
         return;
     }
     let instance_ids = instance_ids.unwrap();
-    let tx = unsafe { PLAYER_EVENT_TX.clone() }.unwrap();
+    let tx = crate::player::active_event_tx().unwrap();
     tx.try_send(PlayerVMEvent::Targeted(
         handler_name.to_owned(),
         args.to_owned(),

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -114,13 +114,25 @@ pub async fn player_dispatch_event_to_sprite_targeted(
 
     player_wait_available().await;
 
-     for instance_id in instance_ids {
-        player_invoke_targeted_event(
-            handler_name,
-            args,
-            Some(&vec![instance_id].as_ref()),
-        ).await;
-    }
+    // Dispatch to ALL of the sprite's behaviors in a single pass, then — if
+    // none of them handled it (or the sprite has no behaviors at all) — fall
+    // through to the frame + movie scripts. Director's message hierarchy for a
+    // sprite-directed event is behaviors → frame → movie, stopping at the first
+    // non-passing handler.
+    //
+    // The previous per-instance loop broke this two ways: with an EMPTY
+    // instance list (a Flash sprite carries no behaviors) the loop body never
+    // ran, so the static-script fall-through never fired — that's why a
+    // `getURL("event: FlashLoaderLoaded")` whose handler lives in a movie
+    // script (Neopets DGS `on FlashLoaderLoaded`) never reached it and the DGS
+    // loader stalled. And with multiple behaviors it fired the static scripts
+    // once per non-handling behavior. `player_invoke_targeted_event` with the
+    // full instance list does the right thing in both cases.
+    let _ = player_invoke_targeted_event(
+        handler_name,
+        args,
+        Some(&instance_ids),
+    ).await;
 }
 
 pub async fn player_invoke_event_to_instances(

--- a/vm-rust/src/player/font/mod.rs
+++ b/vm-rust/src/player/font/mod.rs
@@ -371,7 +371,10 @@ impl FontManager {
             }
         }
 
-        warn!(
+        // Normal fallback (e.g. 'Arial' has no PFR strike — we drop to the
+        // embedded PFR / bitmap path below). Kept at debug so a per-frame text
+        // render doesn't flood the browser console (which retains every entry).
+        debug!(
             "[font] No PFR re-rasterization match for '{}' at size {}",
             font_name, requested_size,
         );
@@ -1015,7 +1018,7 @@ pub async fn player_load_system_font(path: &str) {
                 debug!("System font loaded successfully");
             });
 
-            warn!("Loaded system font image data: {:?}", image_data);
+            debug!("Loaded system font image data: {:?}", image_data);
         }
         Err(err) => {
             warn!("Error fetching system font: {:?}", err);

--- a/vm-rust/src/player/font/mod.rs
+++ b/vm-rust/src/player/font/mod.rs
@@ -266,6 +266,17 @@ impl FontManager {
                         // coords_scaled branch. Fontinator's 9px atlas output
                         // for fugue_arial / fugue_arial_italic verifies this
                         // produces complete, thin glyphs.
+                        // Match FontinatorFINAL's working approach: parse with
+                        // target_em_px = outline_resolution rather than 0 or
+                        // the small render size. Hinting still fires, but at
+                        // ~unity scale (the multiplier `target/outline_res` is
+                        // 1), so it doesn't try to snap stems into a 12-pixel
+                        // box and fragment glyphs. The rasterizer then handles
+                        // the actual downscale to the displayed size via
+                        // `scale = target_height / target_em_px` in the
+                        // coords_scaled branch. Fontinator's 9px atlas output
+                        // for fugue_arial / fugue_arial_italic verifies this
+                        // produces complete, thin glyphs.
                         let outline_res = parsed.physical_font.outline_resolution as i32;
                         let parse_target = if outline_res > 0 { outline_res } else { 0 };
                         let parsed_for_size = if let Some(ref raw) = font_data.pfr_data {
@@ -1011,6 +1022,113 @@ pub async fn player_load_system_font(path: &str) {
             return;
         }
     };
+}
+
+/// Recover a PFR bitmap STRIKE's true vertical metrics by scanning the
+/// rasterized atlas for the cap-top and descender-bottom ink rows within a cell
+/// (both relative to the cell top).
+///
+/// Director licensed the Paige text engine, which draws each line's baseline at
+/// `lineTop + ascent` and the underline down in the descent (Hermes-Paige
+/// `PGGRAFX.C` pgTextOut: `MoveTo(top, top_v + info.ascent)`; `PGTEXT.C`
+/// lineheight = ascent + descent + leading). dirplayer's PFR rasterizer instead
+/// anchors the atlas baseline at `round(outlineAscender * scale)`, which for a
+/// bitmap strike sits ~2px below the strike's true ascent (its cap height) — so
+/// rendered text lands ~2px too low and descenders/underline fall off the bottom
+/// of a tight member box. Callers anchor the scanned cap-top at the box/sprite
+/// top so the baseline lands at the strike's real ascent (matches Shockwave).
+///
+/// Returns `(cap_top_row, descender_bottom_row)`; either is `None` when the font
+/// is not a PFR strike or the reference glyphs carry no ink.
+pub fn pfr_strike_vertical_metrics(
+    font: &BitmapFont,
+    font_bitmap: &Bitmap,
+) -> (Option<i32>, Option<i32>) {
+    if font.char_widths.is_none() {
+        return (None, None);
+    }
+    let cell_ink_rows = |c: u8| -> Option<(i32, i32)> {
+        if c < font.first_char_num {
+            return None;
+        }
+        let idx = (c - font.first_char_num) as usize;
+        let cols = font.grid_columns.max(1) as usize;
+        let cx = (idx % cols) as i32;
+        let cy = (idx / cols) as i32;
+        let sx = cx * font.grid_cell_width as i32 + font.char_offset_x as i32;
+        let sy = cy * font.grid_cell_height as i32 + font.char_offset_y as i32;
+        let fw = font_bitmap.width as i32;
+        let fh = font_bitmap.height as i32;
+        let mut top: Option<i32> = None;
+        let mut bot: Option<i32> = None;
+        for ry in 0..font.char_height as i32 {
+            let mut ink = false;
+            for rx in 0..font.char_width as i32 {
+                let px = sx + rx;
+                let py = sy + ry;
+                if px < 0 || py < 0 || px >= fw || py >= fh {
+                    continue;
+                }
+                let i = ((py as usize) * fw as usize + px as usize) * 4 + 3;
+                if i < font_bitmap.data.len() && font_bitmap.data[i] > 16 {
+                    ink = true;
+                    break;
+                }
+            }
+            if ink {
+                if top.is_none() {
+                    top = Some(ry);
+                }
+                bot = Some(ry);
+            }
+        }
+        match (top, bot) {
+            (Some(t), Some(b)) => Some((t, b)),
+            _ => None,
+        }
+    };
+    let mut cap_top: Option<i32> = None;
+    for &c in b"HEFLTIBRKMNPX".iter() {
+        if let Some((t, _)) = cell_ink_rows(c) {
+            cap_top = Some(cap_top.map_or(t, |a: i32| a.min(t)));
+        }
+    }
+    let mut desc_bot: Option<i32> = None;
+    for &c in b"gypqj".iter() {
+        if let Some((_, b)) = cell_ink_rows(c) {
+            desc_bot = Some(desc_bot.map_or(b, |a: i32| a.max(b)));
+        }
+    }
+    (cap_top, desc_bot)
+}
+
+/// Extra rows a PFR text `.image`/`.rect` must reserve BELOW its
+/// `fixedLineSpace`-based content height so the last line's descender — and the
+/// underline drawn on it (`underline_y = y_pos + pfr_desc_bottom`) — are not
+/// clipped. Habbo's Writer forces `fixedLineSpace = fontSize`, but Volter's
+/// `g/y/p/q/j` descenders (and link underlines) reach `pfr_desc_bottom`, BELOW
+/// that line. Returns 0 when `fixedLineSpace` already covers the descender or the
+/// font is not a PFR/bitmap font.
+///
+/// Derivation: the box must reach `anchor_y + db + 1` (underline row inclusive).
+/// The anchor absorbs `(top_spacing - 1)` for `top_spacing >= 1`, so the reserve
+/// below `fixedLineSpace` is `db + 1 - fixedLineSpace - min(top_spacing, 1)`.
+pub fn pfr_underline_descender_overflow(
+    font: &BitmapFont,
+    font_bitmap: &Bitmap,
+    fixed_line_space: u16,
+    top_spacing: i16,
+) -> u16 {
+    if fixed_line_space == 0 || font.char_widths.is_none() {
+        return 0;
+    }
+    match pfr_strike_vertical_metrics(font, font_bitmap).1 {
+        Some(db) => {
+            let ts1 = top_spacing.clamp(0, 1) as i32;
+            (db + 1 - fixed_line_space as i32 - ts1).max(0) as u16
+        }
+        None => 0,
+    }
 }
 
 pub fn bitmap_font_copy_char(

--- a/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
@@ -489,7 +489,7 @@ impl BitmapDatumHandlers {
 
             // Handle optional color argument before the prop list
             // draw(x1, y1, x2, y2, [color,] propList)
-            let explicit_color = if arg_pos + 1 < args.len() {
+            let mut explicit_color = if arg_pos + 1 < args.len() {
                 let maybe_color = player.get_datum(&args[arg_pos]);
                 if matches!(maybe_color, Datum::ColorRef(_)) {
                     let c = maybe_color.to_color_ref().ok();
@@ -502,7 +502,31 @@ impl BitmapDatumHandlers {
                 None
             };
 
-            let draw_map = player.get_datum(&args[arg_pos]).to_map()?;
+            // The final `colorObjOrParamList` argument is EITHER a plain color
+            // object OR a parameter list ([#shapeType, #lineSize, #color, ...]).
+            // (11.5 Scripting Dictionary: draw(rect, colorObjOrParamList) — "A
+            // color object or parameter list"; the default #shapeType is #line.)
+            // When it is a bare color there is no list, so draw a 1-pixel #line
+            // in that color and let every prop lookup below fall through to its
+            // default via an empty map. Tetris' make_table draws grid lines with
+            // `the_image.draw(rect, rgb(255,255,255))`, which previously errored
+            // ("Cannot convert datum to map") trying to to_map() the color.
+            let empty_map: std::collections::VecDeque<(DatumRef, DatumRef)> =
+                std::collections::VecDeque::new();
+            let draw_map: &std::collections::VecDeque<(DatumRef, DatumRef)> =
+                if arg_pos >= args.len() {
+                    &empty_map
+                } else {
+                    let last_arg = player.get_datum(&args[arg_pos]);
+                    if matches!(last_arg, Datum::ColorRef(_)) {
+                        if explicit_color.is_none() {
+                            explicit_color = last_arg.to_color_ref().ok();
+                        }
+                        &empty_map
+                    } else {
+                        last_arg.to_map()?
+                    }
+                };
             let bitmap = player.bitmap_manager.get_bitmap(*bitmap_ref).unwrap();
 
             let color_ref = if let Some(c) = explicit_color {
@@ -680,77 +704,115 @@ impl BitmapDatumHandlers {
     pub fn fill(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let bitmap = player.get_datum(datum);
-            let (rect_i32, color_ref, shape) = if args.len() == 2 {
-                let (rect_vals, _flags) = player.get_datum(&args[0]).to_rect_inline()?;
-                let params = player.get_datum(&args[1]);
-                let (color, shape) = match params {
-                    Datum::ColorRef(color_ref) => (color_ref.clone(), "rect".to_string()),
-                    Datum::PropList(prop_list, ..) => {
-                        let color_ref = PropListUtils::get_by_concrete_key(
-                            &prop_list,
-                            &Datum::Symbol("color".to_string()),
-                            &player.allocator,
-                        )?;
-                        let shape_ref = PropListUtils::get_by_concrete_key(
-                            &prop_list,
-                            &Datum::Symbol("shapeType".to_string()),
-                            &player.allocator,
-                        )?;
-                        let shape_datum = player.get_datum(&shape_ref);
-                        let shape = match shape_datum {
-                            Datum::Symbol(s) => s.clone(),
-                            Datum::Void => "rect".to_string(),
-                            _ => {
-                                return Err(ScriptError::new(
-                                    "Invalid shapeType in fill prop list".to_string(),
-                                ))
-                            }
-                        };
-                        let color_ref = player.get_datum(&color_ref).to_color_ref()?;
-                        (color_ref.clone(), shape)
-                    }
-                    _ => {
-                        return Err(ScriptError::new(
-                            "Invalid parameter for fill".to_string(),
-                        ))
-                    }
-                };
-                
-                let x1 = rect_vals[0] as i32;
-                let y1 = rect_vals[1] as i32;
-                let x2 = rect_vals[2] as i32;
-                let y2 = rect_vals[3] as i32;
+            if args.is_empty() {
+                return Err(ScriptError::new("fill requires arguments".to_string()));
+            }
 
-                ((x1, y1, x2, y2), color, shape)
-            } else if args.len() == 5 {
-                let x = player.get_datum(&args[0]).int_value()?;
-                let y = player.get_datum(&args[1]).int_value()?;
-                let width = player.get_datum(&args[2]).int_value()?;
-                let height = player.get_datum(&args[3]).int_value()?;
-                let params = player.get_datum(&args[4]);
-                let color = match params {
-                    Datum::ColorRef(color_ref) => color_ref.clone(),
-                    Datum::PropList(prop_list, ..) => {
-                        let color_ref = PropListUtils::get_by_concrete_key(
-                            &prop_list,
-                            &Datum::Symbol("color".to_string()),
-                            &player.allocator,
-                        )?;
-                        player.get_datum(&color_ref).to_color_ref()?.clone()
-                    }
-                    Datum::Int(i) => ColorRef::PaletteIndex(*i as u8),
-                    _ => {
+            // Parse the region, mirroring draw(): coordinates (left,top,right,
+            // bottom), two points, or a rect. (11.5 Scripting Dictionary:
+            // fill(left,top,right,bottom, ...) / fill(point,point, ...) /
+            // fill(rect, ...).)
+            let first = player.get_datum(&args[0]);
+            let mut arg_pos = 1;
+            let (x1, y1, x2, y2) = match first {
+                Datum::Int(x1) => {
+                    if args.len() < 5 {
                         return Err(ScriptError::new(
-                            "Invalid color parameter for fill".to_string(),
-                        ))
+                            "fill(left, top, right, bottom, ...) requires at least 5 arguments"
+                                .to_string(),
+                        ));
                     }
-                };
-                ((x, y, width, height), color, "rect".to_string())
-            } else {
+                    let y1 = player.get_datum(&args[1]).int_value()?;
+                    let x2 = player.get_datum(&args[2]).int_value()?;
+                    let y2 = player.get_datum(&args[3]).int_value()?;
+                    arg_pos = 4;
+                    (*x1, y1, x2, y2)
+                }
+                Datum::Point(p1, _flags) => {
+                    let x1 = p1[0] as i32;
+                    let y1 = p1[1] as i32;
+                    let (p2, _flags) = player.get_datum(&args[1]).to_point_inline()?;
+                    arg_pos = 2;
+                    (x1, y1, p2[0] as i32, p2[1] as i32)
+                }
+                Datum::Rect(r, _flags) => {
+                    (r[0] as i32, r[1] as i32, r[2] as i32, r[3] as i32)
+                }
+                _ => {
+                    return Err(ScriptError::new(
+                        "First argument to fill must be coordinates, a point, or a rect"
+                            .to_string(),
+                    ))
+                }
+            };
+
+            // The final `colorObjOrParamList` argument is EITHER a plain color
+            // OR a parameter list. Director also accepts an explicit color
+            // BEFORE the list (`fill(region, color, [#shapeType: ...])`, as
+            // Tetris' name-input table does) — peel it off first when something
+            // follows it.
+            let mut explicit_color: Option<ColorRef> = None;
+            if arg_pos + 1 < args.len() {
+                let maybe_color = player.get_datum(&args[arg_pos]);
+                match maybe_color {
+                    Datum::ColorRef(_) => {
+                        explicit_color = maybe_color.to_color_ref().ok().cloned();
+                        arg_pos += 1;
+                    }
+                    Datum::Int(i) => {
+                        explicit_color = Some(ColorRef::PaletteIndex(*i as u8));
+                        arg_pos += 1;
+                    }
+                    _ => {}
+                }
+            }
+
+            if arg_pos >= args.len() {
                 return Err(ScriptError::new(
                     "Invalid number of arguments for fill".to_string(),
                 ));
+            }
+
+            let params = player.get_datum(&args[arg_pos]);
+            let (color_ref, shape) = match params {
+                Datum::ColorRef(color_ref) => (color_ref.clone(), "rect".to_string()),
+                Datum::Int(i) => (ColorRef::PaletteIndex(*i as u8), "rect".to_string()),
+                Datum::PropList(prop_list, ..) => {
+                    let shape_ref = PropListUtils::get_by_concrete_key(
+                        &prop_list,
+                        &Datum::Symbol("shapeType".to_string()),
+                        &player.allocator,
+                    )?;
+                    let shape = match player.get_datum(&shape_ref) {
+                        Datum::Symbol(s) => s.clone(),
+                        Datum::Void => "rect".to_string(),
+                        _ => {
+                            return Err(ScriptError::new(
+                                "Invalid shapeType in fill prop list".to_string(),
+                            ))
+                        }
+                    };
+                    // Color comes from the explicit leading arg if present,
+                    // otherwise from the list's #color entry.
+                    let color_ref = if let Some(c) = explicit_color.clone() {
+                        c
+                    } else {
+                        let cr = PropListUtils::get_by_concrete_key(
+                            &prop_list,
+                            &Datum::Symbol("color".to_string()),
+                            &player.allocator,
+                        )?;
+                        player.get_datum(&cr).to_color_ref()?.clone()
+                    };
+                    (color_ref, shape)
+                }
+                _ => {
+                    return Err(ScriptError::new(
+                        "Invalid parameter for fill".to_string(),
+                    ))
+                }
             };
+            let rect_i32 = (x1, y1, x2, y2);
             let bitmap_ref = match bitmap {
                 Datum::BitmapRef(bitmap) => Ok(bitmap),
                 _ => Err(ScriptError::new("Cannot fill non-bitmap".to_string())),

--- a/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
@@ -523,12 +523,22 @@ impl BitmapDatumHandlers {
                 bitmap.original_bit_depth,
             );
 
-            let shape_type = PropListUtils::get_by_concrete_key(
+            // Director 11.5 Scripting Dictionary, draw() image method: the
+            // `#shapeType` property "is a symbol value of #oval, #rect,
+            // #roundRect, or #line. The default is #line." When the param list
+            // omits #shapeType, fall back to #line rather than treating the
+            // VOID lookup result as a literal "VOID" shape name.
+            let shape_type_d = PropListUtils::get_by_concrete_key(
                 &draw_map,
                 &Datum::Symbol("shapeType".to_owned()),
                 &player.allocator,
             )?;
-            let shape_type = player.get_datum(&shape_type).string_value()?;
+            let shape_type_d = player.get_datum(&shape_type_d);
+            let shape_type = if shape_type_d.is_void() {
+                "line".to_string()
+            } else {
+                shape_type_d.string_value()?
+            };
 
             let blend = PropListUtils::get_by_concrete_key(
                 &draw_map,
@@ -590,30 +600,6 @@ impl BitmapDatumHandlers {
                     // For #line, (x1,y1) and (x2,y2) are the line endpoints
                     // (rather than a bounding rect like the other shapes).
                     bitmap.draw_line_thick(x1, y1, x2, y2, color, &palettes, alpha, thickness);
-                }
-                "oval" => {
-                    bitmap.stroke_ellipse(
-                        x1,
-                        y1,
-                        x2,
-                        y2,
-                        color,
-                        &palettes,
-                        blend as f32 / 100.0,
-                        thickness,
-                    );
-                }
-                "line" => {
-                    bitmap.draw_line_thick(
-                        x1,
-                        y1,
-                        x2,
-                        y2,
-                        color,
-                        &palettes,
-                        blend as f32 / 100.0,
-                        thickness,
-                    );
                 }
                 _ => {
                     return Err(ScriptError::new(format!(

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -960,6 +960,17 @@ impl FontMemberHandlers {
         // caret/selection overlay can place rects in the same positions later.
         let mut line_positions: Vec<(f64, f64)> = Vec::new();
 
+        // Per-styled-run color regions, in logical (1x) coords. The canvas is
+        // drawn at 2x via ctx.scale, and output pixel (cx,cy) maps back to
+        // logical (cx,cy), so these rects can be matched directly against
+        // output pixels in the downscale below. This lets each STXT run keep
+        // its own color (the red "- 50 POINTS - Get Stung!" line in SpongeBob's
+        // Scoring field) instead of the whole field using one color. Font
+        // size/face/bold/italic/underline are already per-segment (set_font /
+        // underline above); only color needed this per-pixel routing because
+        // the text is rendered white-on-black for coverage.
+        let mut seg_color_rects: Vec<(f64, f64, f64, f64, (u8, u8, u8))> = Vec::new();
+
         let mut y = top_spacing.max(0) as f64;
         let mut prev_par_idx: Option<u16> = None;
         for line in &lines {
@@ -1057,6 +1068,17 @@ impl FontMemberHandlers {
                 // Always render in WHITE on the black canvas for coverage measurement
                 ctx.set_fill_style_str("rgb(255,255,255)");
                 let _ = ctx.fill_text(&segment.text, x, y);
+
+                // Record this segment's color region (logical coords, baseline
+                // is "top" so the glyph cell is [y, y+size_px]) for per-run
+                // color lookup during the downscale.
+                seg_color_rects.push((
+                    x,
+                    x + segment.width,
+                    y,
+                    y + segment.style.size_px,
+                    segment.style.color,
+                ));
 
                 if segment.style.underline {
                     let underline_y = y + segment.style.size_px - 1.0;
@@ -1199,9 +1221,19 @@ impl FontMemberHandlers {
                 // background = transparent (preserved from bitmap pre-fill).
                 let dest_idx = (dest_y as usize * bitmap.width as usize + dest_x as usize) * 4;
                 if dest_idx + 3 < bitmap.data.len() {
-                    let fg_r = spans.first().and_then(|s| s.style.color).map(|c| ((c >> 16) & 0xFF) as u8).unwrap_or(0);
-                    let fg_g = spans.first().and_then(|s| s.style.color).map(|c| ((c >> 8) & 0xFF) as u8).unwrap_or(0);
-                    let fg_b = spans.first().and_then(|s| s.style.color).map(|c| (c & 0xFF) as u8).unwrap_or(0);
+                    // Per-run color: find the styled segment covering this
+                    // pixel (output coords == logical coords). segment.style.color
+                    // already folds in the field default for runs with no
+                    // explicit color, so unmatched pixels fall back to it too.
+                    let (fg_r, fg_g, fg_b) = {
+                        let fx = cx as f64;
+                        let fy = cy as f64;
+                        seg_color_rects
+                            .iter()
+                            .find(|&&(x0, x1, yt, yb, _)| fx >= x0 && fx < x1 && fy >= yt && fy < yb)
+                            .map(|&(_, _, _, _, c)| c)
+                            .unwrap_or(fallback_color)
+                    };
                     bitmap.data[dest_idx] = fg_r;
                     bitmap.data[dest_idx + 1] = fg_g;
                     bitmap.data[dest_idx + 2] = fg_b;

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -742,8 +742,27 @@ impl HavokPhysicsMemberHandlers {
                     // mass properties from geometry). A box-AABB inertia is wrong about
                     // the pitch axis for a long flat chassis. Box fallback for
                     // degenerate/open meshes.
+                    // Inertia must be built in the SAME spawn-rotated frame as the collision
+                    // mesh `vertices` above (both apply the node transform's rotation), else the
+                    // body tensor stays in the un-rotated mesh frame while rb.orientation (the
+                    // HKE spawn rotation) rotates it AGAIN when the integrator forms the world
+                    // inverse-inertia, double-counting the placement rotation. For an anisotropic
+                    // chassis with a spawn rotation that aliased the pitch axis onto the small
+                    // roll inertia, so the car leaned/pitched far too easily. Rotation only (the
+                    // polyhedron inertia is taken about the centroid; translation must not enter).
                     let local_verts: Vec<[f64; 3]> = mesh.vertices.iter()
-                        .map(|v| [v[0] as f64 * inv_scale, v[1] as f64 * inv_scale, v[2] as f64 * inv_scale])
+                        .map(|v| {
+                            let lx = v[0] as f64 * inv_scale;
+                            let ly = v[1] as f64 * inv_scale;
+                            let lz = v[2] as f64 * inv_scale;
+                            if let Some(r) = &xform_rt {
+                                [r[0]*lx + r[3]*ly + r[6]*lz,
+                                 r[1]*lx + r[4]*ly + r[7]*lz,
+                                 r[2]*lx + r[5]*ly + r[8]*lz]
+                            } else {
+                                [lx, ly, lz]
+                            }
+                        })
                         .collect();
                     let unit_i = super::havok_physics::compute_polyhedron_unit_inertia(&local_verts, &mesh.triangles)
                         .map(|(ui, _com, _vol)| ui)
@@ -752,7 +771,14 @@ impl HavokPhysicsMemberHandlers {
                     super::havok_physics::recompute_body_inertia(mass, unit_i, &mut it, &mut inv_it, &mut inv_m);
                     let rb = &mut havok.state.rigid_bodies[rb_index];
                     rb.inertia_half_extents = he;
-                    rb.center_of_mass = com;
+                    // Keep the authored DISPLACEMENT (the HKE's real COM, already assigned
+                    // from p.displacement above) — only fall back to the geometric box-centre
+                    // when no COM was authored. The unconditional overwrite discarded it: the
+                    // FinalDrive chassis got the mesh-AABB centre (0.37,2.72,-3.65) instead of
+                    // its real COM (0.49,4.20,-4.95), shifting wheel ray origins + mis-kicking.
+                    if props.and_then(|p| p.displacement).is_none() {
+                        rb.center_of_mass = com;
+                    }
                     rb.unit_inertia_tensor = unit_i;
                     rb.inertia_tensor = it;
                     rb.inverse_inertia_tensor = inv_it;
@@ -844,7 +870,11 @@ impl HavokPhysicsMemberHandlers {
                     let (mut it, mut inv_it, mut inv_m) = ([0.0; 9], [0.0; 9], 0.0);
                     super::havok_physics::recompute_body_inertia(mass, unit_i, &mut it, &mut inv_it, &mut inv_m);
                     rb.inertia_half_extents = he;
-                    rb.center_of_mass = com;
+                    // Keep the authored DISPLACEMENT COM (tail-only body path) — same fix as
+                    // the mesh-body path above; only use the geometric centre if none authored.
+                    if body_def.displacement.is_none() {
+                        rb.center_of_mass = com;
+                    }
                     rb.unit_inertia_tensor = unit_i;
                     rb.inertia_tensor = it;
                     rb.inverse_inertia_tensor = inv_it;

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -265,8 +265,8 @@ impl HavokPhysicsMemberHandlers {
             });
 
             let mut step_cbs: Vec<(String, DatumRef, f64)> = Vec::new();
-            // Raw collision data: (handler, instance, body_a, body_b, point, normal)
-            let mut raw_collisions: Vec<(String, DatumRef, String, String, [f64;3], [f64;3])> = Vec::new();
+            // Raw collision data: (handler, instance, body_a, body_b, point, normal, nrv)
+            let mut raw_collisions: Vec<(String, DatumRef, String, String, [f64;3], [f64;3], f64)> = Vec::new();
 
             if let Some(havok) = havok {
                 // Step callbacks
@@ -300,12 +300,28 @@ impl HavokPhysicsMemberHandlers {
                             (contact.body_a.eq_ignore_ascii_case(&interest.rb_name1) && contact.body_b.eq_ignore_ascii_case(&interest.rb_name2))
                             || (contact.body_a.eq_ignore_ascii_case(&interest.rb_name2) && contact.body_b.eq_ignore_ascii_case(&interest.rb_name1))
                         };
-                        if matches {
+                        // Gate on the registerInterest threshold: the Xtra only
+                        // fires the callback when the impact (normal relative)
+                        // speed reaches the threshold, so a body merely resting on
+                        // or sliding along a surface (nrv≈0) doesn't trigger a
+                        // collision event. (Frequency throttling is not yet
+                        // applied; freq is 0 for the player car so it's a no-op
+                        // there, and the scripts self-throttle via sndCollisionWait.)
+                        if matches && contact.normal_rel_vel >= interest.threshold {
+                            // Report the registered body (rb_name1) first so the
+                            // callback can treat cd[1] as "self" and cd[2] as the
+                            // other object (matches the Havok Xtra ordering).
+                            let (name_self, name_other) =
+                                if contact.body_b.eq_ignore_ascii_case(&interest.rb_name1) {
+                                    (contact.body_b.clone(), contact.body_a.clone())
+                                } else {
+                                    (contact.body_a.clone(), contact.body_b.clone())
+                                };
                             raw_collisions.push((
                                 interest.handler_name.clone().unwrap(),
                                 interest.script_instance.clone().unwrap(),
-                                contact.body_a.clone(), contact.body_b.clone(),
-                                contact.point, contact.normal,
+                                name_self, name_other,
+                                contact.point, contact.normal, contact.normal_rel_vel,
                             ));
                         }
                     }
@@ -315,18 +331,21 @@ impl HavokPhysicsMemberHandlers {
 
             // Now allocate datums (requires mutable player, no longer borrowing havok)
             let mut collision_cbs = Vec::new();
-            for (handler, instance, ba, bb, pt, nm) in raw_collisions {
+            for (handler, instance, ba, bb, pt, nm, nrv) in raw_collisions {
+                // Match the Havok Xtra collision-callback signature
+                // `(bodyNameA, bodyNameB, contactPoint, contactNormal, nrv)`:
+                // cd[3]/cd[4] are VECTORS and cd[5] is the impact speed. (The old
+                // 8-flat-scalar form put contactPoint.z at cd[5], so scripts that
+                // read cd[5] as an impact speed — On the Run's DriveHuman damage
+                // logic — saw a position instead.)
                 let ba_r = player.alloc_datum(Datum::String(ba));
                 let bb_r = player.alloc_datum(Datum::String(bb));
-                let cx = player.alloc_datum(Datum::Float(pt[0]));
-                let cy = player.alloc_datum(Datum::Float(pt[1]));
-                let cz = player.alloc_datum(Datum::Float(pt[2]));
-                let nx = player.alloc_datum(Datum::Float(nm[0]));
-                let ny = player.alloc_datum(Datum::Float(nm[1]));
-                let nz = player.alloc_datum(Datum::Float(nm[2]));
+                let pt_r = player.alloc_datum(Datum::Vector(pt));
+                let nm_r = player.alloc_datum(Datum::Vector(nm));
+                let nrv_r = player.alloc_datum(Datum::Float(nrv));
                 let info = player.alloc_datum(Datum::List(
                     DatumType::List,
-                    VecDeque::from([ba_r, bb_r, cx, cy, cz, nx, ny, nz]),
+                    VecDeque::from([ba_r, bb_r, pt_r, nm_r, nrv_r]),
                     false,
                 ));
                 collision_cbs.push((handler, instance, info));
@@ -562,6 +581,20 @@ impl HavokPhysicsMemberHandlers {
                     g[1] as f64 * inv_s,
                     g[2] as f64 * inv_s,
                 ];
+            }
+
+            // Apply the modeler-authored collision tolerance from the HKE subspace
+            // unless the movie passed an explicit tolerance to initialize(). The
+            // Xtra (and the C# HkeParser) take it from the .hke; our hardcoded 0.1
+            // default is only meant for `initialize(member)` calls whose HKE omits
+            // it. On the Run authors 0.35 — the tolerance sets how far a resting
+            // body floats above a surface, so with 0.1 the car sat ~0.1 above the
+            // road, below the ~0.2 raised (visual-only) sidewalk curbs, and
+            // modelsUnderRay then found no ground (pheight=9999 → couldn't drive).
+            if args.len() <= 1 {
+                if let Some(t) = hke.tolerance {
+                    havok.state.tolerance = t as f64;
+                }
             }
 
             // Apply HKE drag parameters as initial defaults

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -899,6 +899,12 @@ impl HavokPhysicsMemberHandlers {
             }
         }
 
+        // Snapshot every body's authored state so havok.reset() can revert the
+        // scene to the .hke-defined state.
+        for rb in &mut havok.state.rigid_bodies {
+            rb.snapshot_initial();
+        }
+
         let movable_names: Vec<String> = havok.state.rigid_bodies.iter()
             .filter(|rb| !rb.pinned && rb.mass > 0.0)
             .map(|rb| format!("{}({:.1})", rb.name, rb.mass)).collect();
@@ -1051,8 +1057,37 @@ impl HavokPhysicsMemberHandlers {
             CastMemberType::HavokPhysics(h) => h,
             _ => return Err(ScriptError::new("Not a Havok member".to_string())),
         };
+        // havok.reset() "reverts the entire scene back to the state defined in
+        // the .hke file": restore every body to its authored initial transform,
+        // velocity and active flag, and clear runtime state.
         havok.state.sim_time = 0.0;
-        // Reset rigid body states to initial positions would go here
+        havok.state.collision_list_cache.clear();
+        for rb in &mut havok.state.rigid_bodies {
+            rb.restore_initial();
+        }
+
+        // Write the restored transforms back to the W3D scene so the models snap
+        // to their start positions (same path step() uses). Sync all non-fixed
+        // bodies regardless of active flag so even authored-asleep bodies reset.
+        let w3d_cast_lib = havok.state.w3d_cast_lib;
+        let w3d_cast_member = havok.state.w3d_cast_member;
+        let sync_data: Vec<(String, [f32; 16])> = havok.state.rigid_bodies.iter()
+            .filter(|rb| !rb.is_fixed)
+            .map(|rb| {
+                let t = super::havok_physics::build_sync_transform(
+                    rb.position, rb.orientation, rb.center_of_mass, rb.sync_scale,
+                );
+                (rb.name.clone(), t)
+            })
+            .collect();
+        drop(member);
+        let w3d_ref = CastMemberRef { cast_lib: w3d_cast_lib, cast_member: w3d_cast_member };
+        for (name, t) in &sync_data {
+            if t.iter().any(|v| !v.is_finite()) { continue; }
+            crate::player::handlers::datum_handlers::shockwave3d_object::set_node_transform(
+                player, &w3d_ref, name, *t,
+            );
+        }
         Ok(DatumRef::Void)
     }
 
@@ -1315,6 +1350,7 @@ impl HavokPhysicsMemberHandlers {
 
         havok.state.rigid_bodies.push(rb);
         let new_rb_index = havok.state.rigid_bodies.len() - 1;
+        havok.state.rigid_bodies[new_rb_index].snapshot_initial();
         // Re-link collision mesh for this body
         for cmesh in &mut havok.state.collision_meshes {
             if cmesh.name.eq_ignore_ascii_case(&model_name) && cmesh.body_index.is_none() {
@@ -1464,6 +1500,7 @@ impl HavokPhysicsMemberHandlers {
         let rb = HavokRigidBody::new_fixed(&model_name, is_convex);
         havok.state.rigid_bodies.push(rb);
         let rb_index = havok.state.rigid_bodies.len() - 1;
+        havok.state.rigid_bodies[rb_index].snapshot_initial();
 
         if let Some(mut cmesh) = collision_mesh {
             cmesh.body_index = Some(rb_index);

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -672,6 +672,10 @@ impl HavokPhysicsMemberHandlers {
                     if let Some(v) = p.linear_velocity {
                         rb.linear_velocity = [v[0] as f64*inv_scale, v[1] as f64*inv_scale, v[2] as f64*inv_scale];
                     }
+                    // Angular velocity is rad/s — scale-independent, do NOT × inv_scale.
+                    if let Some(w) = p.angular_velocity {
+                        rb.angular_velocity = [w[0] as f64, w[1] as f64, w[2] as f64];
+                    }
                 }
 
                 // Set position + authored model scale from the W3D transform.
@@ -774,6 +778,10 @@ impl HavokPhysicsMemberHandlers {
                 if mass > 0.0 { if let Some(act) = body_def.active { rb.active = act; } }
                 if let Some(v) = body_def.linear_velocity {
                     rb.linear_velocity = [v[0] as f64*inv_scale, v[1] as f64*inv_scale, v[2] as f64*inv_scale];
+                }
+                // Angular velocity is rad/s — scale-independent, do NOT × inv_scale.
+                if let Some(w) = body_def.angular_velocity {
+                    rb.angular_velocity = [w[0] as f64, w[1] as f64, w[2] as f64];
                 }
 
                 // World transform: prefer the W3D node (matches the render),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -1322,17 +1322,21 @@ impl HavokPhysicsMemberHandlers {
         // first inner integrate step" behaviour. With the divider handling
         // angular attenuation, the inertia reverts to the mathematically
         // correct polyhedron values here.
-        let unit_inertia = if shape_type.eq_ignore_ascii_case("sphere") {
-            // Sphere inertia: I = (2/5) * r² on all axes (isotropic)
+        // Compute the unit inertia AND the local centre of mass. The COM is the lever
+        // origin for applyForceAtPoint/applyImpulse — leaving it [0,0,0] when the mesh's
+        // true COM is offset (e.g. the SuperSonic car box spans z∈[0,10] → COM z=+5) makes
+        // every off-centre force torque about the wrong point (lever 15 vs 10 → 1.5× error).
+        let (unit_inertia, com) = if shape_type.eq_ignore_ascii_case("sphere") {
+            // Sphere inertia: I = (2/5) * r² on all axes (isotropic); centred.
             let r = mesh_half_extents[0].max(mesh_half_extents[1]).max(mesh_half_extents[2]);
             let i_diag = 0.4 * r * r;
-            [i_diag, 0.0, 0.0, 0.0, i_diag, 0.0, 0.0, 0.0, i_diag]
+            ([i_diag, 0.0, 0.0, 0.0, i_diag, 0.0, 0.0, 0.0, i_diag], [0.0_f64; 3])
         } else {
             crate::player::handlers::datum_handlers::cast_member::havok_physics
                 ::compute_polyhedron_unit_inertia(&mesh_vertices, &mesh_faces)
-                .map(|(ui, _com, _vol)| ui)
-                .unwrap_or_else(|| crate::player::handlers::datum_handlers::cast_member::havok_physics
-                    ::box_unit_inertia(mesh_half_extents))
+                .map(|(ui, com, _vol)| (ui, com))
+                .unwrap_or_else(|| (crate::player::handlers::datum_handlers::cast_member::havok_physics
+                    ::box_unit_inertia(mesh_half_extents), [0.0_f64; 3]))
         };
 
         // Diagnostic: log mesh + computed unit inertia so we can verify it matches
@@ -1388,6 +1392,9 @@ impl HavokPhysicsMemberHandlers {
             || prim_type.eq_ignore_ascii_case("box");
         rb.inertia_half_extents = mesh_half_extents;
         rb.unit_inertia_tensor = unit_inertia;
+        // The mesh-derived local COM is the lever origin for force/impulse-at-point. The
+        // car box's COM is (0,0,+5); without this, off-centre forces torque about the origin.
+        rb.center_of_mass = com;
         // Apply mass → finalise inertia / inverseInertia.
         crate::player::handlers::datum_handlers::cast_member::havok_physics::recompute_body_inertia(
             mass,

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -676,6 +676,15 @@ impl HavokPhysicsMemberHandlers {
                     if let Some(w) = p.angular_velocity {
                         rb.angular_velocity = [w[0] as f64, w[1] as f64, w[2] as f64];
                     }
+                    // Initial orientation from the HKE body's axis-angle. The renderer
+                    // syncs the W3D model from rb.orientation (build_sync_transform), so
+                    // without this a mesh-derived body kept its identity rotation and
+                    // the car spawned facing the wrong way — the HKE places AutoPlayer
+                    // rotated 90 degrees about Z. Axis-angle is scale-independent.
+                    if let Some(o) = p.orientation {
+                        rb.orientation = super::havok_physics::quat_from_axis_angle(
+                            [o[1] as f64, o[2] as f64, o[3] as f64], o[0] as f64);
+                    }
                 }
 
                 // Set position + authored model scale from the W3D transform.

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -685,6 +685,15 @@ impl HavokPhysicsMemberHandlers {
                         rb.orientation = super::havok_physics::quat_from_axis_angle(
                             [o[1] as f64, o[2] as f64, o[3] as f64], o[0] as f64);
                     }
+                    // COLLISIONS_DISABLED: keep the body out of the collision detector.
+                    if let Some(cd) = p.collisions_disabled { rb.collisions_disabled = cd; }
+                    // CASTS_SHADOWS: render metadata (no physics effect).
+                    if let Some(cs) = p.casts_shadows { rb.casts_shadows = cs; }
+                    // DISPLACEMENT is the authored centre of mass (Havok metres); Import
+                    // writes it over the geometric COM. Scale metres → display units.
+                    if let Some(d) = p.displacement {
+                        rb.center_of_mass = [d[0] as f64*inv_scale, d[1] as f64*inv_scale, d[2] as f64*inv_scale];
+                    }
                 }
 
                 // Set position + authored model scale from the W3D transform.
@@ -729,7 +738,16 @@ impl HavokPhysicsMemberHandlers {
                     // COM = local box centre = body-frame offset from the node
                     // origin (model base) to the collision-box centre.
                     let com = [0.5*(lmn[0]+lmx[0]), 0.5*(lmn[1]+lmx[1]), 0.5*(lmn[2]+lmx[2])];
-                    let unit_i = super::havok_physics::box_unit_inertia(he);
+                    // Unit inertia from the actual mesh polyhedron (the engine derives
+                    // mass properties from geometry). A box-AABB inertia is wrong about
+                    // the pitch axis for a long flat chassis. Box fallback for
+                    // degenerate/open meshes.
+                    let local_verts: Vec<[f64; 3]> = mesh.vertices.iter()
+                        .map(|v| [v[0] as f64 * inv_scale, v[1] as f64 * inv_scale, v[2] as f64 * inv_scale])
+                        .collect();
+                    let unit_i = super::havok_physics::compute_polyhedron_unit_inertia(&local_verts, &mesh.triangles)
+                        .map(|(ui, _com, _vol)| ui)
+                        .unwrap_or_else(|| super::havok_physics::box_unit_inertia(he));
                     let (mut it, mut inv_it, mut inv_m) = ([0.0; 9], [0.0; 9], 0.0);
                     super::havok_physics::recompute_body_inertia(mass, unit_i, &mut it, &mut inv_it, &mut inv_m);
                     let rb = &mut havok.state.rigid_bodies[rb_index];
@@ -791,6 +809,12 @@ impl HavokPhysicsMemberHandlers {
                 // Angular velocity is rad/s — scale-independent, do NOT × inv_scale.
                 if let Some(w) = body_def.angular_velocity {
                     rb.angular_velocity = [w[0] as f64, w[1] as f64, w[2] as f64];
+                }
+                if let Some(cd) = body_def.collisions_disabled { rb.collisions_disabled = cd; }
+                if let Some(cs) = body_def.casts_shadows { rb.casts_shadows = cs; }
+                // DISPLACEMENT = authored centre of mass (Havok metres), overrides geometric.
+                if let Some(d) = body_def.displacement {
+                    rb.center_of_mass = [d[0] as f64*inv_scale, d[1] as f64*inv_scale, d[2] as f64*inv_scale];
                 }
 
                 // World transform: prefer the W3D node (matches the render),
@@ -1192,7 +1216,7 @@ impl HavokPhysicsMemberHandlers {
         };
 
         // Read model's initial transform + mesh bounding box + vertices/faces from W3D scene
-        let (initial_position, mesh_half_extents, mesh_vertices, mesh_faces) = {
+        let (initial_position, mesh_half_extents, mesh_vertices, mesh_faces, prim_type) = {
             let member = player
                 .movie
                 .cast_manager
@@ -1268,12 +1292,20 @@ impl HavokPhysicsMemberHandlers {
                         })
                         .unwrap_or(([10.0, 10.0, 10.0], Vec::new(), Vec::new()));
 
-                    (pos, half_ext, verts, faces)
+                    // Primitive kind of the model resource (#box / #sphere / …), so
+                    // physics can treat a box differently from a rolling sphere.
+                    let prim_type = res_name
+                        .and_then(|rn| w3d.parsed_scene.as_ref()
+                            .and_then(|s| s.model_resources.get(rn.as_str())))
+                        .and_then(|mr| mr.primitive_type.clone())
+                        .unwrap_or_default();
+
+                    (pos, half_ext, verts, faces, prim_type)
                 } else {
-                    ([0.0; 3], [10.0, 10.0, 10.0], Vec::new(), Vec::new())
+                    ([0.0; 3], [10.0, 10.0, 10.0], Vec::new(), Vec::new(), String::new())
                 }
             } else {
-                ([0.0; 3], [10.0, 10.0, 10.0], Vec::new(), Vec::new())
+                ([0.0; 3], [10.0, 10.0, 10.0], Vec::new(), Vec::new(), String::new())
             }
         };
 
@@ -1341,14 +1373,22 @@ impl HavokPhysicsMemberHandlers {
 
         let mut rb = HavokRigidBody::new_movable(&model_name, mass, is_convex);
         rb.position = initial_position;
-        // A body created by Lingo (makeMovableRigidBody) is a script-driven
-        // vehicle (e.g. the SuperSonic car) — keep it on the original collision
-        // path (hover-driven, no box-stacking). HKE-authored bodies (warehouse
-        // crates, the car-demo chassis) stay on the passive path.
+        // Default a Lingo-created movable body to the script-driven vehicle path
+        // (the raycast cars are held up by hover forces and stay off the
+        // box-stacking path). A body that is only ever positioned kinematically
+        // (interpolatingMoveTo) without ever receiving an applied force is
+        // reclassified there to a passive stacking body, so the add-cubes demo
+        // still box-stacks. HKE-authored bodies load as driven=false already.
         rb.driven = true;
+        // Box primitives must not be given sphere "rolling" on resting surfaces —
+        // a cube slides/tumbles, it doesn't roll. Flag it from the shape-type arg
+        // (#box) or the model resource's primitive type. Spheres, cylinders/coins,
+        // cars and meshes are left to roll exactly as before.
+        rb.is_box = shape_type.eq_ignore_ascii_case("box")
+            || prim_type.eq_ignore_ascii_case("box");
         rb.inertia_half_extents = mesh_half_extents;
         rb.unit_inertia_tensor = unit_inertia;
-        // Apply mass → finalise inertia / inverseInertia (PPC setMass 0x4c930)
+        // Apply mass → finalise inertia / inverseInertia.
         crate::player::handlers::datum_handlers::cast_member::havok_physics::recompute_body_inertia(
             mass,
             rb.unit_inertia_tensor,

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
@@ -568,6 +568,44 @@ pub fn detect_body_contacts(
                         normal_rel_vel: nrv,
                     });
                 }
+            } else if passive && normal[2].abs() > 0.85 {
+                // Edge/vertex contact on a near-horizontal FLOOR triangle: the body's
+                // footprint still overlaps the triangle near an edge even though its
+                // CENTRE projects outside the face. This is the seam between adjacent
+                // road box colliders — On the Run paves the road with separate boxes,
+                // and a car whose centre sits over the gap/edge between two of them
+                // finds no face underneath and falls through. The face-only
+                // `pt_in_tri_3d` test (a simplification of the C# reference's full
+                // triangle-triangle closest-point) misses it.
+                //
+                // Restricted to up-facing floor triangles (|n.z|>0.85, Havok is
+                // Z-up): applying it to ramp/wall faces turned their base edges into a
+                // back-stop that blocked the car from climbing small 45° ramps and
+                // whipped it out of the world. Sloped/vertical faces keep the
+                // face-only test. Passive-only so SuperSonic's tuned narrow phase is
+                // unchanged.
+                let closest = closest_pt_on_tri(pos, v0, v1, v2);
+                let to_pos = v3_sub(pos, closest);
+                let d = v3_len(to_pos);
+                if d > 1e-6 && d <= eff_radius {
+                    let depth = eff_radius - d;
+                    // Keep the surface normal (oriented toward the body) so a flat
+                    // seam pushes the car straight up, not sideways toward the edge.
+                    let n = if v3_dot(to_pos, normal) >= 0.0 { normal } else { v3_scale(normal, -1.0) };
+                    if depth > -margin && n[2] > 0.85 {
+                        let va = body_point_velocity(&bodies[body_idx], closest);
+                        let nrv = (va[0]*n[0] + va[1]*n[1] + va[2]*n[2]).abs();
+                        contacts.push(CollisionContact {
+                            body_a: body_idx,
+                            body_b: mesh.body_index,
+                            point: closest,
+                            normal: n,
+                            depth,
+                            mesh_index: Some(mesh_idx),
+                            normal_rel_vel: nrv,
+                        });
+                    }
+                }
             }
         }
     }
@@ -682,6 +720,47 @@ fn pt_in_tri_3d(p: V3, v0: V3, v1: V3, v2: V3) -> bool {
     let u = (d11*d02 - d01*d12) / denom;
     let v = (d00*d12 - d01*d02) / denom;
     u >= -0.01 && v >= -0.01 && (u + v) <= 1.01
+}
+
+/// Closest point on triangle (a,b,c) to point p — Ericson, Real-Time Collision
+/// Detection (handles the face, the three edges, and the three vertex regions).
+/// Used by the box-support narrow phase to rest a body on a triangle edge when
+/// its centre projects just outside the face (road box seams in On the Run).
+fn closest_pt_on_tri(p: V3, a: V3, b: V3, c: V3) -> V3 {
+    let ab = v3_sub(b, a);
+    let ac = v3_sub(c, a);
+    let ap = v3_sub(p, a);
+    let d1 = v3_dot(ab, ap);
+    let d2 = v3_dot(ac, ap);
+    if d1 <= 0.0 && d2 <= 0.0 { return a; }            // vertex region A
+    let bp = v3_sub(p, b);
+    let d3 = v3_dot(ab, bp);
+    let d4 = v3_dot(ac, bp);
+    if d3 >= 0.0 && d4 <= d3 { return b; }             // vertex region B
+    let vc = d1*d4 - d3*d2;
+    if vc <= 0.0 && d1 >= 0.0 && d3 <= 0.0 {           // edge region AB
+        let v = d1 / (d1 - d3);
+        return v3_add(a, v3_scale(ab, v));
+    }
+    let cp = v3_sub(p, c);
+    let d5 = v3_dot(ab, cp);
+    let d6 = v3_dot(ac, cp);
+    if d6 >= 0.0 && d5 <= d6 { return c; }             // vertex region C
+    let vb = d5*d2 - d1*d6;
+    if vb <= 0.0 && d2 >= 0.0 && d6 <= 0.0 {           // edge region AC
+        let w = d2 / (d2 - d6);
+        return v3_add(a, v3_scale(ac, w));
+    }
+    let va = d3*d6 - d5*d4;
+    if va <= 0.0 && (d4 - d3) >= 0.0 && (d5 - d6) >= 0.0 {   // edge region BC
+        let w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+        return v3_add(b, v3_scale(v3_sub(c, b), w));
+    }
+    // Inside face region — barycentric combination.
+    let denom = 1.0 / (va + vb + vc);
+    let v = vb * denom;
+    let w = vc * denom;
+    v3_add(a, v3_add(v3_scale(ab, v), v3_scale(ac, w)))
 }
 
 fn interp_z(px: f64, py: f64, v0: V3, v1: V3, v2: V3) -> f64 {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
@@ -12,6 +12,33 @@ pub type Quat = [f64; 4];
 /// 3x3 matrix, row-major: [M00,M01,M02, M10,M11,M12, M20,M21,M22]
 pub type Mat3 = [f64; 9];
 
+/// Compatibility stub: `HavokPhysicsState` (cast_member.rs) stores per-pair persistent
+/// contact manifolds keyed by body indices. This older physics base does not use them
+/// (the maps stay empty), but the field type must still resolve.
+#[derive(Clone, Default)]
+pub struct Manifold;
+
+/// True if body `body_idx`, placed at (`pos`, `orient`), overlaps any static mesh or other
+/// body beyond `tolerance`. Used by `attemptMoveTo` to reject a blocked move. Temporarily
+/// moves the body to test the pose, then restores it.
+pub fn body_blocked_at(state: &mut HavokPhysicsState, body_idx: usize, pos: V3, orient: Quat) -> bool {
+    if body_idx >= state.rigid_bodies.len() { return false; }
+    let saved_pos = state.rigid_bodies[body_idx].position;
+    let saved_orient = state.rigid_bodies[body_idx].orientation;
+    state.rigid_bodies[body_idx].position = pos;
+    state.rigid_bodies[body_idx].orientation = orient;
+    let tol = state.tolerance;
+    let involves = |c: &CollisionContact| c.body_a == body_idx || c.body_b == Some(body_idx);
+    let blocked = {
+        let s: &HavokPhysicsState = state;
+        detect_all_collisions(s).iter().any(|c| involves(c) && c.depth > tol)
+            || detect_body_body_collisions(s).iter().any(|c| involves(c) && c.depth > tol)
+    };
+    state.rigid_bodies[body_idx].position = saved_pos;
+    state.rigid_bodies[body_idx].orientation = saved_orient;
+    blocked
+}
+
 pub const QUAT_IDENTITY: Quat = [1.0, 0.0, 0.0, 0.0];
 pub const MAT3_IDENTITY: Mat3 = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0];
 pub const MAT3_ZERO: Mat3 = [0.0; 9];

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
@@ -12,12 +12,6 @@ pub type Quat = [f64; 4];
 /// 3x3 matrix, row-major: [M00,M01,M02, M10,M11,M12, M20,M21,M22]
 pub type Mat3 = [f64; 9];
 
-/// Compatibility stub: `HavokPhysicsState` (cast_member.rs) stores per-pair persistent
-/// contact manifolds keyed by body indices. This older physics base does not use them
-/// (the maps stay empty), but the field type must still resolve.
-#[derive(Clone, Default)]
-pub struct Manifold;
-
 /// True if body `body_idx`, placed at (`pos`, `orient`), overlaps any static mesh or other
 /// body beyond `tolerance`. Used by `attemptMoveTo` to reject a blocked move. Temporarily
 /// moves the body to test the pose, then restores it.

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
@@ -453,6 +453,16 @@ pub struct CollisionContact {
     pub normal: V3,
     /// Penetration depth (positive = interpenetrating).
     pub depth: f64,
+    /// Index into `state.collision_meshes` of the static mesh this contact hit
+    /// (None for body-vs-body contacts). Lets the collision callback report the
+    /// real surface model name (e.g. "GraficaStradaZona01") instead of a generic
+    /// fallback when `body_b` is None.
+    pub mesh_index: Option<usize>,
+    /// Closing speed (|normal relative velocity|) captured PRE-resolution. The
+    /// Havok Xtra passes this to collision callbacks as the 5th argument (the
+    /// impact speed used for damage/sound) and gates the callback on the
+    /// registerInterest threshold.
+    pub normal_rel_vel: f64,
 }
 
 // ============================================================
@@ -477,6 +487,20 @@ pub fn find_ground_z(meshes: &[CollisionMesh], x: f64, y: f64, max_z: f64) -> Op
     best
 }
 
+/// World-space velocity of a point rigidly attached to `rb`:
+/// `v = v_linear + omega × (point - position)`. Used to capture the true impact
+/// (closing) speed at a contact point for the collision callback's 5th argument.
+#[inline]
+pub fn body_point_velocity(rb: &crate::player::cast_member::HavokRigidBody, point: V3) -> V3 {
+    let r = [point[0] - rb.position[0], point[1] - rb.position[1], point[2] - rb.position[2]];
+    let w = rb.angular_velocity;
+    [
+        rb.linear_velocity[0] + w[1] * r[2] - w[2] * r[1],
+        rb.linear_velocity[1] + w[2] * r[0] - w[0] * r[2],
+        rb.linear_velocity[2] + w[0] * r[1] - w[1] * r[0],
+    ]
+}
+
 /// Detect contacts for a body (sphere approximation) against static meshes.
 /// Returns contacts with normals pointing AWAY from the triangle surface.
 /// `tolerance` expands the effective collision distance so Havok detects
@@ -493,7 +517,7 @@ pub fn detect_body_contacts(
     let max_r = half_extents[0].max(half_extents[1]).max(half_extents[2]) + tolerance;
     let margin = if passive { CONTACT_MARGIN } else { 0.0 };
     let mut contacts = Vec::new();
-    for mesh in meshes {
+    for (mesh_idx, mesh) in meshes.iter().enumerate() {
         // Skip meshes owned by a MOVABLE body: those are baked at the body's
         // initial position and go stale once it moves (bogus deep collisions;
         // dynamic bodies interact via box-vs-box instead). A FIXED body's mesh
@@ -529,12 +553,19 @@ pub fn detect_body_contacts(
             if pt_in_tri_3d(proj, v0, v1, v2) {
                 let depth = eff_radius - dist;
                 if depth > -margin {
+                    // Impact speed at the contact point, captured before the
+                    // resolver cancels the normal velocity. The mesh's owner (if
+                    // any) is pinned here, so body_b's velocity is zero.
+                    let va = body_point_velocity(&bodies[body_idx], proj);
+                    let nrv = (va[0]*normal[0] + va[1]*normal[1] + va[2]*normal[2]).abs();
                     contacts.push(CollisionContact {
                         body_a: body_idx,
                         body_b: mesh.body_index,
                         point: proj,
                         normal,
                         depth,
+                        mesh_index: Some(mesh_idx),
+                        normal_rel_vel: nrv,
                     });
                 }
             }
@@ -681,6 +712,10 @@ const CONTACT_MARGIN: f64 = 2.0;
 /// Default ground material: friction=0.5, restitution=0.3
 const GROUND_FRICTION: f64 = 0.5;
 const GROUND_RESTITUTION: f64 = 0.3;
+/// Below this closing speed (Director units/s) a contact is treated as "resting":
+/// restitution is suppressed and the penetration-correction *driving impulse* is
+/// skipped, so a body sitting on a surface doesn't get pumped into a bounce.
+const REST_VEL_THRESHOLD: f64 = 10.0;
 
 /// Resolve collision contacts using iterative impulses.
 /// From PPC: resolveWithImpulses (0x5AAB0)
@@ -704,7 +739,14 @@ fn resolve_contacts(state: &mut HavokPhysicsState, contacts: &[CollisionContact]
             // position correction after the resolver handles depenetration;
             // applying driving impulse here injects energy into low-velocity
             // bounces and causes runaway velocity growth.
-            if contact.body_b.is_none() {
+            //
+            // Also skip it for low-velocity (resting) terrain contacts: the
+            // post-resolver position correction already depenetrates them, and
+            // the driving impulse — which is strongest for the shallow contacts a
+            // resting body produces every substep — otherwise pumps energy in and
+            // makes a body sitting on the ground bounce (On the Run's car on the
+            // road). Genuine high-speed penetrations still get it.
+            if contact.body_b.is_none() && contact.normal_rel_vel >= REST_VEL_THRESHOLD {
                 apply_driving_impulse(state, contact, tolerance);
             }
 
@@ -742,7 +784,6 @@ fn resolve_single_contact(state: &HavokPhysicsState, contact: &CollisionContact)
     let restitution = restitution * COLLISION_ENERGY_LOSS;
 
     // Suppress restitution for low-speed contacts to prevent jitter at rest.
-    const REST_VEL_THRESHOLD: f64 = 10.0;
     let is_resting = vn.abs() < REST_VEL_THRESHOLD;
     let eff_restitution = if is_resting { 0.0 } else { restitution };
     let target_vn = -eff_restitution * vn;
@@ -1475,13 +1516,24 @@ fn step_single(state: &mut HavokPhysicsState, dt: f64) {
                 state.collision_list_cache.clear();
                 for c in &contacts {
                     let body_a_name = state.rigid_bodies[c.body_a].name.clone();
-                    let body_b_name = c.body_b.map(|i| state.rigid_bodies[i].name.clone())
+                    // Name the contact partner. For a body-vs-body contact use the
+                    // other rigid body's name; for a static-mesh contact fall back
+                    // to the collision mesh's own name (the real surface model,
+                    // e.g. "GraficaStradaZona01") so Lingo callbacks that classify
+                    // the ground by name (cd[2] contains "strada"/"marciapiede"/…)
+                    // work. Only when neither is known do we emit "ground".
+                    let body_b_name = c.body_b
+                        .map(|i| state.rigid_bodies[i].name.clone())
+                        .or_else(|| c.mesh_index
+                            .and_then(|mi| state.collision_meshes.get(mi))
+                            .map(|m| m.name.clone()))
                         .unwrap_or_else(|| "ground".to_string());
                     state.collision_list_cache.push(crate::player::cast_member::HavokCollisionInfo {
                         body_a: body_a_name,
                         body_b: body_b_name,
                         point: c.point,
                         normal: c.normal,
+                        normal_rel_vel: c.normal_rel_vel,
                     });
                 }
             }
@@ -1689,12 +1741,19 @@ fn detect_body_body_collisions(state: &HavokPhysicsState) -> Vec<CollisionContac
             let mut normal = [0.0; 3];
             normal[axis] = if ca[axis] - cb[axis] >= 0.0 { 1.0 } else { -1.0 };
             let point = v3_scale(v3_add(ca, cb), 0.5);
+            // Closing speed between the two bodies at the contact point, captured
+            // before resolution (impact speed for the collision callback).
+            let va = body_point_velocity(a, point);
+            let vb = body_point_velocity(b, point);
+            let nrv = ((va[0]-vb[0])*normal[0] + (va[1]-vb[1])*normal[1] + (va[2]-vb[2])*normal[2]).abs();
             out.push(CollisionContact {
                 body_a: i,
                 body_b: Some(j),
                 point,
                 normal,
                 depth: min_overlap,
+                mesh_index: None,
+                normal_rel_vel: nrv,
             });
         }
     }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
@@ -1360,6 +1360,43 @@ pub fn step_native(state: &mut HavokPhysicsState, time_increment: f64, num_sub_s
         update_axis_angle_from_orientation(rb);
     }
 
+    // --- Auto-sleep (deactivation) ---
+    // A non-driven body that stays still — low linear+angular speed AND no Lingo
+    // disturbance this step — for SLEEP_DELAY seconds deactivates, so resting
+    // stacks stop jittering and stop loading the solver. Driven/forced bodies
+    // (the SuperSonic car, On the Run's impulse-driven cars) are disturbed every
+    // frame and never reach the countdown, so they never sleep mid-play. Waking
+    // is unchanged (collision at resolve time; Lingo apply*/setters set
+    // `active=true`). The reference RigidBody.ShouldDeactivate exists but is
+    // unwired; this is a velocity-based equivalent of its settle test.
+    {
+        const SLEEP_DELAY: f64 = 0.5;
+        let inv_s = if state.scale.abs() > 1e-10 { 1.0 / state.scale } else { 1.0 };
+        let lin_thr2 = (0.1 * inv_s) * (0.1 * inv_s); // ~0.1 m/s, in display units
+        let ang_thr2 = 0.05 * 0.05;                   // ~0.05 rad/s
+        for rb in &mut state.rigid_bodies {
+            if !rb.active || rb.pinned || rb.driven || rb.inverse_mass <= 0.0 {
+                rb.lingo_disturbed = false;
+                continue;
+            }
+            let lv = rb.linear_velocity;
+            let av = rb.angular_velocity;
+            let lin2 = lv[0]*lv[0] + lv[1]*lv[1] + lv[2]*lv[2];
+            let ang2 = av[0]*av[0] + av[1]*av[1] + av[2]*av[2];
+            if rb.lingo_disturbed || lin2 > lin_thr2 || ang2 > ang_thr2 {
+                rb.sleep_countdown = SLEEP_DELAY;
+            } else {
+                rb.sleep_countdown -= time_increment;
+                if rb.sleep_countdown <= 0.0 {
+                    rb.active = false;
+                    rb.linear_velocity = [0.0; 3];
+                    rb.angular_velocity = [0.0; 3];
+                }
+            }
+            rb.lingo_disturbed = false;
+        }
+    }
+
     state.sim_time += time_increment;
 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
@@ -53,6 +53,16 @@ pub struct HkeBodyProps {
     /// Initial angular velocity (radians/s — scale-independent, NOT × worldScale).
     pub angular_velocity: Option<[f32; 3]>,
     pub active: Option<bool>,
+    /// `COLLISIONS_DISABLED` — when true the body is NOT registered with the
+    /// collision detector (it still integrates under gravity/forces but never
+    /// collides). From `Import`: `if (!collisions_disabled) addRigidBody(...)`.
+    pub collisions_disabled: Option<bool>,
+    /// `DISPLACEMENT` — the authored CENTER OF MASS (Havok metres). `Import`
+    /// writes it to the body's COM slot *after* computeMassProperties, so it
+    /// overrides the geometric centre of mass.
+    pub displacement: Option<[f32; 3]>,
+    /// `CASTS_SHADOWS` — render metadata (display-body shadow); not used by physics.
+    pub casts_shadows: Option<bool>,
     pub primitives: Vec<HkePrimitive>,
 }
 
@@ -89,7 +99,28 @@ pub struct HkeWorld {
     pub cables: Vec<HkeCable>,
 }
 
-// --- Markers and tokens (from C# HkeParser.cs) ---
+// --- Markers and tokens ---
+//
+// HKE field tokens are the ELF/PJW hash of the field's keyword string. In the
+// binary HKE every value is preceded by its 4-byte little-endian token id, and
+// the field order is fixed per record type. `elf_hash` below reproduces the
+// hash; the test module asserts every constant equals elf_hash(its keyword), so
+// these ids are exact rather than approximate.
+
+/// HKE token hash (ELF/PJW). `token_id = elf_hash(KEYWORD)`.
+pub fn elf_hash(s: &str) -> u32 {
+    let mut h: u32 = 0;
+    for &c in s.as_bytes() {
+        h = h.wrapping_mul(16).wrapping_add(c as u32);
+        let g = h & 0xF000_0000;
+        if g != 0 {
+            h ^= g >> 24;
+        }
+        h &= !g;
+    }
+    h
+}
+
 const ENTRY_MARKER: [u8; 6] = [0xA9, 0xEE, 0x9F, 0x01, 0x45, 0x30];
 const ENTRY_SEPARATOR: [u8; 8] = [0xEF, 0xCD, 0xAB, 0x12, 0xC9, 0x0A, 0xA3, 0x0E];
 
@@ -126,18 +157,27 @@ const DEACTIVATOR_ACTION_MARKER: [u8; 16] = [
 ];
 const SUBSPACE_MARKER: [u8; 4] = [0x95, 0x05, 0xC6, 0x00];
 
-// Property tokens (4 bytes each, followed by value)
-const RESTITUTION_TOKEN: [u8; 4] = [0xF9, 0x6E, 0xC7, 0x08];
-const STATIC_FRICTION_TOKEN: [u8; 4] = [0x0E, 0x67, 0x55, 0x00];
-const DYNAMIC_FRICTION_TOKEN: [u8; 4] = [0xAE, 0xA1, 0xC1, 0x00];
-const TRANSLATION_TOKEN: [u8; 4] = [0x0E, 0xEC, 0x5F, 0x08];
-const ACTIVE_TOKEN: [u8; 4] = [0xA5, 0x8E, 0x58, 0x04];
-const PRIMITIVE_MASS_TOKEN: [u8; 4] = [0x83, 0x16, 0x05, 0x00];
-const ORIENTATION_TOKEN: [u8; 4] = [0x4E, 0x89, 0x86, 0x04]; // [angle, axisX, axisY, axisZ]
-const LINEAR_VELOCITY_TOKEN: [u8; 4] = [0xD9, 0x4A, 0xA5, 0x0C]; // [vx, vy, vz] m/s
-const ANGULAR_VELOCITY_TOKEN: [u8; 4] = [0xF9, 0x58, 0x11, 0x04]; // [wx, wy, wz] rad/s
-const PLANE_NORMAL_TOKEN: [u8; 4] = [0x25, 0x06, 0x55, 0x00]; // [nx, ny, nz, dist]
-const SPHERE_RADIUS_TOKEN: [u8; 4] = [0xA3, 0x8E, 0x65, 0x05]; // [radius]
+// Property tokens (4 bytes each, followed by value). Keyword in the trailing
+// comment is the verified elf_hash() pre-image (see the test module).
+const RESTITUTION_TOKEN: [u8; 4] = [0xF9, 0x6E, 0xC7, 0x08]; // "ELLASTICITY" (sic)
+const STATIC_FRICTION_TOKEN: [u8; 4] = [0x0E, 0x67, 0x55, 0x00]; // "STATIC_FRICTION"
+const DYNAMIC_FRICTION_TOKEN: [u8; 4] = [0xAE, 0xA1, 0xC1, 0x00]; // "DYNAMIC_FRICTION"
+const TRANSLATION_TOKEN: [u8; 4] = [0x0E, 0xEC, 0x5F, 0x08]; // "TRANSLATION"
+const ACTIVE_TOKEN: [u8; 4] = [0xA5, 0x8E, 0x58, 0x04]; // "ACTIVE"
+const PRIMITIVE_MASS_TOKEN: [u8; 4] = [0x83, 0x16, 0x05, 0x00]; // "MASS"
+const ORIENTATION_TOKEN: [u8; 4] = [0x4E, 0x89, 0x86, 0x04]; // "ROTATION" [angle, axisX, axisY, axisZ]
+const LINEAR_VELOCITY_TOKEN: [u8; 4] = [0xD9, 0x4A, 0xA5, 0x0C]; // "LINEAR_VELOCITY" [vx, vy, vz] m/s
+const ANGULAR_VELOCITY_TOKEN: [u8; 4] = [0xF9, 0x58, 0x11, 0x04]; // "ANGULAR_VELOCITY" [wx, wy, wz] rad/s
+const PLANE_NORMAL_TOKEN: [u8; 4] = [0x25, 0x06, 0x55, 0x00]; // "PLANE" [nx, ny, nz, dist]
+const SPHERE_RADIUS_TOKEN: [u8; 4] = [0xA3, 0x8E, 0x65, 0x05]; // "RADIUS"
+
+// Per-body fields read from the HKE rigid-body record (Export*::Import order).
+// Token ids derived from elf_hash() and checked in the test module.
+// COLLISIONS_DISABLED gates whether the body is registered for collision;
+// DISPLACEMENT is the authored centre of mass; CASTS_SHADOWS is render-only.
+const COLLISIONS_DISABLED_TOKEN: [u8; 4] = [0x24, 0x0D, 0xF8, 0x08]; // "COLLISIONS_DISABLED" bool
+const DISPLACEMENT_TOKEN: [u8; 4] = [0x34, 0x9D, 0xF8, 0x01]; // "DISPLACEMENT" vec3 (= centre of mass)
+const CASTS_SHADOWS_TOKEN: [u8; 4] = [0xC3, 0x2D, 0xAD, 0x00]; // "CASTS_SHADOWS" bool
 
 // Subspace tokens
 const SUBSPACE_GRAVITY_TOKEN: [u8; 4] = [0xD9, 0xAE, 0x66, 0x0C];
@@ -399,6 +439,9 @@ fn parse_rigid_body(data: &[u8], pos: &mut usize, marker_len: usize, world: &mut
         linear_velocity: try_read_vec3_after_token(payload, &LINEAR_VELOCITY_TOKEN),
         angular_velocity: try_read_vec3_after_token(payload, &ANGULAR_VELOCITY_TOKEN),
         active: try_read_bool_after_token(payload, &ACTIVE_TOKEN),
+        collisions_disabled: try_read_bool_after_token(payload, &COLLISIONS_DISABLED_TOKEN),
+        displacement: try_read_vec3_after_token(payload, &DISPLACEMENT_TOKEN),
+        casts_shadows: try_read_bool_after_token(payload, &CASTS_SHADOWS_TOKEN),
         primitives: Vec::new(),
     };
 

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
@@ -75,6 +75,11 @@ pub struct HkeCable {
 pub struct HkeWorld {
     pub world_name: String,
     pub world_scale: f32,
+    /// Collision tolerance authored in the modeler and stored in the HKE subspace
+    /// (`havok.tolerance`). The Xtra uses it as the "objects are touching" distance,
+    /// which also sets how far above a surface a resting body floats. `initialize()`
+    /// uses it when the movie doesn't pass an explicit tolerance argument.
+    pub tolerance: Option<f32>,
     pub gravity: Option<[f32; 3]>,
     pub drag: Option<HkeDragAction>,
     pub meshes: Vec<HkeCollisionMesh>,
@@ -133,6 +138,7 @@ const SPHERE_RADIUS_TOKEN: [u8; 4] = [0xA3, 0x8E, 0x65, 0x05]; // [radius]
 
 // Subspace tokens
 const SUBSPACE_GRAVITY_TOKEN: [u8; 4] = [0xD9, 0xAE, 0x66, 0x0C];
+const SUBSPACE_TOLERANCE_TOKEN: [u8; 4] = [0x35, 0x1B, 0xA6, 0x00];
 
 // Drag action tokens
 const DRAG_LINEAR_TOKEN: [u8; 4] = [0xC7, 0x74, 0x33, 0x06];
@@ -142,6 +148,7 @@ pub fn parse_hke(data: &[u8]) -> HkeWorld {
     let mut world = HkeWorld {
         world_name: String::new(),
         world_scale: 0.0254,
+        tolerance: None,
         gravity: None,
         drag: None,
         meshes: Vec::new(),
@@ -273,6 +280,9 @@ fn parse_tail(data: &[u8], start: usize, world: &mut HkeWorld) {
             let payload = &data[pos..end];
             if world.gravity.is_none() {
                 world.gravity = try_read_vec3_after_token(payload, &SUBSPACE_GRAVITY_TOKEN);
+            }
+            if world.tolerance.is_none() {
+                world.tolerance = try_read_f32_after_token(payload, &SUBSPACE_TOLERANCE_TOKEN);
             }
             pos = end;
             continue;

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
@@ -50,6 +50,8 @@ pub struct HkeBodyProps {
     pub orientation: Option<[f32; 4]>,
     /// Initial linear velocity (Havok metres/s).
     pub linear_velocity: Option<[f32; 3]>,
+    /// Initial angular velocity (radians/s — scale-independent, NOT × worldScale).
+    pub angular_velocity: Option<[f32; 3]>,
     pub active: Option<bool>,
     pub primitives: Vec<HkePrimitive>,
 }
@@ -133,6 +135,7 @@ const ACTIVE_TOKEN: [u8; 4] = [0xA5, 0x8E, 0x58, 0x04];
 const PRIMITIVE_MASS_TOKEN: [u8; 4] = [0x83, 0x16, 0x05, 0x00];
 const ORIENTATION_TOKEN: [u8; 4] = [0x4E, 0x89, 0x86, 0x04]; // [angle, axisX, axisY, axisZ]
 const LINEAR_VELOCITY_TOKEN: [u8; 4] = [0xD9, 0x4A, 0xA5, 0x0C]; // [vx, vy, vz] m/s
+const ANGULAR_VELOCITY_TOKEN: [u8; 4] = [0xF9, 0x58, 0x11, 0x04]; // [wx, wy, wz] rad/s
 const PLANE_NORMAL_TOKEN: [u8; 4] = [0x25, 0x06, 0x55, 0x00]; // [nx, ny, nz, dist]
 const SPHERE_RADIUS_TOKEN: [u8; 4] = [0xA3, 0x8E, 0x65, 0x05]; // [radius]
 
@@ -394,6 +397,7 @@ fn parse_rigid_body(data: &[u8], pos: &mut usize, marker_len: usize, world: &mut
         translation: try_read_vec3_after_token(payload, &TRANSLATION_TOKEN),
         orientation: try_read_vec4_after_token(payload, &ORIENTATION_TOKEN),
         linear_velocity: try_read_vec3_after_token(payload, &LINEAR_VELOCITY_TOKEN),
+        angular_velocity: try_read_vec3_after_token(payload, &ANGULAR_VELOCITY_TOKEN),
         active: try_read_bool_after_token(payload, &ACTIVE_TOKEN),
         primitives: Vec::new(),
     };

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -2321,7 +2321,7 @@ impl Shockwave3dMemberHandlers {
                                         }
                                         crate::js_api::JsApi::dispatch_flash_member_loaded(
                                             synthetic as i32, src_ref.cast_lib, src_ref.cast_member,
-                                            &swf, fw, fh, true,
+                                            &swf, fw, fh, true, -1,
                                         );
                                         log(&format!(
                                             "[W3D] newTexture(\"{}\"): Flash member {}:{} -> off-screen Ruffle (sprite {}, {}x{})",

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -114,10 +114,13 @@ impl Shockwave3dMemberHandlers {
 
     fn native_text_supersample(smoothness: u32) -> i32 {
         // The native-font path traces the rasterised glyph at this resolution, so
-        // the extruded silhouette is only as smooth as the supersample. Bias it
-        // higher (Director smoothness 0..10 → 3..6) so text like Pacman's score
-        // popups (smoothness 5 → 5) reads far less stair-stepped.
-        (3 + (smoothness as i32 / 2)).clamp(3, 6)
+        // the extruded silhouette (and especially the per-edge tunnel side walls)
+        // is only as smooth as the supersample: too low and curved glyphs get a
+        // coarse contour whose few large side quads don't cover the wall smoothly,
+        // reading as stair-steps / gaps next to the front face. The mesh is rebuilt
+        // only on change (not per frame), so a high supersample is affordable.
+        // Director smoothness 0..10 → 6..10.
+        (6 + (smoothness as i32 / 2)).clamp(6, 10)
     }
 
     fn render_native_text_bitmap(

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -1335,6 +1335,14 @@ impl Shockwave3dMemberHandlers {
 
                         // Track shader name remapping for -clone suffix creation
                         let mut shader_name_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+                        // Track texture name remapping for -clone suffix creation. Director
+                        // renames a colliding texture to "<name>-clone<N>": two models can both
+                        // ship a generically-named texture (e.g. the base map AND the Shield item
+                        // both export "Map #19"); the second model's copy becomes "Map #19-clone1"
+                        // and that model's shaders are repointed at the clone, so neither hijacks
+                        // the other. dirplayer previously kept only the first → the map wall showed
+                        // the shield's sunset texture.
+                        let mut texture_name_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
 
                         // Copy source shaders, model resources, meshes, and textures that don't exist in target scene
                         if let Some(ref src_ref) = source_member_ref {
@@ -1436,6 +1444,30 @@ impl Shockwave3dMemberHandlers {
                                         // (handles cases where shader bindings are empty/unknown)
                                         let filter_shaders = !used_shader_names.is_empty();
 
+                                        // Pre-pass: detect texture-name collisions. A texture whose
+                                        // name already exists in the target scene with DIFFERENT
+                                        // pixels is a real collision (generic exporter names); record
+                                        // a "-clone<N>" rename so the shaders below point at it. Same
+                                        // bytes under the same name are genuinely shared — left as-is.
+                                        for (tex_name, tex_data) in &src_textures {
+                                            if filter_shaders && !used_texture_names.contains(tex_name) { continue; }
+                                            if let Some(existing) = scene.texture_images.get(tex_name) {
+                                                if existing != tex_data {
+                                                    let mut n = 1;
+                                                    loop {
+                                                        let cand = format!("{}-clone{}", tex_name, n);
+                                                        if !scene.texture_images.contains_key(&cand)
+                                                            && !texture_name_map.values().any(|v| v == &cand)
+                                                        {
+                                                            texture_name_map.insert(tex_name.clone(), cand);
+                                                            break;
+                                                        }
+                                                        n += 1;
+                                                    }
+                                                }
+                                            }
+                                        }
+
                                         // Shaders: only copy those used by the model.
                                         // If name conflicts, create -clone<N> copy (Director behavior).
                                         // DefaultShader is built-in to every cast member — never copy it.
@@ -1446,6 +1478,16 @@ impl Shockwave3dMemberHandlers {
                                             if filter_shaders && !used_shader_names.contains(&shader.name) {
                                                 continue; // Skip shaders not used by this model
                                             }
+                                            let mut cloned = shader.clone();
+                                            // Repoint any texture layers whose texture was renamed
+                                            // on collision (Director's -clone<N> behavior).
+                                            if !texture_name_map.is_empty() {
+                                                for layer in &mut cloned.texture_layers {
+                                                    if let Some(nt) = texture_name_map.get(&layer.name) {
+                                                        layer.name = nt.clone();
+                                                    }
+                                                }
+                                            }
                                             if scene.shaders.iter().any(|s| s.name == shader.name) {
                                                 // Name conflict — create a -clone<N> copy
                                                 let mut n = 1;
@@ -1453,7 +1495,6 @@ impl Shockwave3dMemberHandlers {
                                                     let clone_name = format!("{}-clone{}", shader.name, n);
                                                     if !scene.shaders.iter().any(|s| s.name == clone_name) {
                                                         shader_name_map.insert(shader.name.clone(), clone_name.clone());
-                                                        let mut cloned = shader.clone();
                                                         cloned.name = clone_name;
                                                         scene.shaders.push(cloned);
                                                         break;
@@ -1461,7 +1502,7 @@ impl Shockwave3dMemberHandlers {
                                                     n += 1;
                                                 }
                                             } else {
-                                                scene.shaders.push(shader.clone());
+                                                scene.shaders.push(cloned);
                                             }
                                         }
                                         // Copy materials referenced by copied shaders.
@@ -1515,13 +1556,16 @@ impl Shockwave3dMemberHandlers {
                                                 scene.clod_meshes.insert(new_name, mesh_data.clone());
                                             }
                                         }
-                                        // Textures: only copy those used by copied shaders
+                                        // Textures: only copy those used by copied shaders.
+                                        // A collided texture lands under its "-clone<N>" name.
                                         for (tex_name, tex_data) in &src_textures {
                                             if filter_shaders && !used_texture_names.contains(tex_name) {
                                                 continue;
                                             }
-                                            if !scene.texture_images.contains_key(tex_name) {
-                                                scene.texture_images.insert(tex_name.clone(), tex_data.clone());
+                                            let target = texture_name_map.get(tex_name).cloned()
+                                                .unwrap_or_else(|| tex_name.clone());
+                                            if !scene.texture_images.contains_key(&target) {
+                                                scene.texture_images.insert(target, tex_data.clone());
                                                 scene.texture_content_version += 1;
                                             }
                                         }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -2095,6 +2095,9 @@ impl Shockwave3dMemberHandlers {
                                                 // the flag explicitly (the ghost body sets topCap=0 AND bottomCap=0).
                                                 primitive_top_cap: true,
                                                 primitive_bottom_cap: true,
+                                                // #back/#both (e.g. skybox cylinder) → render two-sided
+                                                // so the inward-facing surface isn't backface-culled.
+                                                primitive_facing: new_res_facing.clone(),
                                                 ..Default::default()
                                             });
 
@@ -2701,10 +2704,24 @@ impl Shockwave3dMemberHandlers {
                             origin: [origin[0] as f32, origin[1] as f32, origin[2] as f32],
                             direction: norm_dir,
                         };
+                        // Director parameterizes the ray as origin + t*direction with
+                        // t in [0, maxDistance], so maxDistance is measured in units of
+                        // the DIRECTION VECTOR's length, not world units. The world reach
+                        // is therefore maxDistance * |direction|. We cast with a unit
+                        // direction, so scale the world cutoff by |direction| to match.
+                        // SweeTarts' snake ground-snap casts vector(0,-15,0) with
+                        // maxDistance 100 → 1500 units of reach; treating it as 100 world
+                        // units fell ~7 units short of the platform 107 below the spawn
+                        // origin, so the snake never seated ("can't move before it jumps").
+                        let world_max_dist = if dir_len > 1e-10 {
+                            max_dist * dir_len as f32
+                        } else {
+                            max_dist
+                        };
                         let excluded_ref = if excluded_nodes.is_empty() { None } else { Some(&excluded_nodes) };
                         let included_ref = if model_whitelist.is_empty() { None } else { Some(&model_whitelist) };
                         let hits = raycast_scene_multi(
-                            &ray, &scene, max_dist, max_models as usize,
+                            &ray, &scene, world_max_dist, max_models as usize,
                             node_transforms.as_ref(),
                             excluded_ref,
                             included_ref,

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -2463,10 +2463,55 @@ impl Shockwave3dMemberHandlers {
                     }
                     let origin = player.get_datum(&args[0]).to_vector()?;
                     let direction = player.get_datum(&args[1]).to_vector()?;
-                    let max_models = if args.len() > 2 { player.get_datum(&args[2]).int_value().unwrap_or(100) } else { 100 };
-                    let detailed = if args.len() > 3 {
-                        player.get_datum(&args[3]).string_value().unwrap_or_default() == "detailed"
-                    } else { false };
+
+                    // Director's modelsUnderRay accepts EITHER the positional form
+                    //   (loc, dir, maxNumber, #detailed [, modelList])
+                    // OR the documented options-list form (Director 11.5 dictionary)
+                    //   (loc, dir, optionsList)
+                    // where optionsList is a property list with #maxNumberOfModels,
+                    // #levelOfDetail (#simple default / #detailed), #modelList and
+                    // #maxDistance. Rasterwerks' C_MissilePhysics uses the proplist form;
+                    // parsing it as a positional int silently dropped #modelList/#detailed,
+                    // so missiles hit the firer's own proxy/walls -> bots shot themselves.
+                    use crate::player::handlers::datum_handlers::prop_list::PropListUtils;
+                    let mut max_models: i32 = 100;
+                    let mut detailed = false;
+                    let mut max_dist: f32 = 100000.0;
+                    // #modelList: a list of model REFERENCES to restrict the cast to. An
+                    // empty/absent list means "no restriction" (test all), matching the
+                    // dictionary's "if omitted, all models" wording.
+                    let mut model_whitelist: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+                    let is_proplist = args.len() > 2 && matches!(player.get_datum(&args[2]), Datum::PropList(..));
+                    if is_proplist {
+                        let map = player.get_datum(&args[2]).to_map()?.clone();
+                        let v = PropListUtils::get_by_concrete_key(&map, &Datum::Symbol("maxNumberOfModels".to_owned()), &player.allocator)?;
+                        if let Ok(n) = player.get_datum(&v).int_value() { max_models = n; }
+                        let v = PropListUtils::get_by_concrete_key(&map, &Datum::Symbol("levelOfDetail".to_owned()), &player.allocator)?;
+                        if player.get_datum(&v).string_value().unwrap_or_default().eq_ignore_ascii_case("detailed") { detailed = true; }
+                        let v = PropListUtils::get_by_concrete_key(&map, &Datum::Symbol("maxDistance".to_owned()), &player.allocator)?;
+                        match player.get_datum(&v) {
+                            Datum::Int(i) => max_dist = *i as f32,
+                            Datum::Float(f) => max_dist = *f as f32,
+                            _ => {}
+                        }
+                        let v = PropListUtils::get_by_concrete_key(&map, &Datum::Symbol("modelList".to_owned()), &player.allocator)?;
+                        let items = match player.get_datum(&v) { Datum::List(_, items, _) => items.clone(), _ => VecDeque::new() };
+                        for item in &items {
+                            if let Datum::Shockwave3dObjectRef(r) = player.get_datum(item) { model_whitelist.insert(r.name.clone()); }
+                        }
+                    } else {
+                        if args.len() > 2 { max_models = player.get_datum(&args[2]).int_value().unwrap_or(100); }
+                        if args.len() > 3 { detailed = player.get_datum(&args[3]).string_value().unwrap_or_default().eq_ignore_ascii_case("detailed"); }
+                        // Optional positional #modelList at args[4].
+                        if args.len() > 4 {
+                            let items = match player.get_datum(&args[4]) { Datum::List(_, items, _) => items.clone(), _ => VecDeque::new() };
+                            for item in &items {
+                                if let Datum::Shockwave3dObjectRef(r) = player.get_datum(item) { model_whitelist.insert(r.name.clone()); }
+                            }
+                        }
+                    }
+                    if max_models <= 0 { max_models = 100; }
 
                     let scene = {
                         let member = player.movie.cast_manager.find_member_by_ref(&member_ref);
@@ -2534,10 +2579,12 @@ impl Shockwave3dMemberHandlers {
                             direction: norm_dir,
                         };
                         let excluded_ref = if excluded_nodes.is_empty() { None } else { Some(&excluded_nodes) };
+                        let included_ref = if model_whitelist.is_empty() { None } else { Some(&model_whitelist) };
                         let hits = raycast_scene_multi(
-                            &ray, &scene, 100000.0, max_models as usize,
+                            &ray, &scene, max_dist, max_models as usize,
                             node_transforms.as_ref(),
                             excluded_ref,
+                            included_ref,
                         );
                         for hit in &hits {
                             if detailed {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -1592,7 +1592,32 @@ impl Shockwave3dMemberHandlers {
                                     if let Some(scene) = w3d.scene_mut() {
                                         match obj_type {
                                             "model" | "group" | "camera" => {
-                                                scene.nodes.retain(|n| !n.name.eq_ignore_ascii_case(&obj_name));
+                                                // Director deleteModel removes the model AND its child
+                                                // subtree. Without that, children added via addChild are
+                                                // orphaned (parent gone) and keep rendering at a fixed
+                                                // local position. frog01 builds an invisible "car1"
+                                                // template with the body (acar) + 4 wheels as children,
+                                                // clones it 16×, then deleteModel("car1") — leaving the
+                                                // original acar behind as a static, misplaced car. The
+                                                // clones (children of car2..car17) are NOT in car1's
+                                                // subtree, so they're unaffected.
+                                                let mut doomed: std::collections::HashSet<String> =
+                                                    std::collections::HashSet::new();
+                                                doomed.insert(obj_name.to_ascii_lowercase());
+                                                let mut changed = true;
+                                                while changed {
+                                                    changed = false;
+                                                    for n in scene.nodes.iter() {
+                                                        let nl = n.name.to_ascii_lowercase();
+                                                        if !doomed.contains(&nl)
+                                                            && doomed.contains(&n.parent_name.to_ascii_lowercase())
+                                                        {
+                                                            doomed.insert(nl);
+                                                            changed = true;
+                                                        }
+                                                    }
+                                                }
+                                                scene.nodes.retain(|n| !doomed.contains(&n.name.to_ascii_lowercase()));
                                             }
                                             "light" => {
                                                 // Lights live in two places: the scene
@@ -1980,6 +2005,56 @@ impl Shockwave3dMemberHandlers {
                                     _ => None,
                                 };
                                 if let Some(src_ref) = source_member_ref {
+                                    // Off-screen Flash → 3D texture (frog01 environment): capture the
+                                    // SWF bytes + native dims so we can kick off a Ruffle render below.
+                                    // The synchronous bitmap path produces None for Flash members.
+                                    let flash_dispatch: Option<(Vec<u8>, u32, u32)> = {
+                                        let src_member = player.movie.cast_manager.find_member_by_ref(&src_ref);
+                                        match src_member.map(|m| &m.member_type) {
+                                            Some(CastMemberType::Flash(flash)) => {
+                                                let (l, t, r, b) = flash.effective_rect();
+                                                let mut fw = (r - l).max(1) as u32;
+                                                let mut fh = (b - t).max(1) as u32;
+                                                // Director renders a Flash member into the texture at the SWF's OWN
+                                                // stage size, NOT the cast member's display rect. frog01's
+                                                // `front`/`back` banner have a TALL display rect (640×1320) but a
+                                                // WIDE swf stage (≈1320×640); using the rect letterboxed the wide
+                                                // banner into a tall frame → mostly-black. Parse the frame RECT from
+                                                // the (uncompressed FWS) SWF header for the real stage size.
+                                                //
+                                                // Do NOT round to power-of-2: an earlier POT rounding (to match
+                                                // Director's reported 1024×512) DISTORTED other members — the
+                                                // bark/wood log textures came out the wrong size, so the logs looked
+                                                // gappy / "open caps". NPOT textures are fine in WebGL2; keep the raw
+                                                // stage size.
+                                                if flash.data.len() >= 9 && &flash.data[0..3] == b"FWS" {
+                                                    let bits = &flash.data[8..];
+                                                    let mut bitpos = 0usize;
+                                                    let mut read = |n: usize| -> u32 {
+                                                        let mut v = 0u32;
+                                                        for _ in 0..n {
+                                                            let byte = bits.get(bitpos >> 3).copied().unwrap_or(0);
+                                                            v = (v << 1) | ((byte >> (7 - (bitpos & 7))) & 1) as u32;
+                                                            bitpos += 1;
+                                                        }
+                                                        v
+                                                    };
+                                                    let nbits = read(5) as usize;
+                                                    if nbits > 0 && nbits <= 31 {
+                                                        let _xmin = read(nbits);
+                                                        let xmax = read(nbits);
+                                                        let _ymin = read(nbits);
+                                                        let ymax = read(nbits);
+                                                        let w = (xmax / 20).max(1); // twips → px
+                                                        let h = (ymax / 20).max(1);
+                                                        if w > 1 && h > 1 { fw = w; fh = h; }
+                                                    }
+                                                }
+                                                Some((flash.data.clone(), fw, fh))
+                                            }
+                                            _ => None,
+                                        }
+                                    };
                                     let rgba_data = {
                                         let src_member = player.movie.cast_manager.find_member_by_ref(&src_ref);
                                         src_member.and_then(|m| {
@@ -1990,6 +2065,7 @@ impl Shockwave3dMemberHandlers {
                                                     let h = bmp.height;
                                                     let palettes = player.movie.cast_manager.palettes();
                                                     let mut rgba = vec![0u8; (w as usize) * (h as usize) * 4];
+                                                    let mut any_opaque = false;
                                                     for y in 0..h as usize {
                                                         for x in 0..w as usize {
                                                             let (r, g, b, a) = bmp.get_pixel_color_with_alpha(&palettes, x as u16, y as u16);
@@ -1998,14 +2074,30 @@ impl Shockwave3dMemberHandlers {
                                                             rgba[idx + 1] = g;
                                                             rgba[idx + 2] = b;
                                                             rgba[idx + 3] = a;
+                                                            if a != 0 { any_opaque = true; }
+                                                        }
+                                                    }
+                                                    // A 32-bit cast bitmap with no real alpha channel (use_alpha
+                                                    // off) or whose alpha bytes are all 0 must render OPAQUE as a
+                                                    // 3D texture — Director ignores texture alpha for #standard
+                                                    // shaders. Without this, frog01's car-colour textures cc2-cc5
+                                                    // (32-bit, alpha 0) made the car bodies fully transparent
+                                                    // (invisible); cc1 happened to have alpha 255 so it showed.
+                                                    if !bmp.use_alpha || !any_opaque {
+                                                        for px in 0..(w as usize) * (h as usize) {
+                                                            rgba[px * 4 + 3] = 255;
                                                         }
                                                     }
                                                     log(&format!(
-                                                        "[W3D] newTexture(\"{}\", #fromCastMember): {}x{} from member {}:{} '{}'",
-                                                        obj_name, w, h, src_ref.cast_lib, src_ref.cast_member, m.name
+                                                        "[W3D] newTexture(\"{}\", #fromCastMember): {}x{} from member {}:{} '{}' (forced_opaque={})",
+                                                        obj_name, w, h, src_ref.cast_lib, src_ref.cast_member, m.name,
+                                                        !bmp.use_alpha || !any_opaque
                                                     ));
                                                     Some((w, h, rgba))
                                                 }
+                                                // Flash members are rendered off-screen via Ruffle
+                                                // (flash_dispatch above), not the synchronous bitmap path.
+                                                CastMemberType::Flash(_) => None,
                                                 _ => {
                                                     console_warn!(
                                                         "[W3D] newTexture(\"{}\", #fromCastMember): member {}:{} '{}' is {} not Bitmap",
@@ -2035,6 +2127,46 @@ impl Shockwave3dMemberHandlers {
                                                 }
                                             }
                                         }
+                                    }
+                                    // Flash source: start an off-screen Ruffle render and route its
+                                    // captured frames into this texture (update_flash_frame consults
+                                    // player.flash_texture_targets). The synthetic sprite number is
+                                    // NEGATIVE so it never collides with an on-stage channel, and
+                                    // deterministic per source member so a movie restart reuses the
+                                    // same Ruffle instance instead of leaking a new one.
+                                    if let Some((swf, fw, fh)) = flash_dispatch {
+                                        let synthetic = {
+                                            let raw = 2000i32
+                                                + src_ref.cast_lib.max(0) * 1000
+                                                + src_ref.cast_member.max(0);
+                                            -(raw.min(30000)) as i16
+                                        };
+                                        player.flash_texture_targets
+                                            .insert(synthetic, (member_ref.clone(), obj_name.clone()));
+                                        // Transparent 1×1 placeholder so the plane isn't the default
+                                        // checker (primitive fallback) until the first Flash frame lands.
+                                        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                                            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                                if let Some(scene) = w3d.scene_mut() {
+                                                    if !scene.texture_images.contains_key(&obj_name) {
+                                                        let mut ph = Vec::with_capacity(12);
+                                                        ph.extend_from_slice(&1u32.to_le_bytes());
+                                                        ph.extend_from_slice(&1u32.to_le_bytes());
+                                                        ph.extend_from_slice(&[0u8, 0, 0, 0]);
+                                                        scene.texture_images.insert(obj_name.clone(), ph);
+                                                        scene.texture_content_version += 1;
+                                                    }
+                                                }
+                                            }
+                                        }
+                                        crate::js_api::JsApi::dispatch_flash_member_loaded(
+                                            synthetic as i32, src_ref.cast_lib, src_ref.cast_member,
+                                            &swf, fw, fh, true,
+                                        );
+                                        log(&format!(
+                                            "[W3D] newTexture(\"{}\"): Flash member {}:{} -> off-screen Ruffle (sprite {}, {}x{})",
+                                            obj_name, src_ref.cast_lib, src_ref.cast_member, synthetic, fw, fh
+                                        ));
                                     }
                                 }
                             } else if tex_type == "fromImageObject" {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -1270,10 +1270,27 @@ impl Shockwave3dMemberHandlers {
                                         } else {
                                             (String::new(), identity, String::new(), String::new())
                                         };
-                                        let motion_tracks = scene.motions.iter()
-                                            .max_by_key(|m| m.tracks.len())
-                                            .map(|m| m.tracks.clone())
-                                            .unwrap_or_default();
+                                        // cloneMotionFromCastmember(newName, sourceMotionName, member)
+                                        // must clone the SPECIFIC motion named sourceMotionName
+                                        // (= source_model_name, arg1). The old code grabbed the
+                                        // motion with the most tracks instead, so every cloned
+                                        // motion in a member collapsed onto the last/largest one
+                                        // (ties resolve to the last) — On the Run's bonus got the
+                                        // gate's "SbarraChiusura" swing instead of "BonusRotazione",
+                                        // and all train/jeep motions became "JeepCPU02". For model
+                                        // clones (no specific motion requested) keep the
+                                        // most-tracks heuristic (a skeletal model's main motion).
+                                        let motion_tracks = if obj_type == "motion" {
+                                            scene.motions.iter()
+                                                .find(|m| m.name.eq_ignore_ascii_case(&source_model_name))
+                                                .map(|m| m.tracks.clone())
+                                                .unwrap_or_default()
+                                        } else {
+                                            scene.motions.iter()
+                                                .max_by_key(|m| m.tracks.len())
+                                                .map(|m| m.tracks.clone())
+                                                .unwrap_or_default()
+                                        };
                                         // Collect all descendant nodes of the source model recursively
                                         // Use case-insensitive matching (Director is case-insensitive)
                                         let child_nodes = {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -225,14 +225,57 @@ impl Shockwave3dMemberHandlers {
         source: &crate::player::cast_member::Text3dSource,
         state: &crate::player::cast_member::Text3dState,
     ) -> Option<crate::director::chunks::w3d::types::ClodDecodedMesh> {
-        let (bw, bh, rgba) = Self::render_native_text_bitmap(source, state.smoothness)?;
-        // Marching-squares extrusion: smooth (sub-pixel) silhouette vs the
-        // per-pixel voxel mesh, matching Director's vector-outline edges.
-        Some(crate::director::chunks::w3d::primitives::extrude_alpha_mask_smooth(
-            bw, bh, &rgba,
-            source.width as f32, source.height as f32,
-            state.tunnel_depth,
-        ))
+        use crate::director::chunks::w3d::text3d;
+
+        // displayFace bitmask: bit0=#front, bit1=#tunnel, bit2=#back; -1 = all.
+        let df = state.display_face;
+        let params = text3d::ExtrudeParams {
+            depth: state.tunnel_depth.max(1.0),
+            bevel_type: state.bevel_type,
+            bevel_depth: state.bevel_depth.max(0.0),
+            smoothness: state.smoothness,
+            front: df == -1 || (df & 1) != 0,
+            tunnel: df == -1 || (df & 2) != 0,
+            back: df == -1 || (df & 4) != 0,
+        };
+
+        // Render at a high supersample for a smooth re-vectorised outline (the
+        // marching-squares trace is only as smooth as the rasterised source).
+        let (bw, bh, rgba) = Self::render_native_text_bitmap(source, state.smoothness.max(8))?;
+        // No-PFR (system/native font) path: there are no embedded glyph outlines,
+        // so re-vectorise the rasterised text into clean contours, then run the
+        // SAME contour pipeline as the PFR path (caps-with-holes + tunnel + bevel).
+        // This replaces the old drop-shadow alpha mesh, so system-font 3D text
+        // extrudes properly (frog01 title). px→model maps like the alpha-mask path
+        // (Y flipped to Y-up).
+        let ww = (source.width.max(1)) as f32;
+        let wh = (source.height.max(1)) as f32;
+        let pw = ww / bw.max(1) as f32;
+        let ph = wh / bh.max(1) as f32;
+        // Simplify tolerance ≈ 1 model unit (supersample = bw/ww pixels per model unit).
+        // supersample px per model unit; blur ~⅓ of that smooths the AA iso-edge.
+        let ss = (bw as f32 / ww).max(1.0);
+        let blur_radius = (ss / 3.0).round().max(1.0) as usize;
+        let eps_px = ss * 0.3;
+        let contours_px = text3d::vectorize_alpha(bw, bh, &rgba, 128, eps_px, 2, blur_radius);
+        let contours: Vec<Vec<[f32; 2]>> = contours_px
+            .iter()
+            .map(|c| c.iter().map(|p| [p[0] * pw, wh - p[1] * ph]).collect())
+            .collect();
+        if contours.is_empty() {
+            return None;
+        }
+        // Raster-vectorised fallback uses the same extrude params built above.
+        let (positions, normals, faces) = text3d::extrude_glyph(&contours, &params);
+        if positions.is_empty() {
+            return None;
+        }
+        let mut mesh = crate::director::chunks::w3d::types::ClodDecodedMesh::default();
+        mesh.name = "Text".to_string();
+        mesh.positions = positions;
+        mesh.normals = normals;
+        mesh.faces = faces;
+        Some(mesh)
     }
 
     /// Re-extrude an extrude3d resource (keyed by `resname`) into `member`'s
@@ -324,30 +367,14 @@ impl Shockwave3dMemberHandlers {
         runtime_state: &mut crate::player::cast_member::Shockwave3dRuntimeState,
         display_face: i32,
     ) {
-        let front = display_face == -1 || (display_face & 1) != 0;
-        let tunnel = display_face == -1 || (display_face & 2) != 0;
-        let back = display_face == -1 || (display_face & 4) != 0;
-
-        let mode = if !front && !back && !tunnel {
-            Some(0u8)
-        } else if tunnel || (front && back) {
-            // Tunnel faces need culling disabled to read as extruded text.
-            Some(3u8)
-        } else if back && !front {
-            Some(2u8)
-        } else {
-            Some(1u8)
-        };
-
-        match mode {
-            Some(1) => {
-                runtime_state.node_visibility.remove("Text");
-            }
-            Some(mode) => {
-                runtime_state.node_visibility.insert("Text".to_string(), mode);
-            }
-            None => {}
-        }
+        // extrude_glyph now generates exactly the requested faces (front cap /
+        // back cap / tunnel) per displayFace, so this only toggles overall
+        // visibility and keeps backface culling OFF (mode 3) so every generated
+        // face — including the inward tunnel and hole walls — renders.
+        let any = display_face == -1 || (display_face & 7) != 0;
+        runtime_state
+            .node_visibility
+            .insert("Text".to_string(), if any { 3u8 } else { 0u8 });
     }
 
     /// Lazily initialize the embedded 3D world for text members.
@@ -499,8 +526,13 @@ impl Shockwave3dMemberHandlers {
 
                 // Add mesh to the scene
                 if let Some((glyphs, outline_res)) = glyph_data {
+                    let bevel_depth = w3d_member.text3d_state.as_ref().map(|s| s.bevel_depth).unwrap_or(1.0);
+                    let bevel_type = w3d_member.text3d_state.as_ref().map(|s| s.bevel_type).unwrap_or(1);
+                    let smoothness = w3d_member.text3d_state.as_ref().map(|s| s.smoothness).unwrap_or(10);
+                    let display_face = w3d_member.text3d_state.as_ref().map(|s| s.display_face).unwrap_or(-1);
                     let mesh = crate::director::chunks::w3d::primitives::extrude_text_to_mesh(
                         &text_content, &glyphs, outline_res, font_size as f32, depth,
+                        bevel_type, bevel_depth, smoothness, display_face,
                     );
                     if !mesh.positions.is_empty() {
                         if let Some(scene) = w3d_member.scene_mut() {
@@ -558,7 +590,10 @@ impl Shockwave3dMemberHandlers {
                         tunnel_depth: depth.max(1.0),
                         smoothness: 10,
                         bevel_depth: 1.0,
-                        bevel_type: 0,
+                        // Director's default bevelType is #miter (1), not #none. A flat
+                        // #none slab has no lit edge so letters/hole-rims read poorly;
+                        // the miter chamfer catches light and makes depth + holes pop.
+                        bevel_type: 1,
                         display_face: -1,
                         display_mode: 1,
                         diffuse_color: (0, 0, 0),
@@ -2285,7 +2320,17 @@ impl Shockwave3dMemberHandlers {
                         };
                         let src_name = player.movie.cast_manager.find_member_by_ref(&member_ref)
                             .map(|m| m.name.clone()).unwrap_or_else(|| "text".to_string());
-                        let resname = format!("{}_extrude3d", src_name);
+                        // Each extrude3d call returns a DISTINCT model resource — Director does
+                        // too, even when the SAME text member is reused (set text → extrude →
+                        // newModel → repeat), which frog01's title screen does. Keying the mesh
+                        // by member name alone made every call overwrite the one "<name>_extrude3d"
+                        // mesh, so every model showed the LAST text ("www.jellygames.com"). Make
+                        // the name unique per call via the target scene's current resource count.
+                        let seq = player.movie.cast_manager.find_member_by_ref(&target_ref)
+                            .and_then(|m| m.member_type.as_shockwave3d())
+                            .map(|w| w.runtime_state.text3d_resources.len())
+                            .unwrap_or(0);
+                        let resname = format!("{}_extrude3d_{}", src_name, seq);
                         let mut mesh = match Self::build_text3d_mesh(&source, &state) {
                             Some(m) => m,
                             None => return Ok(player.alloc_datum(Datum::Void)),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -992,6 +992,23 @@ impl Shockwave3dMemberHandlers {
                 }
                 Ok(())
             }
+            // Cast member property: the default rectangle used to size new
+            // sprites / the rendered 3D image (Director dict: `defaultRect`,
+            // e.g. `member.defaultRect = rect(0, 0, 300, 300)`). Stored as the
+            // member's default_rect, which drives width/height/`.image` size.
+            // `rect` is accepted as an alias since the getter maps it to the
+            // same field. (defaultRectMode→#fixed isn't tracked for 3D members.)
+            "defaultRect" | "defaultrect" | "rect" => {
+                if let Datum::Rect([l, t, r, b], _) = value {
+                    let new_rect = (*l as i32, *t as i32, *r as i32, *b as i32);
+                    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(cast_member_ref) {
+                        if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                            w3d.info.default_rect = new_rect;
+                        }
+                    }
+                }
+                Ok(())
+            }
             _ => {
                 Err(ScriptError::new(format!(
                     "Cannot set Shockwave3D property '{}'", prop
@@ -1532,11 +1549,33 @@ impl Shockwave3dMemberHandlers {
                                 .unwrap_or(source_shader_name)
                         };
 
+                        // Copy the source member's keyframe MOTIONS so the cloned
+                        // model's keyframePlayer.play(name) can find them — clone
+                        // otherwise copies geometry/shaders/meshes but NOT motions.
+                        // (Splat: pac-man feet footA/footB clones play "footA-Key"/
+                        // "footB-Key"; the motion's track is named after the source
+                        // node "footA"/"footB", which matches the same-named clone.)
+                        let src_motions: Vec<crate::director::chunks::w3d::types::W3dMotion> = if obj_type == "model" {
+                            source_member_ref.as_ref()
+                                .and_then(|sr| player.movie.cast_manager.find_member_by_ref(sr))
+                                .and_then(|sm| sm.member_type.as_shockwave3d())
+                                .and_then(|sw| sw.parsed_scene.as_ref())
+                                .map(|sc| sc.motions.clone())
+                                .unwrap_or_default()
+                        } else { Vec::new() };
+
                         if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                             if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
                                 if let Some(scene) = w3d.scene_mut() {
                                     use crate::director::chunks::w3d::types::*;
                                     if obj_type == "model" {
+                                        // Bring over any source motions not already present (by
+                                        // name) so keyframePlayer.play() resolves them.
+                                        for m in &src_motions {
+                                            if !scene.motions.iter().any(|em| em.name.eq_ignore_ascii_case(&m.name)) {
+                                                scene.motions.push(m.clone());
+                                            }
+                                        }
                                         scene.nodes.push(W3dNode {
                                             name: obj_name.clone(), node_type: W3dNodeType::Model,
                                             parent_name: "World".to_string(),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -16,6 +16,15 @@ use crate::{
 
 const W3D_HANDLER_LOG: bool = false;
 
+/// Director's W3D motion collection has an implicit default motion at index 1,
+/// so authored motions start at index 2. dirplayer's scene.motions holds only
+/// authored motions, so the accessors below synthesise this default at index 1
+/// to keep `member.motion[i]` / `.count` aligned with Director (mirrors the way
+/// the camera accessor inserts DefaultView as camera[1]). Without it,
+/// e.g. Rasterwerks' `m.motion[3].name` returned the wrong (3rd authored) motion
+/// and every actor cloned a non-skeletal motion → T-pose.
+const DEFAULT_MOTION_NAME: &str = "Default Motion";
+
 fn log(msg: &str) {
     if W3D_HANDLER_LOG {
         debug!("[W3D-HANDLER] {}", msg);
@@ -687,7 +696,12 @@ impl Shockwave3dMemberHandlers {
                             cams
                         }
                         "group" => scene.nodes.iter().filter(|n| n.node_type == W3dNodeType::Group).map(|n| n.name.clone()).collect(),
-                        "motion" => scene.motions.iter().map(|m| m.name.clone()).collect(),
+                        "motion" => {
+                            // Default motion at index 1, then authored motions (see DEFAULT_MOTION_NAME).
+                            let mut v = vec![DEFAULT_MOTION_NAME.to_string()];
+                            v.extend(scene.motions.iter().map(|m| m.name.clone()));
+                            v
+                        }
                         _ => vec![],
                     }
                 } else {
@@ -1281,8 +1295,13 @@ impl Shockwave3dMemberHandlers {
                                         // clones (no specific motion requested) keep the
                                         // most-tracks heuristic (a skeletal model's main motion).
                                         let motion_tracks = if obj_type == "motion" {
+                                            // Among motions matching the requested name, take the one
+                                            // with the most tracks (the skeletal animation, vs an
+                                            // empty/stub of the same name) — robust to duplicate names;
+                                            // a no-op when the name is unique (On the Run).
                                             scene.motions.iter()
-                                                .find(|m| m.name.eq_ignore_ascii_case(&source_model_name))
+                                                .filter(|m| m.name.eq_ignore_ascii_case(&source_model_name))
+                                                .max_by_key(|m| m.tracks.len())
                                                 .map(|m| m.tracks.clone())
                                                 .unwrap_or_default()
                                         } else {
@@ -2784,7 +2803,8 @@ impl Shockwave3dMemberHandlers {
             "light" => scene.lights.len() as i32,
             "camera" => scene.nodes.iter().filter(|n| n.node_type == W3dNodeType::View).count() as i32,
             "group" => scene.nodes.iter().filter(|n| n.node_type == W3dNodeType::Group).count() as i32,
-            "motion" => scene.motions.len() as i32,
+            // +1 for the implicit default motion at index 1 (see DEFAULT_MOTION_NAME).
+            "motion" => scene.motions.len() as i32 + 1,
             _ => 0,
         }
     }
@@ -2815,7 +2835,14 @@ impl Shockwave3dMemberHandlers {
                 cams.get(idx).map(|s| s.to_string())
             }
             "group" => scene.nodes.iter().filter(|n| n.node_type == W3dNodeType::Group).nth(idx).map(|n| n.name.clone()),
-            "motion" => scene.motions.get(idx).map(|m| m.name.clone()),
+            // motion[1] = implicit default; authored motions follow at 2.. (see DEFAULT_MOTION_NAME).
+            "motion" => {
+                if idx == 0 {
+                    Some(DEFAULT_MOTION_NAME.to_string())
+                } else {
+                    scene.motions.get(idx - 1).map(|m| m.name.clone())
+                }
+            }
             _ => None,
         }
     }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -390,6 +390,18 @@ impl TextMemberHandlers {
                     "setContentsBefore" => format!("{}{}", new_str, text_member.text),
                     _ => unreachable!(),
                 };
+                // Clear stale styled spans — same as the `.text` property setter
+                // above. `put X into member` lowers to setContents; without this
+                // the parse-time `html_styled_spans` keep their ORIGINAL text
+                // (and the native renderer draws them, not the updated `.text`),
+                // so a score/round display frozen at its authored value
+                // (pengapop gameScore/gameRound: `put newScore into member`
+                // updated `.text` to "8600" but the span still said "0", so the
+                // HUD never changed). Clearing lets the next render synthesise a
+                // clean default span from the member-level font/size/color and
+                // the new text — matching Director resetting styling on a text
+                // rewrite.
+                text_member.html_styled_spans.clear();
                 Ok(DatumRef::Void)
             }
             _ => Err(ScriptError::new(format!(

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -45,6 +45,73 @@ pub(crate) fn scroll_line_height(fixed_line_space: u16, font_size: u16) -> i32 {
     }
 }
 
+/// Count the number of VISUAL lines a text member produces, walking the SAME
+/// greedy word-wrap rule the renderer and the `.image` getter use (split on
+/// line breaks, then wrap on spaces at `wrap_width` using per-char advances +
+/// `char_spacing`).
+///
+/// The `.rect`/`.height` getters previously derived the line count as
+/// `measure_text_wrapped().height / (char_height - 1)`. For PFR fonts whose
+/// atlas cell (`char_height` ≈ 26 for Volter-9) dwarfs the authored
+/// `fixedLineSpace` (≈ 10), `measure_text_wrapped` strides by `fixedLineSpace`
+/// while the divisor was `char_height - 1` — so the count came out ~2.3× too
+/// SMALL, making `.rect`/`.height` report ~43% of `.image`'s height. Habbo's
+/// window Text-Wrapper bakes text via
+/// `pimage.copyPixels(member.image, dst = member.image.rect, src = member.rect)`,
+/// so that mismatch stretched the registration ToS (Origins "Habbo Details")
+/// ~2.3× vertically. Sharing this walk keeps `.rect`/`.height` == `.image`.
+pub(crate) fn count_text_lines(
+    text: &str,
+    font: &crate::player::font::BitmapFont,
+    word_wrap: bool,
+    wrap_width: i32,
+    char_spacing: i32,
+) -> usize {
+    if word_wrap && wrap_width > 0 {
+        let cs = char_spacing;
+        let space_w = font.get_char_advance(b' ') as i32 + cs;
+        let normalised: String = text.replace("\r\n", "\n").replace('\r', "\n");
+        let mut count: usize = 0;
+        for raw in normalised.split('\n') {
+            if raw.is_empty() {
+                count += 1;
+                continue;
+            }
+            let mut current_w: i32 = 0;
+            let mut had_word = false;
+            for word in raw.split(' ') {
+                if word.is_empty() {
+                    continue;
+                }
+                let word_w: i32 = word
+                    .chars()
+                    .map(|c| font.get_char_advance(c as u8) as i32 + cs)
+                    .sum();
+                let candidate = if !had_word {
+                    word_w
+                } else {
+                    current_w + space_w + word_w
+                };
+                if candidate <= wrap_width || !had_word {
+                    current_w = candidate;
+                    had_word = true;
+                } else {
+                    count += 1;
+                    current_w = word_w;
+                }
+            }
+            count += 1;
+        }
+        count.max(1)
+    } else {
+        text.replace("\r\n", "\n")
+            .chars()
+            .filter(|c| *c == '\r' || *c == '\n')
+            .count()
+            + 1
+    }
+}
+
 /// Read `(fixed_line_space, font_size, height_px)` from a field or text member,
 /// or `None` for any other member type. `height_px` is the member's box height
 /// (used to size a "page" for `scrollByPage`).
@@ -463,12 +530,19 @@ impl TextMemberHandlers {
                 Ok(Datum::String(html))
             }
             "rect" => {
+                // Load the font IDENTICALLY to the `.image` getter
+                // (`get_font_with_cast_and_bitmap`, which rasterizes the PFR atlas
+                // at the requested size). `get_font_with_cast` returned a font with
+                // different (wider) char advances, so `count_text_lines` wrapped to
+                // ~2x more lines here than `.image` did — making `.rect` over-report
+                // and the Text-Wrapper bake squish the terms text. Must match.
                 let font = if !text_data.font.is_empty() {
                     player
                         .font_manager
-                        .get_font_with_cast(
+                        .get_font_with_cast_and_bitmap(
                             &text_data.font,
-                            Some(&player.movie.cast_manager),
+                            &player.movie.cast_manager,
+                            &mut player.bitmap_manager,
                             Some(text_data.font_size),
                             None,
                         )
@@ -550,25 +624,16 @@ impl TextMemberHandlers {
                     } else if let Some(ref info) = text_data.info {
                         if info.width > 0 { info.width as u16 } else { 0 }
                     } else { 0 };
-                    let line_count = if text_data.word_wrap && wrap_width > 0 {
-                        let (_, wrapped_h) = measure_text_wrapped(
-                            &text_data.text, &font, wrap_width, true,
-                            text_data.fixed_line_space,
-                            text_data.top_spacing, text_data.bottom_spacing,
-                            text_data.char_spacing,
-                        );
-                        let raw_line_h = font.char_height.saturating_sub(1).max(1) as u16;
-                        (wrapped_h / raw_line_h.max(1)).max(1) as usize
-                    } else {
-                        // Count CRLF / lone CR / lone LF as one break each.
-                        // Without CRLF normalisation Lingo's `& RETURN` (which
-                        // is `\r\n` on Windows-saved movies) double-counts.
-                        text_data.text
-                            .replace("\r\n", "\n")
-                            .chars()
-                            .filter(|c| *c == '\r' || *c == '\n')
-                            .count() + 1
-                    };
+                    // Count visual lines with the SAME word-wrap walk the
+                    // `.image` getter + renderer use (see `count_text_lines`).
+                    // The old `measure_text_wrapped().height / (char_height-1)`
+                    // shortcut under-counted PFR lines ~2.3x, making `.rect`
+                    // disagree with `.image` and triggering Habbo's window
+                    // Text-Wrapper to copyPixels-stretch the terms text.
+                    let line_count = count_text_lines(
+                        &text_data.text, &font, text_data.word_wrap,
+                        wrap_width as i32, text_data.char_spacing,
+                    );
                     let nominal = if text_data.font_size > 0 {
                         text_data.font_size
                     } else if font.font_size > 0 {
@@ -650,11 +715,41 @@ impl TextMemberHandlers {
                 let text_has_breaks = text_data.text.contains('\n')
                     || text_data.text.contains('\r');
                 let is_multi_par_authored = text_data.par_runs.len() > 1;
-                let box_height = if text_data.height > 0
-                    && (text_data.box_type != "adjust"
-                        || text_has_breaks
-                        || is_multi_par_authored)
-                {
+                // Reserve PFR descender/underline overflow so a content-sized box
+                // matches the `.image` getter (the Origins Text-Wrapper bakes with
+                // `src = member.rect`, so a `.rect` shorter than `.image` would drop
+                // the underline of links like `login_b_login_forgotten`).
+                let measured_height = measured_height + player
+                    .bitmap_manager
+                    .get_bitmap(font.bitmap_ref)
+                    .map_or(0, |fb| crate::player::font::pfr_underline_descender_overflow(
+                        &font, fb, text_data.fixed_line_space, text_data.top_spacing,
+                    ));
+                let box_height = if text_data.box_type == "adjust" {
+                    if text_data.rect_set_at_runtime {
+                        // #adjust + runtime-set rect: auto-grow to content but keep
+                        // the set height when content fits. CS navigator toggles
+                        // boxType=#adjust to capture the FULL room list (content >>
+                        // set box); Origins' Text-Wrapper sizes the box to the
+                        // content (set >= content, so this stays text_data.height).
+                        // EXCEPTION: a NON-WRAPPING #adjust member auto-sizes its
+                        // height to the content (Director), even when its canvas rect
+                        // is much taller. The v7 Habbo Purse reuses one big-text
+                        // writer (rect 60x480) to render "9366" (~22px); checkSaldo
+                        // CENTRES member.image, so a 480-tall image shoved the digits
+                        // off the top. The bake-users that rely on the set height
+                        // (CS roomlist / Origins ToS / Spineworld droplist) all WRAP.
+                        if !text_data.word_wrap {
+                            measured_height
+                        } else {
+                            text_data.height.max(measured_height)
+                        }
+                    } else if text_has_breaks || is_multi_par_authored {
+                        text_data.height
+                    } else {
+                        measured_height
+                    }
+                } else if text_data.height > 0 {
                     text_data.height
                 } else if let Some(ref info) = text_data.info {
                     if info.height > 0 { info.height as u16 } else { measured_height }
@@ -688,19 +783,15 @@ impl TextMemberHandlers {
                 let text_has_breaks = text_data.text.contains('\n')
                     || text_data.text.contains('\r');
                 let is_multi_par_authored = text_data.par_runs.len() > 1;
-                if text_data.height > 0
-                    && (text_data.box_type != "adjust"
-                        || text_has_breaks
-                        || is_multi_par_authored)
-                {
-                    Ok(Datum::Int(text_data.height as i32))
-                } else {
+                let measured: u16 = {
+                    // Match the `.image` getter's font load exactly (see `.rect`).
                     let font = if !text_data.font.is_empty() {
                         player
                             .font_manager
-                            .get_font_with_cast(
+                            .get_font_with_cast_and_bitmap(
                                 &text_data.font,
-                                Some(&player.movie.cast_manager),
+                                &player.movie.cast_manager,
+                                &mut player.bitmap_manager,
                                 Some(text_data.font_size),
                                 None,
                             )
@@ -758,18 +849,16 @@ impl TextMemberHandlers {
                         } else {
                             font.char_height
                         };
-                        // Count lines (respecting word-wrap if enabled).
-                        let line_count = if text_data.word_wrap && wrap_width > 0 {
-                            let (_, wrapped_h) = measure_text_wrapped(
-                                &text_data.text, &font, wrap_width, true,
-                                text_data.fixed_line_space, text_data.top_spacing, text_data.bottom_spacing,
-                                text_data.char_spacing,
-                            );
-                            let raw_line_h = font.char_height.saturating_sub(1).max(1) as u16;
-                            (wrapped_h / raw_line_h.max(1)).max(1) as usize
-                        } else {
-                            text_data.text.chars().filter(|c| *c == '\r' || *c == '\n').count() + 1
-                        };
+                        // Count lines with the SAME word-wrap walk `.image` uses
+                        // (see `count_text_lines`). The old `wrapped_h /
+                        // (char_height-1)` shortcut under-counted PFR lines ~2.3x
+                        // (atlas cell ≫ fixedLineSpace), so `.height` disagreed
+                        // with `.image` and Habbo's Text-Wrapper stretched the
+                        // baked terms text vertically.
+                        let line_count = count_text_lines(
+                            &text_data.text, &font, text_data.word_wrap,
+                            wrap_width as i32, text_data.char_spacing,
+                        );
                         // See `.rect` getter for the rationale —
                         // `min(cell_h, nominal × 1.5)` caps pixel-padded
                         // PFR atlases without regressing tight-cell ones.
@@ -803,8 +892,39 @@ impl TextMemberHandlers {
                             + (line_count as i32 - 1) * line_step)
                             .max(0) as u16
                     };
-                    Ok(Datum::Int(height as i32))
-                }
+                    // Reserve PFR descender/underline overflow so `.height` agrees
+                    // with `.image`/`.rect` (the Origins Text-Wrapper bakes with
+                    // src=member.rect, dropping the underline otherwise —
+                    // login_b_login_forgotten).
+                    let overflow = player
+                        .bitmap_manager
+                        .get_bitmap(font.bitmap_ref)
+                        .map_or(0, |fb| crate::player::font::pfr_underline_descender_overflow(
+                            &font, fb, text_data.fixed_line_space, text_data.top_spacing,
+                        ));
+                    height + overflow
+                };
+                let box_height = if text_data.box_type == "adjust" {
+                    if text_data.rect_set_at_runtime {
+                        // #adjust + runtime-set rect: auto-grow to content but keep
+                        // the set height when content fits (mirrors `.rect`/`.image`).
+                        // Non-wrapping #adjust auto-sizes to content (see `.rect`).
+                        if !text_data.word_wrap {
+                            measured
+                        } else {
+                            text_data.height.max(measured)
+                        }
+                    } else if text_has_breaks || is_multi_par_authored {
+                        text_data.height
+                    } else {
+                        measured
+                    }
+                } else if text_data.height > 0 {
+                    text_data.height
+                } else {
+                    measured
+                };
+                Ok(Datum::Int(box_height as i32))
             }
             "forecolor" | "color" => {
                 // Get foreground color from cast member
@@ -1324,7 +1444,16 @@ impl TextMemberHandlers {
                             .filter(|c| *c == '\r' || *c == '\n')
                             .count() + 1
                     };
-                    let line_h = (nominal as f32 * 1.4).round() as u16;
+                    // Honor the member's explicit line height (set from the font
+                    // struct's #lineHeight → fixedLineSpace) so the produced bitmap
+                    // is one line tall (Volter: lineHeight 10 + topSpacing 1 = 11,
+                    // matching the baked login_b_title bitmap) rather than the
+                    // font_size×1.4 heuristic (→14). The bitmap is drawn 1:1.
+                    let line_h = if text_data.fixed_line_space > 0 {
+                        text_data.fixed_line_space
+                    } else {
+                        (nominal as f32 * 1.4).round() as u16
+                    };
                     // See `.rect` getter for rationale on folding
                     // top_spacing + bottom_spacing into line_step.
                     let line_step = (if text_data.fixed_line_space > 0 {
@@ -1339,16 +1468,67 @@ impl TextMemberHandlers {
                         + (line_count as i32 - 1) * line_step)
                         .max(1) as u16;
                 }
-                // For #adjust box type, always use measured height. For #fixed/#scroll, use stored height.
-                if text_data.box_type != "adjust" {
-                    if text_data.height > 0 {
-                        box_height = box_height.max(text_data.height);
-                    }
-                    if let Some(ref info) = text_data.info {
-                        if info.height > 0 {
-                            box_height = box_height.max(info.height as u16);
+                // CRITICAL: member.image.height MUST equal member.rect.height
+                // (Director invariant) — otherwise Habbo's Text-Wrapper bake
+                // `pimage.copyPixels(member.image, dest=image-height, src=member.rect)`
+                // stretches the text vertically (login text 2px tall, registration
+                // paragraph blown up to one giant line). Use the IDENTICAL box_height
+                // selection as the `.rect`/`.height` getters above.
+                {
+                    // `.image` must always render the FULL content (>= measured) so
+                    // movies that capture it to build scroll buffers / dropdowns get
+                    // every line — Director's text `.image` never clips the rendered
+                    // content. This is unlike the `.rect`/`.height` getters, which
+                    // REPORT a logical size (and trust text_data.height for authored
+                    // multi-line members like Junkbot credits). Capturing movies:
+                    // CS navigator roomlist (copyPixels member.image), Spineworld
+                    // GUI_droplist (makeListImage reads txt_droplist.image).
+                    // Reserve the PFR descender overflow for the auto-sized
+                    // (non-wrapping #adjust) case below: the Writer forces
+                    // fixedLineSpace=fontSize, but the glyph descender (and the
+                    // underline drawn on it — `underline_y = y_pos + pfr_desc_bottom`)
+                    // reaches BELOW that. Shrinking the box to the fixedLineSpace-based
+                    // `measured` then clipped the v7 Navigator "Go" link underline.
+                    // Adds 0 when fixedLineSpace already covers the descender.
+                    let pfr_descender_overflow: u16 = player
+                        .bitmap_manager
+                        .get_bitmap(font.bitmap_ref)
+                        .map_or(0, |fb| crate::player::font::pfr_underline_descender_overflow(
+                            &font, fb, text_data.fixed_line_space, text_data.top_spacing,
+                        ));
+                    // Fold the descender/underline overflow into `measured` so every
+                    // content-sized branch (and the `.rect`/`.height` getters) agree —
+                    // the Origins Text-Wrapper bakes with src=member.rect, so .image
+                    // and .rect must match or the underline ("login_b_login_forgotten",
+                    // Navigator "Go") is dropped.
+                    let measured = box_height + pfr_descender_overflow;
+                    box_height = if text_data.box_type == "adjust" {
+                        if text_data.rect_set_at_runtime {
+                            // CS / Origins runtime-set rect: grow to content, keep the
+                            // set height when it fits (keeps .image == .rect so the
+                            // Origins Text-Wrapper bake stays 1:1, no stretch).
+                            // Non-wrapping #adjust auto-sizes to content (see `.rect`):
+                            // the v7 Habbo Purse big-text writer's 480-tall canvas
+                            // must shrink to the digits so checkSaldo's centred
+                            // copyPixels keeps them on-screen.
+                            if !text_data.word_wrap {
+                                measured
+                            } else {
+                                text_data.height.max(measured)
+                            }
+                        } else {
+                            measured
                         }
-                    }
+                    } else {
+                        // #fixed/#scroll/#limit: still render the full content so list
+                        // members overflowing a fixed box can be captured whole.
+                        let mut h = measured;
+                        if text_data.height > 0 { h = h.max(text_data.height); }
+                        if let Some(ref info) = text_data.info {
+                            if info.height > 0 { h = h.max(info.height as u16); }
+                        }
+                        h
+                    };
                 }
 
                 // Create 32-bit bitmap with TRANSPARENT background for .image.
@@ -1579,9 +1759,64 @@ impl TextMemberHandlers {
                     let default_underline = text_data.font_style.iter().any(|s| s == "underline");
                     let is_pfr_font = font.char_widths.is_some();
 
+                    // PFR pixel-font vertical anchoring (Paige semantics). Recover
+                    // the strike's cap-top / descender-bottom from the atlas so the
+                    // first line's cell top anchors at lineTop and the underline lands
+                    // in the descent, matching Shockwave. Shared with the on-stage
+                    // `Bitmap::draw_text` path so both render identically.
+                    let (pfr_cap_top, pfr_desc_bottom) =
+                        crate::player::font::pfr_strike_vertical_metrics(&font, font_bitmap);
+
                     let max_width = box_width as i32;
-                    let mut y = text_data.top_spacing as i32;
-                    let line_height = (font.char_height as i32 - 1).max(1);
+                    // Anchor the first line's atlas cell top at box row 0. In Paige
+                    // the line is placed by its baseline = lineTop + ascent, and the
+                    // PFR atlas cell top already corresponds to (baseline - ascent) =
+                    // lineTop, so the cell top maps straight onto box row 0. The
+                    // natural ascent-to-cap gap (cap_top) above the capitals is kept,
+                    // exactly as Shockwave renders it. (Previously this subtracted
+                    // cap_top, pulling the caps onto row 0 and the whole block ~3-4px
+                    // too high.) Non-PFR fonts keep the historical top_spacing.
+                    let mut y = match (pfr_cap_top, pfr_desc_bottom) {
+                        // Director positions baked text using BOTH the authored
+                        // topSpacing (extra space above the line) AND the
+                        // fixedLineSpace leading distributed above the glyph:
+                        //   - The v7 Navigator ROOM ROWS go through Habbo's Writer
+                        //     Class, which FORCES `fixedLineSpace = fontSize` (9) and
+                        //     puts the real line height into `topSpacing`
+                        //     (= fixedLineSpace(18) - fontSize(9) = 9). Their offset
+                        //     therefore lives in topSpacing, not fixedLineSpace.
+                        //   - The TITLE is a non-Writer member that keeps
+                        //     fixedLineSpace=15 over a ~11px glyph, so its offset is
+                        //     fixedLineSpace leading (descender sits at line bottom).
+                        // Volter strikes' taller atlas cell masked both; the scaling
+                        // outline exposed them, baking text ~7px too high (the
+                        // window-element bitmap PLACEMENT is correct). For tight
+                        // lines both terms are ~0, so the registration ToS / headings
+                        // are unchanged. No member has both terms large, so summing
+                        // does not double-count.
+                        //
+                        // The topSpacing term carries a -1: the glyph descender (db)
+                        // already overruns the Writer-forced `fixedLineSpace=fontSize`
+                        // by ~1px, so applying the raw topSpacing dropped the room rows
+                        // 1px below Shockwave. Calibrated against the v7 Navigator room
+                        // list (topSpacing=9 -> 8px effective).
+                        (Some(_), Some(db)) if text_data.fixed_line_space > 0 => {
+                            (text_data.fixed_line_space as i32 - 1 - db).max(0)
+                                + (text_data.top_spacing as i32 - 1).max(0)
+                        }
+                        (Some(_), _) => text_data.top_spacing as i32,
+                        (None, _) => text_data.top_spacing as i32,
+                    };
+                    // Underline row sits just below the line's baseline. Use the
+                    // member's explicit line height (fixedLineSpace) when set so
+                    // the underline lands inside the bitmap (Volter login link
+                    // text is 11px tall); the atlas cell height (char_height-1,
+                    // ~25) would place it far below and clip it.
+                    let line_height = if text_data.fixed_line_space > 0 {
+                        (text_data.fixed_line_space as i32).max(1)
+                    } else {
+                        (font.char_height as i32 - 1).max(1)
+                    };
 
                     // Get char_spacing from styled spans (XMED data)
                     let char_spacing: i32 = text_data.html_styled_spans.first()
@@ -1802,7 +2037,14 @@ impl TextMemberHandlers {
                                 // Per-character underline so per-span underline
                                 // is honoured (CS uses underline on some items
                                 // only). Draw one pixel row under this glyph.
-                                let underline_y = y_pos + line_height - 1;
+                                // Paige draws the underline in the descent. For
+                                // PFR strikes put it on the descender's lowest row
+                                // (scanned), so it sits just under the text instead
+                                // of at the oversized atlas cell bottom.
+                                let underline_y = match pfr_desc_bottom {
+                                    Some(db) => y_pos + db,
+                                    None => y_pos + line_height - 1,
+                                };
                                 let run_end = (x + adv + char_spacing).max(x);
                                 for ux in x..run_end {
                                     bitmap.set_pixel(ux, underline_y, per.color, &palettes);
@@ -2374,9 +2616,15 @@ impl TextMemberHandlers {
                     if w > 0 {
                         text_data.width = w;
                     }
-                    // Setting height via rect is a no-op for #adjust box type
-                    if h > 0 && text_data.box_type != "adjust" {
+                    // An explicit `member.rect = …` resizes the member even for
+                    // #adjust (Habbo's Text-Wrapper relies on this). Record that
+                    // the height is runtime-set so the `.rect`/`.height`/`.image`
+                    // getters report this height consistently — keeping
+                    // member.image.height == member.rect.height so the bake
+                    // copyPixels doesn't stretch the text vertically.
+                    if h > 0 {
                         text_data.height = h;
+                        text_data.rect_set_at_runtime = true;
                     }
 
                     Ok(())
@@ -2387,10 +2635,10 @@ impl TextMemberHandlers {
                 |player| value.int_value(),
                 |cast_member, value| {
                     let text_data = cast_member.member_type.as_text_mut().unwrap();
-                    // Setting height is a no-op for #adjust box type
-                    if text_data.box_type != "adjust" {
-                        text_data.height = value? as u16;
-                    }
+                    // Explicit `member.height = …` resizes even #adjust members
+                    // (see the `rect` setter for the bake-stretch rationale).
+                    text_data.height = value? as u16;
+                    text_data.rect_set_at_runtime = true;
                     Ok(())
                 },
             ),

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use log::{warn, debug};
+use log::debug;
 
 use super::cast_member::{
     bitmap::BitmapMemberHandlers, button::ButtonMemberHandlers, field::FieldMemberHandlers,
@@ -956,11 +956,15 @@ impl CastMemberRefHandlers {
             match cast_member {
                 Some(cast_member) => Ok(Some(cast_member.member_type.member_type_id())),
                 None => {
-                    // Silently ignore setting props on erased members
-                    web_sys::console::warn_1(&format!(
+                    // Silently ignore setting props on erased members (Director
+                    // does the same). debug!, not console::warn_1 — the latter
+                    // always prints to the browser console and floods it (with
+                    // retained entries) for movies that poke a null member each
+                    // frame.
+                    debug!(
                         "Ignoring set prop {} on erased member {} of castLib {}",
                         prop, member_ref.cast_member, member_ref.cast_lib
-                    ).into());
+                    );
                     Ok(None)
                 }
             }
@@ -1158,7 +1162,11 @@ impl CastMemberRefHandlers {
                 (name, comments, slot_number, member_type, color, bg_color, member_num)
             }
             None => {
-                warn!(
+                // Ref (0,0) is Director's "no member" sentinel (an empty sprite
+                // channel); querying its props is normal and handled by
+                // get_invalid_member_prop. Keep at debug so a per-frame poll
+                // doesn't flood the browser console (which retains every entry).
+                debug!(
                     "Getting prop {} of non-existent castMember reference {}, {}",
                     prop, cast_member_ref.cast_lib, cast_member_ref.cast_member
                 );
@@ -1271,13 +1279,14 @@ impl CastMemberRefHandlers {
                 _ => Self::set_member_type_prop(cast_member_ref, prop, value),
             }
         } else {
-            // Silently ignore setting props on non-existent members
-            // This can happen when a script erases a member but still holds a reference
-            // Director silently ignores this case
-            web_sys::console::warn_1(&format!(
+            // Silently ignore setting props on non-existent members.
+            // This can happen when a script erases a member but still holds a
+            // reference; Director silently ignores this case. debug!, not
+            // console::warn_1 — the latter always floods the browser console.
+            debug!(
                 "Ignoring set prop {} on erased member {} of castLib {}",
                 prop, cast_member_ref.cast_member, cast_member_ref.cast_lib
-            ).into());
+            );
             Ok(())
         };
         if result.is_ok() {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -527,6 +527,24 @@ impl CastMemberRefHandlers {
             };
             new_member.number = dest_ref.cast_member as u32;
 
+            // Deep-copy the backing bitmap so the duplicate is independent.
+            // `BitmapMember.image_ref` is only a SLOT ID into bitmap_manager, so
+            // a plain member clone leaves the duplicate ALIASING the source's
+            // pixels. Director's `member.duplicate()` clones the image — without
+            // this, `member("3dBallTemplate").duplicate(N)` made every generated
+            // ball share one bitmap, and create3DBallOne's copyPixels writes all
+            // landed in that single slot (last color wins → every ball rendered
+            // yellow, the last colour generated).
+            if let CastMemberType::Bitmap(bm) = &new_member.member_type {
+                let cloned = player.bitmap_manager.get_bitmap(bm.image_ref).cloned();
+                if let Some(cloned) = cloned {
+                    let new_ref = player.bitmap_manager.add_bitmap(cloned);
+                    if let CastMemberType::Bitmap(bm) = &mut new_member.member_type {
+                        bm.image_ref = new_ref;
+                    }
+                }
+            }
+
             let dest_cast = player
                 .movie
                 .cast_manager

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -910,6 +910,14 @@ impl CastMemberRefHandlers {
                                 .map(|n| n as i32)
                                 .unwrap_or(0),
                         )),
+                        // `member.size` — "size in memory, in bytes, of a cast
+                        // member. Read-only" (Director 11.5 Scripting Dictionary).
+                        // For a Flash member this is its SWF byte count. Neopets'
+                        // DGS `showPreLoader` gates on `member(x).size < 1000` to
+                        // detect a missing/empty preloader after linking it via
+                        // `x.fileName = <url>`, so this must reflect the bytes the
+                        // fileName setter loaded from the preload cache.
+                        "size" => Ok(Datum::Int(flash.data.len() as i32)),
                         _ => Ok(Datum::Void),
                     }
                 } else {
@@ -1076,8 +1084,43 @@ impl CastMemberRefHandlers {
                 VectorShapeMemberHandlers::set_prop(player, member_ref, prop, value)
             }),
             CastMemberTypeId::Flash => {
-                // Flash members accept various properties silently
-                // (directToStage, quality, scaleMode, etc.)
+                // `member.fileName = <path/url>` — "refers to the name of the file
+                // assigned to a linked cast member. Read/write ... also accepts
+                // URLs ... to minimize download time, use preloadNetThing() ...
+                // then set the fileName property" (Director 11.5 Scripting
+                // Dictionary). Neopets' DGS `showPreLoader` does exactly that:
+                // `preloadNetThing(url)` then `x.fileName = url`, then checks
+                // `member(x).size`. So resolve the URL against the completed net
+                // task the loader already primed and copy its SWF bytes into the
+                // member; `effective_rect()` re-parses dimensions from the SWF
+                // header (flash_info left None). If the URL wasn't preloaded we
+                // leave the member empty (size stays 0) rather than block on a
+                // synchronous fetch — matching Director's "used next time" note.
+                if prop.eq_ignore_ascii_case("filename") || prop.eq_ignore_ascii_case("pathname") {
+                    let url = value.string_value()?;
+                    return reserve_player_mut(|player| {
+                        let bytes = player
+                            .net_manager
+                            .find_task_by_url(&url)
+                            .and_then(|id| player.net_manager.get_task_result(Some(id)))
+                            .and_then(|r| r.ok());
+                        if let Some(bytes) = bytes {
+                            if !bytes.is_empty() {
+                                if let Some(cm) =
+                                    player.movie.cast_manager.find_member_by_ref_mut(member_ref)
+                                {
+                                    if let CastMemberType::Flash(flash) = &mut cm.member_type {
+                                        flash.data = bytes;
+                                        flash.flash_info = None;
+                                    }
+                                }
+                            }
+                        }
+                        Ok(())
+                    });
+                }
+                // Other Flash props (directToStage, quality, scaleMode, etc.)
+                // are accepted silently.
                 Ok(())
             }
             CastMemberTypeId::Shockwave3d => reserve_player_mut(|player| {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -582,7 +582,14 @@ impl CastMemberRefHandlers {
                     member_ref.cast_member.min(-1)
                 },
             )),
-            "type" => Ok(Datum::String("empty".to_string())),
+            // A valid member's `.type` returns a Symbol (see get_prop's "type"
+            // arm), so the invalid/empty member must too — Director's `#empty`.
+            // Returning a String made `member("x").type = #empty` FALSE (String
+            // vs Symbol), so the common lazy-create idiom
+            //   `if member(name).type = #empty then member = new(#bitmap) ...`
+            // took the else branch and used the invalid (-1,-1) ref instead of
+            // creating the member (g349 cave-door `drawframes`).
+            "type" => Ok(Datum::Symbol("empty".to_string())),
             "castLibNum" => Ok(Datum::Int(-1)),
             "memberNum" => Ok(Datum::Int(-1)),
             "text" | "comments" => Ok(Datum::String("".to_string())),
@@ -924,6 +931,35 @@ impl CastMemberRefHandlers {
                     Ok(Datum::Void)
                 }
             }
+            CastMemberTypeId::Movie => {
+                // Linked Movie member props (Director 11.5 Scripting Dictionary).
+                let cast_member = player.movie.cast_manager.find_member_by_ref(cast_member_ref)
+                    .ok_or_else(|| ScriptError::new("Cast member not found".to_string()))?;
+                if let CastMemberType::Movie(mv) = &cast_member.member_type {
+                    match prop {
+                        "fileName" | "pathName" => Ok(Datum::String(mv.file_name.clone())),
+                        "scriptsEnabled" => Ok(Datum::Int(mv.scripts_enabled as i32)),
+                        "crop" => Ok(Datum::Int(mv.crop as i32)),
+                        "center" => Ok(Datum::Int(mv.center as i32)),
+                        "sound" => Ok(Datum::Int(mv.sound as i32)),
+                        "loop" => Ok(Datum::Int(mv.loops as i32)),
+                        "width" => Ok(Datum::Int(mv.width as i32)),
+                        "height" => Ok(Datum::Int(mv.height as i32)),
+                        "rect" => Ok(Datum::Rect(
+                            [0.0, 0.0, mv.width as f64, mv.height as f64],
+                            0,
+                        )),
+                        "linked" => Ok(Datum::Int(1)),
+                        "regPoint" => Ok(Datum::Point(
+                            [mv.reg_point.0 as f64, mv.reg_point.1 as f64],
+                            0,
+                        )),
+                        _ => Ok(Datum::Void),
+                    }
+                } else {
+                    Ok(Datum::Void)
+                }
+            }
             _ => {
                 // SWA/streaming media properties — return sensible defaults
                 match prop {
@@ -1122,6 +1158,65 @@ impl CastMemberRefHandlers {
                 // Other Flash props (directToStage, quality, scaleMode, etc.)
                 // are accepted silently.
                 Ok(())
+            }
+            CastMemberTypeId::Movie => {
+                // Linked Movie member props (Director 11.5 Scripting Dictionary).
+                if prop.eq_ignore_ascii_case("filename") || prop.eq_ignore_ascii_case("pathname") {
+                    // `member.fileName = <url>` links the external .dir/.dcr.
+                    // Like the Flash member, grab the bytes from the net task the
+                    // caller already preloadNetThing'd (Director's preload-then-set
+                    // pattern) and stash them on the member; the live nested Movie
+                    // is parsed/built from them at activation. Left unlinked (bytes
+                    // None) if the URL wasn't preloaded.
+                    let url = value.string_value()?;
+                    return reserve_player_mut(|player| {
+                        let captured: Option<(std::rc::Rc<Vec<u8>>, String)> =
+                            player.net_manager.find_task_by_url(&url).and_then(|id| {
+                                let bytes = player
+                                    .net_manager
+                                    .get_task_result(Some(id))
+                                    .and_then(|r| r.ok())?;
+                                if bytes.is_empty() {
+                                    return None;
+                                }
+                                let base_url = player
+                                    .net_manager
+                                    .get_task(id)
+                                    .map(|task| crate::utils::get_base_url(&task.resolved_url).to_string())
+                                    .unwrap_or_default();
+                                Some((std::rc::Rc::new(bytes), base_url))
+                            });
+                        if let Some(cm) = player.movie.cast_manager.find_member_by_ref_mut(member_ref) {
+                            if let CastMemberType::Movie(mv) = &mut cm.member_type {
+                                mv.file_name = url.clone();
+                                if let Some((bytes, base_url)) = captured {
+                                    mv.bytes = Some(bytes);
+                                    mv.base_url = base_url;
+                                }
+                            }
+                        }
+                        Ok(())
+                    });
+                }
+                return reserve_player_mut(|player| {
+                    if let Some(cm) = player.movie.cast_manager.find_member_by_ref_mut(member_ref) {
+                        if let CastMemberType::Movie(mv) = &mut cm.member_type {
+                            let truthy = value.to_bool().unwrap_or(false);
+                            match prop.to_lowercase().as_str() {
+                                "scriptsenabled" => mv.scripts_enabled = truthy,
+                                "crop" => mv.crop = truthy,
+                                "center" => mv.center = truthy,
+                                "regpoint" => {
+                                    if let Datum::Point(pt, _) = &value {
+                                        mv.reg_point = (pt[0] as i16, pt[1] as i16);
+                                    }
+                                }
+                                _ => {} // other linked-movie props accepted silently
+                            }
+                        }
+                    }
+                    Ok(())
+                });
             }
             CastMemberTypeId::Shockwave3d => reserve_player_mut(|player| {
                 Shockwave3dMemberHandlers::set_prop(player, member_ref, prop, &value)

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -1343,10 +1343,16 @@ impl CastMemberRefHandlers {
     ) -> Result<(), ScriptError> {
         let is_invalid = cast_member_ref.cast_lib < 0 || cast_member_ref.cast_member < 0;
         if is_invalid {
-            return Err(ScriptError::new(format!(
-                "Setting prop {} of invalid castMember reference (member {} of castLib {})",
+            // Silently ignore setting props on an invalid (negative) reference,
+            // e.g. a VOID/unset member ref a script still writes through.
+            // Returning early also keeps the negative indices away from the
+            // `as u32` casts below. debug!, not console::warn_1 — the latter
+            // always floods the browser console.
+            debug!(
+                "Ignoring set prop {} on invalid castMember reference (member {} of castLib {})",
                 prop, cast_member_ref.cast_member, cast_member_ref.cast_lib
-            )));
+            );
+            return Ok(());
         }
         let exists = reserve_player_ref(|player| {
             player

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -897,6 +897,19 @@ impl CastMemberRefHandlers {
                             let rp = flash.reg_point;
                             Ok(Datum::Point([rp.0 as f64, rp.1 as f64], 0))
                         }
+                        // Flash cast-member frameCount (spec :60880, read-only):
+                        // the SWF root timeline's total frame count. Parse it
+                        // from the SWF header bytes — authoritative and correct
+                        // even while the Ruffle instance is still (re)loading
+                        // (asking Ruffle returns 0 during that window, which
+                        // makes bogey_nights' #hiding `sprite.frame =
+                        // member.frameCount` pin the SWF root at frame 0 and
+                        // stall the grab state machine into a stuck #retreat).
+                        "frameCount" => Ok(Datum::Int(
+                            crate::player::cast_member::CastMember::parse_swf_frame_count(&flash.data)
+                                .map(|n| n as i32)
+                                .unwrap_or(0),
+                        )),
                         _ => Ok(Datum::Void),
                     }
                 } else {

--- a/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
@@ -52,6 +52,19 @@ extern "C" {
 /// Most movies have at most one sprite per Flash member; storyscramble's
 /// 3-tile case shares a member but those tiles don't use FlashObjectRef
 /// (they only set frame), so this lookup is fine for the existing surface.
+/// Resolve the Director sprite that backs a Flash object handle. A handle
+/// taken from `getVariable(sprite(N), path, 0)` carries its origin sprite (see
+/// FlashObjectRef::instance_id) and dispatches straight to it; older handles
+/// only know their cast member and fall back to scanning the score. Preferring
+/// the bound sprite keeps `gDemoFlash.play()` working even when the member
+/// wasn't resolvable at the time the handle was captured.
+pub fn resolve_flash_sprite(flash_ref: &FlashObjectRef) -> Option<i32> {
+    if let Some(sn) = flash_ref.bound_sprite() {
+        return Some(sn);
+    }
+    find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member)
+}
+
 pub fn find_sprite_for_flash_member(cast_lib: i32, cast_member: i32) -> Option<i32> {
     crate::player::reserve_player_ref(|player| {
         for channel in &player.movie.score.channels {
@@ -79,7 +92,7 @@ impl FlashObjectDatumHandlers {
 
             if let Datum::FlashObjectRef(flash_ref) = obj_datum {
                 let full_path = format!("{}.{}", flash_ref.path, prop_name);
-                let sprite_num = match find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member) {
+                let sprite_num = match resolve_flash_sprite(flash_ref) {
                     Some(n) => n,
                     None => return Ok(player.alloc_datum(Datum::Void)),
                 };
@@ -99,7 +112,10 @@ impl FlashObjectDatumHandlers {
                         } else if let Some(b) = result.as_bool() {
                             Ok(player.alloc_datum(Datum::Int(if b { 1 } else { 0 })))
                         } else {
-                            let new_flash_ref = FlashObjectRef::from_path_with_member(&full_path, flash_ref.cast_lib, flash_ref.cast_member);
+                            // Carry the sprite binding onto the derived handle so
+                            // chained access (gDemoFlash.foo.bar) stays bound to
+                            // the same sprite.
+                            let new_flash_ref = FlashObjectRef::from_path_with_sprite(&full_path, flash_ref.cast_lib, flash_ref.cast_member, flash_ref.instance_id as i32);
                             Ok(player.alloc_datum(Datum::FlashObjectRef(new_flash_ref)))
                         }
                     }
@@ -139,7 +155,7 @@ impl FlashObjectDatumHandlers {
             }
             let args_str = format!("[{}]", js_args_parts.join(","));
 
-            let sprite_num = match find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member) {
+            let sprite_num = match resolve_flash_sprite(&flash_ref) {
                 Some(n) => n,
                 None => return Ok(player.alloc_datum(Datum::Void)),
             };
@@ -187,7 +203,7 @@ impl FlashObjectDatumHandlers {
                 _ => "null".to_string(),
             };
 
-            let sprite_num = match find_sprite_for_flash_member(flash_ref.cast_lib, flash_ref.cast_member) {
+            let sprite_num = match resolve_flash_sprite(&flash_ref) {
                 Some(n) => n,
                 None => return Err(ScriptError::new(format!("No sprite for Flash member {}:{}", flash_ref.cast_lib, flash_ref.cast_member))),
             };

--- a/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
@@ -145,6 +145,35 @@ impl FlashObjectDatumHandlers {
                 }
             };
 
+            // dirplayer LocalConnection: intercept connect()/close() on a
+            // Director-created LocalConnection. The synthetic
+            // `__dpObj_LocalConnection_*` ref has no real AS object, so a Ruffle
+            // call would just return null. Instead register the connection name
+            // → this LC's path, so the Ruffle fork's forwarded AS
+            // `LocalConnection.send(name, method, ...)` (local_connection_send)
+            // can route to the setCallback handler bound to this LC.
+            if flash_ref.path.contains("__dpObj_LocalConnection") {
+                if handler_name == "connect" {
+                    let name = args
+                        .get(0)
+                        .map(|a| player.get_datum(a).string_value().unwrap_or_default())
+                        .unwrap_or_default();
+                    if !name.is_empty() {
+                        player
+                            .flash_lc_connections
+                            .insert(name, flash_ref.path.clone());
+                    }
+                    // AS LocalConnection.connect() returns true on success.
+                    return Ok(player.alloc_datum(Datum::Int(1)));
+                }
+                if handler_name == "close" {
+                    player
+                        .flash_lc_connections
+                        .retain(|_, v| v != &flash_ref.path);
+                    return Ok(player.alloc_datum(Datum::Void));
+                }
+            }
+
             let method_path = format!("{}.{}", flash_ref.path, handler_name);
 
             // Convert Lingo arguments to a JSON array string for the bridge

--- a/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/flash_object.rs
@@ -42,6 +42,11 @@ extern "C" {
         event_type: &str,
         local_x: i32,
         local_y: i32,
+        // Sprite display size, so JS can rebase sprite-local coords into the SWF's
+        // internal (native) coordinate space — the sprite often shows the SWF scaled
+        // (e.g. a 626x468 SWF displayed in a 600x320 sprite).
+        sprite_w: i32,
+        sprite_h: i32,
     ) -> Result<JsValue, JsValue>;
 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
@@ -275,10 +275,12 @@ impl HavokObjectDatumHandlers {
                         rb.inverse_inertia_tensor = crate::player::handlers::datum_handlers::cast_member::havok_physics::mat3_inverse(rb.inertia_tensor);
                     }
                 }
-                "linearVelocity" | "linearvelocity" => { if let Datum::Vector(v) = &value { rb.linear_velocity = *v; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "angularVelocity" | "angularvelocity" => { if let Datum::Vector(v) = &value { rb.angular_velocity = *v; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "linearMomentum" | "linearmomentum" => { if let Datum::Vector(v) = &value { rb.linear_momentum = *v; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "angularMomentum" | "angularmomentum" => { if let Datum::Vector(v) = &value { rb.angular_momentum = *v; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                // Setting a velocity/momentum is a disturbance: wake the body so it
+                // isn't skipped in step (otherwise the new velocity is ignored).
+                "linearVelocity" | "linearvelocity" => { if let Datum::Vector(v) = &value { rb.linear_velocity = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "angularVelocity" | "angularvelocity" => { if let Datum::Vector(v) = &value { rb.angular_velocity = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "linearMomentum" | "linearmomentum" => { if let Datum::Vector(v) = &value { rb.linear_momentum = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "angularMomentum" | "angularmomentum" => { if let Datum::Vector(v) = &value { rb.angular_momentum = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
                 _ => return Err(ScriptError::new(format!("Cannot set rigidBody property: {}", prop))),
             }
         }
@@ -428,6 +430,10 @@ impl HavokObjectDatumHandlers {
                 if let Some(rb) = havok.state.rigid_bodies.iter_mut()
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
+                    // Wake a sleeping body — a Lingo torque is a disturbance, and
+                    // an inactive body is skipped in step (the torque would be
+                    // silently ignored). Matches applyForce/applyImpulse above.
+                    rb.active = true;
                     rb.torque[0] += torque[0];
                     rb.torque[1] += torque[1];
                     rb.torque[2] += torque[2];
@@ -446,6 +452,8 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_add, mat3_transform};
+                    // Wake a sleeping body (consistent with applyImpulse).
+                    rb.active = true;
                     // angVel += I_inv * angularImpulse (from C# RigidBody.ApplyAngularImpulse)
                     rb.angular_velocity = v3_add(rb.angular_velocity, mat3_transform(rb.inverse_inertia_tensor, impulse));
                 }

--- a/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
@@ -137,7 +137,19 @@ impl HavokObjectDatumHandlers {
             "linearVelocity" | "linearvelocity" => Datum::Vector(rb.linear_velocity),
             "angularVelocity" | "angularvelocity" => Datum::Vector(rb.angular_velocity),
             "linearMomentum" | "linearmomentum" => Datum::Vector(rb.linear_momentum),
-            "angularMomentum" | "angularmomentum" => Datum::Vector(rb.angular_momentum),
+            "angularMomentum" | "angularmomentum" => {
+                use crate::player::handlers::datum_handlers::cast_member::havok_physics::{quat_to_mat3, mat3_mul, mat3_transpose, mat3_transform, v3_scale};
+                // L = I_world * omega (the engine derives angular momentum from the body's
+                // angular velocity, not a stored field). I_world = R * I_body * R^T.
+                // Expressed in Havok METER-scale units (× worldScale²): Lingo reads and
+                // CLAMPS angular momentum in meter-scale, so a bare I·ω in display units is
+                // ~1/worldScale² too large — that inflated value trips the car's spin clamp
+                // (angularMomentum.length > 4) at a near-zero yaw, killing the steering.
+                let rmat = quat_to_mat3(rb.orientation);
+                let i_world = mat3_mul(mat3_mul(rmat, rb.inertia_tensor), mat3_transpose(rmat));
+                let ws = havok.state.scale;
+                Datum::Vector(v3_scale(mat3_transform(i_world, rb.angular_velocity), ws * ws))
+            }
             "force" => Datum::Vector(rb.force),
             "torque" => Datum::Vector(rb.torque),
             "corrector" => {
@@ -232,6 +244,9 @@ impl HavokObjectDatumHandlers {
 
         // Update the HavokRigidBody fields
         {
+            // Captured before the &mut borrow below so the angularMomentum setter can convert
+            // the meter-scale L back to display-unit angular velocity (÷ worldScale²).
+            let world_scale = havok.state.scale;
             let rb = havok.state.rigid_bodies.iter_mut()
                 .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 .ok_or_else(|| ScriptError::new(format!("Rigid body '{}' not found", rb_name)))?;
@@ -280,7 +295,19 @@ impl HavokObjectDatumHandlers {
                 "linearVelocity" | "linearvelocity" => { if let Datum::Vector(v) = &value { rb.linear_velocity = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
                 "angularVelocity" | "angularvelocity" => { if let Datum::Vector(v) = &value { rb.angular_velocity = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
                 "linearMomentum" | "linearmomentum" => { if let Datum::Vector(v) = &value { rb.linear_momentum = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "angularMomentum" | "angularmomentum" => { if let Datum::Vector(v) = &value { rb.angular_momentum = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "angularMomentum" | "angularmomentum" => { if let Datum::Vector(v) = &value {
+                    use crate::player::handlers::datum_handlers::cast_member::havok_physics::{quat_to_mat3, mat3_mul, mat3_transpose, mat3_transform, v3_scale};
+                    // omega = I_world^-1 * L (the engine's setAngularMomentum drives the body's
+                    // angular velocity from the given momentum). L arrives in meter-scale units,
+                    // so divide by worldScale² (the inverse of the getter's × worldScale²) to get
+                    // display-unit angular velocity. Without this, the car's spin clamp
+                    // (angularMomentum = normalized*4) set a near-zero yaw and killed the steering.
+                    let rmat = quat_to_mat3(rb.orientation);
+                    let i_world_inv = mat3_mul(mat3_mul(rmat, rb.inverse_inertia_tensor), mat3_transpose(rmat));
+                    let inv_scale_sq = if world_scale.abs() > 1e-10 { (1.0 / world_scale) * (1.0 / world_scale) } else { 1.0 };
+                    rb.angular_velocity = v3_scale(mat3_transform(i_world_inv, *v), inv_scale_sq);
+                    rb.angular_momentum = *v; rb.active = true; rb.lingo_disturbed = true;
+                } else { return Err(ScriptError::new("Expected vector".to_string())); } }
                 _ => return Err(ScriptError::new(format!("Cannot set rigidBody property: {}", prop))),
             }
         }
@@ -440,6 +467,14 @@ impl HavokObjectDatumHandlers {
                     CastMemberType::HavokPhysics(h) => h,
                     _ => return Err(ScriptError::new("Not a Havok member".to_string())),
                 };
+                // A bare Lingo torque needs the (1/worldScale)² factor, exactly like
+                // applyAngularImpulse below: the chassis inertia is in DISPLAY units, and a
+                // force-based torque (applyForceAtPoint) carries the r×F that already supplies
+                // the worldScale² which cancels — a bare torque does not, so it must be scaled
+                // here to match real Havok (measured: Director's applyTorque response is
+                // ~1/worldScale² stronger than the unscaled value).
+                let world_scale = havok.state.scale;
+                let inv_scale_sq = if world_scale.abs() > 1e-10 { (1.0 / world_scale) * (1.0 / world_scale) } else { 1.0 };
                 if let Some(rb) = havok.state.rigid_bodies.iter_mut()
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
@@ -450,9 +485,9 @@ impl HavokObjectDatumHandlers {
                     // Record force-driven (see applyForce) so a later kinematic
                     // interpolatingMoveTo can't reclassify this body as passive.
                     rb.received_force = true;
-                    rb.torque[0] += torque[0];
-                    rb.torque[1] += torque[1];
-                    rb.torque[2] += torque[2];
+                    rb.torque[0] += torque[0] * inv_scale_sq;
+                    rb.torque[1] += torque[1] * inv_scale_sq;
+                    rb.torque[2] += torque[2] * inv_scale_sq;
                 }
                 Ok(DatumRef::Void)
             }

--- a/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
@@ -249,7 +249,7 @@ impl HavokObjectDatumHandlers {
                 "mass" => {
                     let new_mass = value.to_float()?;
                     rb.mass = new_mass;
-                    // PPC setMass (0x4c930): I = unit_inertia * mass; then invert.
+                    // On a mass change, rescale inertia: I = unit_inertia * mass; then invert.
                     // unit_inertia_tensor was populated from the mesh at body creation time.
                     crate::player::handlers::datum_handlers::cast_member::havok_physics::recompute_body_inertia(
                         new_mass,
@@ -328,6 +328,10 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     rb.active = true; rb.lingo_disturbed = true;
+                    // Record that this body is force-driven so a later kinematic
+                    // interpolatingMoveTo won't reclassify a hover vehicle as a
+                    // passive stacking block. See HavokRigidBody::received_force.
+                    rb.received_force = true;
                     rb.force[0] += force[0];
                     rb.force[1] += force[1];
                     rb.force[2] += force[2];
@@ -349,6 +353,10 @@ impl HavokObjectDatumHandlers {
                 {
                     use super::cast_member::havok_physics::{v3_sub, quat_rotate_v, v3_cross};
                     rb.active = true; rb.lingo_disturbed = true;
+                    // Hover force — record force-driven so a later kinematic
+                    // interpolatingMoveTo can't reclassify this vehicle as a
+                    // passive stacking block. See HavokRigidBody::received_force.
+                    rb.received_force = true;
                     // Add linear force (world-space)
                     rb.force[0] += force[0];
                     rb.force[1] += force[1];
@@ -401,7 +409,7 @@ impl HavokObjectDatumHandlers {
                 if let Some(rb) = havok.state.rigid_bodies.iter_mut()
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
-                    use super::cast_member::havok_physics::{v3_sub, v3_add, v3_scale, v3_cross, quat_rotate_v, mat3_transform};
+                    use super::cast_member::havok_physics::{v3_sub, v3_add, v3_scale, v3_cross, quat_rotate_v, mat3_transform, mat3_mul, mat3_transpose, quat_to_mat3};
                     rb.active = true; rb.lingo_disturbed = true;
                     if rb.inverse_mass > 0.0 {
                         // Linear: v += impulse * inverseMass
@@ -411,9 +419,14 @@ impl HavokObjectDatumHandlers {
                         let rel = v3_sub(point, rb.center_of_mass);
                         let r = quat_rotate_v(rb.orientation, rel);
 
-                        // Angular: omega += I_inv * cross(lever, impulse)
+                        // Angular: omega += I_world^-1 * cross(lever, impulse). The lever and
+                        // impulse are world-frame, so the body-frame inverse inertia must be
+                        // rotated into the current orientation (R·Iinv·R^T) — matching
+                        // integrate_body / applyAngularImpulse / the engine's impulse resolver.
                         let torque_impulse = v3_cross(r, impulse);
-                        let ang = mat3_transform(rb.inverse_inertia_tensor, torque_impulse);
+                        let rmat = quat_to_mat3(rb.orientation);
+                        let i_world_inv = mat3_mul(mat3_mul(rmat, rb.inverse_inertia_tensor), mat3_transpose(rmat));
+                        let ang = mat3_transform(i_world_inv, torque_impulse);
                         rb.angular_velocity = v3_add(rb.angular_velocity, ang);
                     }
                 }
@@ -434,6 +447,9 @@ impl HavokObjectDatumHandlers {
                     // an inactive body is skipped in step (the torque would be
                     // silently ignored). Matches applyForce/applyImpulse above.
                     rb.active = true; rb.lingo_disturbed = true;
+                    // Record force-driven (see applyForce) so a later kinematic
+                    // interpolatingMoveTo can't reclassify this body as passive.
+                    rb.received_force = true;
                     rb.torque[0] += torque[0];
                     rb.torque[1] += torque[1];
                     rb.torque[2] += torque[2];
@@ -448,14 +464,27 @@ impl HavokObjectDatumHandlers {
                     CastMemberType::HavokPhysics(h) => h,
                     _ => return Err(ScriptError::new("Not a Havok member".to_string())),
                 };
+                // The chassis inertia is stored in DISPLAY (scene) units, but Havok
+                // applies a Lingo angular impulse to the METER-scale inertia. A force-
+                // based torque (applyForceAtPoint) carries r×F which already supplies
+                // the worldScale² that cancels — a bare angular impulse does not, so it
+                // must be scaled by (1/worldScale)² here to match real Havok's response.
+                let world_scale = havok.state.scale;
+                let inv_scale_sq = if world_scale.abs() > 1e-10 { (1.0 / world_scale) * (1.0 / world_scale) } else { 1.0 };
                 if let Some(rb) = havok.state.rigid_bodies.iter_mut()
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
-                    use super::cast_member::havok_physics::{v3_add, mat3_transform};
+                    use super::cast_member::havok_physics::{v3_add, v3_scale, mat3_transform, mat3_mul, mat3_transpose, quat_to_mat3};
                     // Wake a sleeping body (consistent with applyImpulse).
                     rb.active = true; rb.lingo_disturbed = true;
-                    // angVel += I_inv * angularImpulse (from C# RigidBody.ApplyAngularImpulse)
-                    rb.angular_velocity = v3_add(rb.angular_velocity, mat3_transform(rb.inverse_inertia_tensor, impulse));
+                    // angVel += I_world^-1 * angularImpulse. The impulse is world-frame
+                    // (e.g. the raycast car steers about world-up), so the body-frame
+                    // inverse inertia must be rotated into the current orientation,
+                    // matching integrate_body's angular update.
+                    let r = quat_to_mat3(rb.orientation);
+                    let i_world_inv = mat3_mul(mat3_mul(r, rb.inverse_inertia_tensor), mat3_transpose(r));
+                    let dw = v3_scale(mat3_transform(i_world_inv, impulse), inv_scale_sq);
+                    rb.angular_velocity = v3_add(rb.angular_velocity, dw);
                 }
                 Ok(DatumRef::Void)
             }
@@ -499,10 +528,77 @@ impl HavokObjectDatumHandlers {
                     CastMemberType::HavokPhysics(h) => h,
                     _ => return Err(ScriptError::new("Not a Havok member".to_string())),
                 };
-                if let Some(rb) = havok.state.rigid_bodies.iter_mut()
-                    .find(|r| r.name.eq_ignore_ascii_case(rb_name))
-                {
-                    rb.position = pos;
+                // A body positioned purely kinematically and never force-driven is a
+                // passive stacking object (the add-cubes demo), not a hover vehicle.
+                // A raycast car has already hovered (received_force) before its
+                // recovery interpolatingMoveTo, so it stays a vehicle and just moves
+                // to the exact target.
+                let idx = havok.state.rigid_bodies.iter()
+                    .position(|r| r.name.eq_ignore_ascii_case(rb_name));
+                if let Some(idx) = idx {
+                    let (received_force, half) = {
+                        let rb = &havok.state.rigid_bodies[idx];
+                        (rb.received_force, rb.inertia_half_extents)
+                    };
+                    if received_force {
+                        havok.state.rigid_bodies[idx].position = pos;
+                    } else {
+                        // Stacking spawn: real Havok interpolatingMoveTo moves the body
+                        // toward the target but collisions STOP it, so a new cube lands
+                        // ON TOP of the pile. Teleporting straight to the target z would
+                        // bury it under the stack (it would be "added from the bottom").
+                        // So drop it just above whatever already occupies the target
+                        // column — the existing cubes AND the static floor — and land
+                        // it over the TOP cube's x,y, not the target x,y. Re-centring
+                        // every cube over the target fights the lean and makes the
+                        // tower far too stable; landing on the leaning top (where the
+                        // pile actually blocks it) lets the lean carry up so it topples
+                        // like Director's does.
+                        let mut baseline = pos[2];
+                        let mut top_xy = [pos[0], pos[1]];
+                        for (j, other) in havok.state.rigid_bodies.iter().enumerate() {
+                            if j == idx || other.collisions_disabled || other.pinned { continue; }
+                            let dx = (other.position[0] - pos[0]).abs();
+                            let dy = (other.position[1] - pos[1]).abs();
+                            if dx < half[0] + other.inertia_half_extents[0]
+                                && dy < half[1] + other.inertia_half_extents[1] {
+                                let top = other.position[2] + other.inertia_half_extents[2];
+                                if top > baseline {
+                                    baseline = top;
+                                    top_xy = [other.position[0], other.position[1]];
+                                }
+                            }
+                        }
+                        for mesh in &havok.state.collision_meshes {
+                            // Only FIXED-owned / static meshes form the floor.
+                            if let Some(owner) = mesh.body_index {
+                                if !havok.state.rigid_bodies[owner].pinned { continue; }
+                            }
+                            if pos[0] >= mesh.aabb_min[0] - half[0] && pos[0] <= mesh.aabb_max[0] + half[0]
+                                && pos[1] >= mesh.aabb_min[1] - half[1] && pos[1] <= mesh.aabb_max[1] + half[1] {
+                                baseline = baseline.max(mesh.aabb_max[2]);
+                            }
+                        }
+                        // Nudge the landing a touch further out along the existing
+                        // lean so the tower leans a bit faster and topples around the
+                        // same height Director's does (~11) instead of standing far
+                        // too long. Pure follow-the-top only grows the lean from
+                        // drift, which holds ~16. Tune LEAN_NUDGE to move the topple
+                        // height (bigger = topples sooner).
+                        const LEAN_NUDGE: f64 = 0.05;
+                        let lean = [top_xy[0] - pos[0], top_xy[1] - pos[1]];
+                        let lean_len = (lean[0]*lean[0] + lean[1]*lean[1]).sqrt();
+                        let place_xy = if lean_len > 1e-3 {
+                            let k = LEAN_NUDGE / lean_len;
+                            [top_xy[0] + lean[0]*k, top_xy[1] + lean[1]*k]
+                        } else {
+                            top_xy
+                        };
+                        let rb = &mut havok.state.rigid_bodies[idx];
+                        rb.position = [place_xy[0], place_xy[1], baseline + half[2] + 1.0];
+                        rb.driven = false;
+                        rb.active = true;
+                    }
                 }
                 // Return 1.0 (fully moved)
                 Ok(player.alloc_datum(Datum::Float(1.0)))

--- a/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
@@ -277,10 +277,10 @@ impl HavokObjectDatumHandlers {
                 }
                 // Setting a velocity/momentum is a disturbance: wake the body so it
                 // isn't skipped in step (otherwise the new velocity is ignored).
-                "linearVelocity" | "linearvelocity" => { if let Datum::Vector(v) = &value { rb.linear_velocity = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "angularVelocity" | "angularvelocity" => { if let Datum::Vector(v) = &value { rb.angular_velocity = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "linearMomentum" | "linearmomentum" => { if let Datum::Vector(v) = &value { rb.linear_momentum = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
-                "angularMomentum" | "angularmomentum" => { if let Datum::Vector(v) = &value { rb.angular_momentum = *v; rb.active = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "linearVelocity" | "linearvelocity" => { if let Datum::Vector(v) = &value { rb.linear_velocity = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "angularVelocity" | "angularvelocity" => { if let Datum::Vector(v) = &value { rb.angular_velocity = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "linearMomentum" | "linearmomentum" => { if let Datum::Vector(v) = &value { rb.linear_momentum = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
+                "angularMomentum" | "angularmomentum" => { if let Datum::Vector(v) = &value { rb.angular_momentum = *v; rb.active = true; rb.lingo_disturbed = true; } else { return Err(ScriptError::new("Expected vector".to_string())); } }
                 _ => return Err(ScriptError::new(format!("Cannot set rigidBody property: {}", prop))),
             }
         }
@@ -327,7 +327,7 @@ impl HavokObjectDatumHandlers {
                 if let Some(rb) = havok.state.rigid_bodies.iter_mut()
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
-                    rb.active = true;
+                    rb.active = true; rb.lingo_disturbed = true;
                     rb.force[0] += force[0];
                     rb.force[1] += force[1];
                     rb.force[2] += force[2];
@@ -348,7 +348,7 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_sub, quat_rotate_v, v3_cross};
-                    rb.active = true;
+                    rb.active = true; rb.lingo_disturbed = true;
                     // Add linear force (world-space)
                     rb.force[0] += force[0];
                     rb.force[1] += force[1];
@@ -379,7 +379,7 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_add, v3_scale};
-                    rb.active = true;
+                    rb.active = true; rb.lingo_disturbed = true;
                     if rb.inverse_mass > 0.0 {
                         rb.linear_velocity = v3_add(rb.linear_velocity, v3_scale(impulse, rb.inverse_mass));
                     }
@@ -402,7 +402,7 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_sub, v3_add, v3_scale, v3_cross, quat_rotate_v, mat3_transform};
-                    rb.active = true;
+                    rb.active = true; rb.lingo_disturbed = true;
                     if rb.inverse_mass > 0.0 {
                         // Linear: v += impulse * inverseMass
                         rb.linear_velocity = v3_add(rb.linear_velocity, v3_scale(impulse, rb.inverse_mass));
@@ -433,7 +433,7 @@ impl HavokObjectDatumHandlers {
                     // Wake a sleeping body — a Lingo torque is a disturbance, and
                     // an inactive body is skipped in step (the torque would be
                     // silently ignored). Matches applyForce/applyImpulse above.
-                    rb.active = true;
+                    rb.active = true; rb.lingo_disturbed = true;
                     rb.torque[0] += torque[0];
                     rb.torque[1] += torque[1];
                     rb.torque[2] += torque[2];
@@ -453,7 +453,7 @@ impl HavokObjectDatumHandlers {
                 {
                     use super::cast_member::havok_physics::{v3_add, mat3_transform};
                     // Wake a sleeping body (consistent with applyImpulse).
-                    rb.active = true;
+                    rb.active = true; rb.lingo_disturbed = true;
                     // angVel += I_inv * angularImpulse (from C# RigidBody.ApplyAngularImpulse)
                     rb.angular_velocity = v3_add(rb.angular_velocity, mat3_transform(rb.inverse_inertia_tensor, impulse));
                 }

--- a/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
@@ -507,18 +507,30 @@ impl HavokObjectDatumHandlers {
                     CastMemberType::HavokPhysics(h) => h,
                     _ => return Err(ScriptError::new("Not a Havok member".to_string())),
                 };
-                if let Some(rb) = havok.state.rigid_bodies.iter_mut()
-                    .find(|r| r.name.eq_ignore_ascii_case(rb_name))
-                {
+                use crate::player::handlers::datum_handlers::cast_member::havok_physics as hv;
+                let idx = havok.state.rigid_bodies.iter()
+                    .position(|r| r.name.eq_ignore_ascii_case(rb_name));
+                if let Some(idx) = idx {
+                    let new_orient = match rotation {
+                        Some((axis, angle)) => hv::quat_from_axis_angle_degrees(axis, angle),
+                        None => havok.state.rigid_bodies[idx].orientation,
+                    };
+                    // Engine attemptMoveTo: only commit when the target is clear;
+                    // otherwise leave the body in place and report failure.
+                    if hv::body_blocked_at(&mut havok.state, idx, pos, new_orient) {
+                        return Ok(player.alloc_datum(Datum::Int(0)));
+                    }
+                    let rb = &mut havok.state.rigid_bodies[idx];
                     rb.position = pos;
                     if let Some((axis, angle)) = rotation {
                         rb.rotation_axis = axis;
                         rb.rotation_angle = angle;
-                        rb.orientation = crate::player::handlers::datum_handlers::cast_member::havok_physics::quat_from_axis_angle_degrees(axis, angle);
+                        rb.orientation = new_orient;
                     }
+                    return Ok(player.alloc_datum(Datum::Int(1)));
                 }
-                // Always return TRUE (move succeeded)
-                Ok(player.alloc_datum(Datum::Int(1)))
+                // No such body — move did not happen.
+                Ok(player.alloc_datum(Datum::Int(0)))
             }
             "interpolatingMoveTo" | "interpolatingmoveto" => {
                 let pos = match player.get_datum(&args[0]) { Datum::Vector(v) => *v, _ => return Err(ScriptError::new("Expected vector".to_string())) };

--- a/vm-rust/src/player/handlers/datum_handlers/list_handlers.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/list_handlers.rs
@@ -82,6 +82,12 @@ impl ListDatumHandlers {
     pub fn get_at(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let (list_type, list_vec, _) = player.get_datum(datum).to_list_tuple()?;
+            // A VOID index (e.g. `list[uninitializedGlobal]`) yields VOID in Director
+            // rather than raising — real movies rely on this (leo3d's checkbonbon does
+            // `SetObjectVisible(pbonbon[weg], 0)` with `weg` VOID before any is collected).
+            if matches!(player.get_datum(&args[0]), Datum::Void) {
+                return Ok(DatumRef::Void);
+            }
             let index_value = player.get_datum(&args[0]).int_value()?;
 
             // Handle different indexing schemes based on list type

--- a/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
@@ -986,7 +986,7 @@ impl PropListDatumHandlers {
         }
 
         let key = args[0].clone();
-        let player = unsafe { PLAYER_OPT.as_mut().unwrap() };
+        let player = unsafe { crate::player::player_mut() };
         let base = player.get_datum(datum);
 
         let result = match base {

--- a/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
@@ -405,6 +405,7 @@ impl PropListDatumHandlers {
             "deleteOne" => Self::delete_one(datum, args),
             "getOne" => Self::get_one(datum, args),
             "findPos" => Self::find_pos(datum, args),
+            "findPosNear" => Self::find_pos_near(datum, args),
             "getPos" => Self::get_pos(datum, args),
             "duplicate" => Self::duplicate(datum, args),
             "getLast" => Self::get_last(datum, args),
@@ -538,6 +539,47 @@ impl PropListDatumHandlers {
             } else {
                 return Ok(DatumRef::Void);
             }
+        })
+    }
+
+    /// `sortedPropList.findPosNear(property)` — Director 11.5 Scripting
+    /// Dictionary, `findPosNear`. For a *sorted* property list, returns the
+    /// 1-based position of the entry whose property (key) is the nearest
+    /// match to `property`. Unlike `findPos` (which is VOID when the property
+    /// is absent), `findPosNear` always reports the position of the closest
+    /// key. The doc's "most similar alphanumeric name" maps to the list's
+    /// sort order: we locate the key's sorted insertion point (lower bound)
+    /// and clamp it into `[1, count]` so the result is always a valid
+    /// position. On Run's DriveHuman behavior calls this on `sndGearSpeed`
+    /// (integer speed keys -> gear symbols) to pick the gear sound nearest the
+    /// current speed.
+    pub fn find_pos_near(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            let (prop_list, is_sorted) = player.get_datum(datum).to_map_tuple()?;
+            let count = prop_list.len() as i32;
+            if count == 0 {
+                return Ok(player.alloc_datum(Datum::Int(0)));
+            }
+            let result = if is_sorted {
+                let pos = PropListUtils::find_index_to_add(
+                    prop_list,
+                    (&args[0], &args[0]),
+                    &player.allocator,
+                )?;
+                (pos + 1).clamp(1, count)
+            } else {
+                // Unsorted list: fall back to an exact key match (mirrors the
+                // linear-list `findPosNear` path), returning 0 when absent.
+                let find = player.get_datum(&args[0]);
+                prop_list
+                    .iter()
+                    .position(|(k, _)| {
+                        datum_equals(player.get_datum(k), find, &player.allocator).unwrap()
+                    })
+                    .map(|x| x as i32 + 1)
+                    .unwrap_or(0)
+            };
+            Ok(player.alloc_datum(Datum::Int(result)))
         })
     }
 

--- a/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
@@ -80,7 +80,7 @@ impl PropListUtils {
         Ok(-1)
     }
 
-    fn datum_equals_for_lookup(
+    pub fn datum_equals_for_lookup(
         left: &Datum,
         right: &Datum,
         allocator: &DatumAllocator,
@@ -531,7 +531,14 @@ impl PropListDatumHandlers {
             let position = prop_list
                 .iter()
                 .position(|(k, _)| {
-                    datum_equals(player.get_datum(&k), find, &player.allocator).unwrap()
+                    // Use the lookup-aware equality so a STRING argument matches a
+                    // SYMBOL key (and vice-versa), matching Director: e.g.
+                    // `[#dozer: "none"].findPos("dozer")` -> 6, and the doc's
+                    // `foodList.findPos("breakfast")` -> 1 for key #breakfast.
+                    // Plain datum_equals is type-strict (#dozer != "dozer") and
+                    // returned VOID, breaking gSoundControl.adjustVolume.
+                    PropListUtils::datum_equals_for_lookup(player.get_datum(&k), find, &player.allocator)
+                        .unwrap()
                 })
                 .map(|x| x as i32);
             if let Some(position) = position {
@@ -574,7 +581,10 @@ impl PropListDatumHandlers {
                 prop_list
                     .iter()
                     .position(|(k, _)| {
-                        datum_equals(player.get_datum(k), find, &player.allocator).unwrap()
+                        // Lookup-aware equality so a string arg matches a symbol
+                        // key (parity with find_pos above).
+                        PropListUtils::datum_equals_for_lookup(player.get_datum(k), find, &player.allocator)
+                            .unwrap()
                     })
                     .map(|x| x as i32 + 1)
                     .unwrap_or(0)

--- a/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/prop_list.rs
@@ -1,6 +1,6 @@
 use std::collections::VecDeque;
 
-use log::{warn, debug};
+use log::debug;
 
 use crate::PLAYER_OPT;
 use crate::{
@@ -656,7 +656,7 @@ impl PropListDatumHandlers {
                         );
                         Ok(result)
                     } else {
-                        warn!("get_a_prop: Key not found, returning void");
+                        debug!("get_a_prop: Key not found, returning void");
                         Ok(DatumRef::Void)
                     }
                 }

--- a/vm-rust/src/player/handlers/datum_handlers/script.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/script.rs
@@ -268,6 +268,16 @@ impl ScriptDatumHandlers {
                 };
 
             player_handle_scope_return(&result_scope);
+            // Director's `new()` returns the new child instance. The `on new`
+            // handler conventionally ends with `return me`, but if it falls off
+            // the end without returning a value (VOID), Director still returns the
+            // instance — NOT VOID. Only an explicit non-void return overrides.
+            // (SpongeBob "JellyFishin'" nav object: `on new me, targetMovie`
+            // has no `return me`, so navMovieObj was VOID and gotoExitPage /
+            // gotoMainMovieAgain dispatched on Void.)
+            if matches!(result_scope.return_value, DatumRef::Void) {
+                return Ok(datum_ref);
+            }
             return Ok(result_scope.return_value);
         } else {
             return Ok(datum_ref);

--- a/vm-rust/src/player/handlers/datum_handlers/script.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/script.rs
@@ -107,6 +107,52 @@ impl ScriptDatumHandlers {
             "rawNew" => Self::raw_new(datum),
             "handler" => Self::handler(datum, args),
             "handlers" => Self::handlers(datum, args),
+            // A movie script's static properties are addressable through the
+            // script reference (Neopets DGS uses `script("globals")` as a global
+            // data store: `g.levellist = []`, `g.levellist.add(...)`, etc.).
+            // getPropRef returns the property's shared DatumRef so in-place list
+            // mutation persists, mirroring the ScriptInstance handler.
+            "getProp" | "getPropRef" | "getaProp" => reserve_player_mut(|player| {
+                let script_ref = match player.get_datum(datum) {
+                    Datum::ScriptRef(s) => s.clone(),
+                    _ => return Err(ScriptError::new("Expected script reference".to_string())),
+                };
+                let prop_name = player.get_datum(&args[0]).string_value()?;
+                let prop_ref =
+                    crate::player::script::script_get_static_prop(player, &script_ref, &prop_name)?;
+                if args.len() >= 2 {
+                    // `g.prop[index]` — the bytecode passes (script, #prop, index),
+                    // so index into the property value (e.g. list element). Without
+                    // this the whole property was returned, ignoring the index.
+                    crate::player::handlers::types::TypeUtils::get_sub_prop(
+                        &prop_ref, &args[1], player,
+                    )
+                } else {
+                    Ok(prop_ref)
+                }
+            }),
+            "setProp" | "setaProp" => reserve_player_mut(|player| {
+                let script_ref = match player.get_datum(datum) {
+                    Datum::ScriptRef(s) => s.clone(),
+                    _ => return Err(ScriptError::new("Expected script reference".to_string())),
+                };
+                let prop_name = player.get_datum(&args[0]).string_value()?;
+                if args.len() >= 3 {
+                    // `g.prop[index] = value`
+                    let prop_ref = crate::player::script::script_get_static_prop(
+                        player, &script_ref, &prop_name,
+                    )?;
+                    crate::player::handlers::types::TypeUtils::set_sub_prop(
+                        &prop_ref, &args[1], &args[2], player,
+                    )?;
+                    Ok(args[2].clone())
+                } else {
+                    crate::player::script::script_set_static_prop(
+                        player, &script_ref, &prop_name, &args[1], false,
+                    )?;
+                    Ok(args[1].clone())
+                }
+            }),
             _ => Err(ScriptError::new(format!(
                 "No handler {handler_name} for script datum"
             ))),

--- a/vm-rust/src/player/handlers/datum_handlers/script.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/script.rs
@@ -18,6 +18,8 @@ impl ScriptDatumHandlers {
     pub fn has_async_handler(obj_ref: &DatumRef, name: &str) -> bool {
         match name {
             "new" => true,
+            // `birth` on a ScriptRef is the Director 6 constructor (see `birth`).
+            "birth" => true,
             "rawNew" => false,
             "handler" => false,
             _ => {
@@ -47,6 +49,7 @@ impl ScriptDatumHandlers {
     ) -> Result<DatumRef, ScriptError> {
         match handler_name {
             "new" => Self::new(obj_ref, args).await,
+            "birth" => Self::birth(obj_ref, args).await,
             "rawNew" => Self::raw_new(obj_ref),
             _ => {
                 // Try to call a handler defined in the script itself
@@ -262,6 +265,24 @@ impl ScriptDatumHandlers {
     }
 
     pub async fn new(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        Self::construct(datum, args, "new").await
+    }
+
+    /// Director 6 `birth(script, args)` — the pre-`new` constructor idiom. It is
+    /// exactly `new` except it runs the instance's `on birth me, args` handler
+    /// instead of `on new`. The 11.5 Scripting Dictionary dropped `birth`, so we
+    /// mirror the documented `new` / parent-script contract: a FRESH instance
+    /// with its OWN property storage per call. (100s-Marios births 200 marios
+    /// via `birth(script "MarioScript", 3+i)`; without a fresh instance each
+    /// call, all same-script marios shared one `sn`/`timr`/`pipe` and only ~4
+    /// sprites were ever driven.)
+    pub async fn birth(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        Self::construct(datum, args, "birth").await
+    }
+
+    /// Shared constructor for `new`/`birth`: allocate a fresh instance, then run
+    /// its `ctor` handler (`on new` / `on birth`) with the instance as `me`.
+    async fn construct(datum: &DatumRef, args: &Vec<DatumRef>, ctor: &str) -> Result<DatumRef, ScriptError> {
         let (script_ref, script_instance_ref, datum_ref) = Self::create_uninit_instance(datum)?;
 
         let (new_handler_ref, expected_param_count, script_name) =
@@ -271,10 +292,10 @@ impl ScriptDatumHandlers {
                     .cast_manager
                     .get_script_by_ref(&script_ref)
                     .unwrap();
-                let new_handler_ref = script.get_own_handler_ref(&"new".to_string());
+                let new_handler_ref = script.get_own_handler_ref(&ctor.to_string());
 
                 let param_count = if let Some(_) = &new_handler_ref {
-                    let handler_def = script.get_own_handler(&"new".to_string()).unwrap();
+                    let handler_def = script.get_own_handler(&ctor.to_string()).unwrap();
                     handler_def.argument_name_ids.len()
                 } else {
                     0
@@ -288,7 +309,7 @@ impl ScriptDatumHandlers {
             })?;
 
         let virtual_new_result = reserve_player_mut(|player| {
-            crate::player::virtual_scripts::VirtualScriptRegistry::try_call_handler(player, &script_ref, Some(&script_instance_ref), "new", args)
+            crate::player::virtual_scripts::VirtualScriptRegistry::try_call_handler(player, &script_ref, Some(&script_instance_ref), ctor, args)
         });
         match virtual_new_result {
             Ok(Some(_)) => return Ok(datum_ref),
@@ -308,7 +329,7 @@ impl ScriptDatumHandlers {
                 {
                     Ok(scope) => scope,
                     Err(err) => {
-                        error!("❌ Error in {}.new(): {}", script_name, err.message);
+                        error!("❌ Error in {}.{}(): {}", script_name, ctor, err.message);
                         return Err(err);
                     }
                 };

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -304,7 +304,19 @@ impl Shockwave3dObjectDatumHandlers {
                                     None => compute_motion_t(motion, &w3d.runtime_state),
                                 };
                                 let matrices = crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, motion, t);
-                                matrices.get(bone_idx).copied()
+                                let bone_m = matrices.get(bone_idx).copied()?;
+                                // Relativize by the idle-pose root to MATCH the renderer's
+                                // skin (scene3d setup_skinning), so a weapon attached via
+                                // bone[].worldTransform lines up with the relativized body.
+                                // Only biped actors have an idle-rest motion; others unchanged.
+                                let idle = scene.motions.iter()
+                                    .find(|m| m.name.to_ascii_lowercase().contains("idle_rest"))
+                                    .or_else(|| scene.motions.iter().find(|m| m.name.to_ascii_lowercase().contains("idle")))
+                                    .map(|im| crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, Some(im), 0.0));
+                                match idle {
+                                    Some(im) if !im.is_empty() => Some(mat4_mul_f32(&invert_transform_f32(&im[0]), &bone_m)),
+                                    _ => Some(bone_m),
+                                }
                             });
                         if let Some(m) = bone_matrix {
                             let m64: [f64; 16] = [
@@ -347,7 +359,19 @@ impl Shockwave3dObjectDatumHandlers {
                                     None => compute_motion_t(motion, &w3d.runtime_state),
                                 };
                                 let matrices = crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, motion, t);
-                                matrices.get(bone_idx).copied()
+                                let bone_m = matrices.get(bone_idx).copied()?;
+                                // Relativize by the idle-pose root to MATCH the renderer's
+                                // skin (scene3d setup_skinning), so a weapon attached via
+                                // bone[].worldTransform lines up with the relativized body.
+                                // Only biped actors have an idle-rest motion; others unchanged.
+                                let idle = scene.motions.iter()
+                                    .find(|m| m.name.to_ascii_lowercase().contains("idle_rest"))
+                                    .or_else(|| scene.motions.iter().find(|m| m.name.to_ascii_lowercase().contains("idle")))
+                                    .map(|im| crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, Some(im), 0.0));
+                                match idle {
+                                    Some(im) if !im.is_empty() => Some(mat4_mul_f32(&invert_transform_f32(&im[0]), &bone_m)),
+                                    _ => Some(bone_m),
+                                }
                             });
                         if let Some(bone_m) = bone_matrix {
                             let model_world = get_node_transform(player, member_ref, model_name);

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -109,6 +109,23 @@ impl Shockwave3dObjectDatumHandlers {
                 })
             },
             "meshDeform" => Self::get_mesh_deform_prop(player, scene, &s3d_ref.name, prop_name, member_ref),
+            "collision" => {
+                // Native #collision modifier object — s3d_ref.name is the model name.
+                let cm = player.movie.cast_manager.find_member_by_ref(member_ref)
+                    .and_then(|m| m.member_type.as_shockwave3d())
+                    .and_then(|w3d| w3d.runtime_state.collision_modifiers.get(&s3d_ref.name)
+                        .or_else(|| w3d.runtime_state.collision_modifiers.iter()
+                            .find(|(k, _)| k.eq_ignore_ascii_case(&s3d_ref.name)).map(|(_, v)| v)))
+                    .cloned()
+                    .unwrap_or_default();
+                match_ci!(prop_name, {
+                    "enabled" => Ok(player.alloc_datum(Datum::Int(if cm.enabled { 1 } else { 0 }))),
+                    "resolve" => Ok(player.alloc_datum(Datum::Int(if cm.resolve { 1 } else { 0 }))),
+                    "immovable" => Ok(player.alloc_datum(Datum::Int(if cm.immovable { 1 } else { 0 }))),
+                    "mode" => Ok(player.alloc_datum(Datum::Symbol(cm.mode.clone()))),
+                    _ => Ok(player.alloc_datum(Datum::Void)),
+                })
+            },
             "overlay" | "backdrop" => {
                 // overlay/backdrop object: name format "cameraName:index".
                 // camera_overlays/camera_backdrops are keyed by lowercased camera
@@ -510,6 +527,35 @@ impl Shockwave3dObjectDatumHandlers {
                 cast_member: s3d_ref.cast_member,
             };
 
+            // Setters on a #collision modifier object ref:
+            // `model.collision.enabled = 1`, `.resolve`, `.immovable`, `.mode`.
+            // Handled before the generic match_ci! (it can't guard prop names by
+            // object_type, and these names overlap with other object types).
+            if s3d_ref.object_type == "collision" {
+                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                    if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                        // Resolve the (case-insensitive) modifier entry, creating
+                        // it if a property was set without addModifier first.
+                        let key = w3d.runtime_state.collision_modifiers.keys()
+                            .find(|k| k.eq_ignore_ascii_case(&s3d_ref.name))
+                            .cloned()
+                            .unwrap_or_else(|| s3d_ref.name.clone());
+                        let cm = w3d.runtime_state.collision_modifiers.entry(key).or_default();
+                        match prop_name.to_ascii_lowercase().as_str() {
+                            "enabled" => cm.enabled = !matches!(value, Datum::Int(0)),
+                            "resolve" => cm.resolve = !matches!(value, Datum::Int(0)),
+                            "immovable" => cm.immovable = !matches!(value, Datum::Int(0)),
+                            "mode" => cm.mode = match value {
+                                Datum::Symbol(s) | Datum::String(s) => s.clone(),
+                                _ => cm.mode.clone(),
+                            },
+                            _ => {}
+                        }
+                    }
+                }
+                return Ok(());
+            }
+
             // Setters on a fog object ref: `cameraFog.near = X`, etc.
             // Handled before the generic match_ci! since the macro doesn't
             // support `if` guards for distinguishing prop names by object_type.
@@ -736,6 +782,46 @@ impl Shockwave3dObjectDatumHandlers {
                                 .entry(s3d_ref.name.clone())
                                 .or_insert_with(std::collections::HashMap::new);
                             shader_map.insert(0, shader_name);
+                        }
+                    }
+                    Ok(())
+                },
+                "shaderList" => {
+                    // Whole-list assignment: `model.shaderList = singleShader` (or
+                    // `[shaderA, shaderB, ...]`). Distinct from `.shader =` (which
+                    // only sets the first shader) and the indexed `shaderList[i] =`
+                    // (setProp). A single shader applies to EVERY mesh via the
+                    // index-0 fallback in node_shader_override; a list maps
+                    // positionally. frog01 uses this form everywhere — e.g.
+                    // `model("ft").shaderList = shader("clearS")` (makes the frog's
+                    // collision box invisible) and `textModel.shaderList =
+                    // shader("redS")` (colors the title text); without this arm the
+                    // assignment was silently dropped, so those models rendered with
+                    // the default opaque checker texture.
+                    let shader_names: Vec<(usize, String)> = match value {
+                        Datum::List(_, items, _) => items.iter().enumerate().filter_map(|(i, item)| {
+                            match player.get_datum(item) {
+                                Datum::Shockwave3dObjectRef(r) if r.object_type == "shader" => Some((i, r.name.clone())),
+                                Datum::String(s) => Some((i, s.clone())),
+                                _ => None,
+                            }
+                        }).collect(),
+                        Datum::Shockwave3dObjectRef(r) if r.object_type == "shader" => vec![(0, r.name.clone())],
+                        Datum::String(s) => vec![(0, s.clone())],
+                        Datum::Symbol(s) => vec![(0, s.clone())],
+                        _ => vec![],
+                    };
+                    if !shader_names.is_empty() {
+                        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                let map = w3d.runtime_state.node_shaders
+                                    .entry(s3d_ref.name.clone())
+                                    .or_insert_with(std::collections::HashMap::new);
+                                map.clear();
+                                for (i, name) in shader_names {
+                                    map.insert(i, name);
+                                }
+                            }
                         }
                     }
                     Ok(())
@@ -1711,19 +1797,58 @@ impl Shockwave3dObjectDatumHandlers {
                                                     }]
                                                 },
                                                 "cylinder" => {
-                                                    // Director #cylinder: axis along Y, centered. `resolution` is
-                                                    // the radial segment count (default 20; the Pacman pipes use 6
+                                                    // Director #cylinder: axis along Y, centered. The radial segment
+                                                    // count comes from `resolution` (default 20; Pacman pipes use 6
                                                     // for hexagonal tubes). topRadius/bottomRadius give the taper
-                                                    // (topRadius 0 => cone). topCap/bottomCap default FALSE, so the
-                                                    // cylinder is an open side wall (no end caps) unless a movie
-                                                    // seals them — which Pacman doesn't. Winding matches the sphere
-                                                    // (ring 0 = top -> ring 1 = bottom) so faces front outward.
+                                                    // (topRadius 0 => cone). topCap/bottomCap default TRUE (real-
+                                                    // world cans/logs have solid ends; the ghost body sets both 0).
+                                                    //
+                                                    // startAngle/endAngle sweep the side wall around the Y axis
+                                                    // (Director 11.5 dict, startAngle/endAngle: "The surface of a
+                                                    // cylinder is generated by sweeping a 2D line around the Y axis
+                                                    // from startAngle to endAngle ... To draw a section of a cylinder,
+                                                    // set endAngle to a value less than 360"). A section is left OPEN
+                                                    // along the angular cut — only the caps become half-discs; there
+                                                    // is no flat closing face (same as the sphere-section example).
+                                                    // frog01's floating logs are `logRes` cylinders with
+                                                    // startAngle=180 (a 180° half-pipe) rotated vector(dir,0,90): the
+                                                    // +X wall rolls to +Y (rounded side up) and the open −X side to
+                                                    // −Y (down into the water), so it reads as a solid floating log.
+                                                    //
+                                                    // Angular convention MUST match the meshDeform-verified #sphere:
+                                                    // x = -sin(L), z = cos(L) (L=startAngle ⇒ +Z). Using cos/sin
+                                                    // instead is harmless for a full circle but places a partial arc
+                                                    // 90° off, which after the log's roll would gape sideways.
                                                     use std::f32::consts::PI;
                                                     let bottom_r = res.primitive_radius;
                                                     let top_r = res.primitive_top_radius;
                                                     let hy = res.primitive_height / 2.0;
-                                                    let segs = if res.primitive_resolution >= 3 { res.primitive_resolution } else { 20 };
+                                                    let start = res.primitive_start_angle.to_radians();
+                                                    let mut sweep = (res.primitive_end_angle - res.primitive_start_angle).to_radians();
+                                                    if sweep <= 0.0 { sweep = 2.0 * PI; }
+                                                    // Keep the facet density of the default full cylinder: scale the
+                                                    // radial segment count by the swept fraction (half sweep → half
+                                                    // the segments) so a 180° log stays smooth without over-tessellating.
+                                                    let base = if res.primitive_resolution >= 3 { res.primitive_resolution } else { 20 };
+                                                    // Director does NOT thin out a section's facets. meshDeform of
+                                                    // frog01's 180° log (resolution=20 default) shows ~22 radial
+                                                    // segments (≈8°/facet) — it keeps the full facet COUNT for the
+                                                    // swept arc rather than scaling it by the arc fraction. dirplayer
+                                                    // was doing `sweep/2π * base` (180° log → only 10 facets), so the
+                                                    // logs rendered visibly polygonal / "smaller" with flat-panel
+                                                    // edges. Use the full `base` count for the arc. A full circle
+                                                    // (sweep=2π) is unchanged (still `base`), so Coke-can / Pacman-pipe
+                                                    // (resolution 6 → hexagon) cylinders keep their exact facet counts.
+                                                    let segs = base.max(2);
                                                     let stride = segs + 1;
+                                                    // A SECTIONED cylinder (sweep < 360°, e.g. frog01's 180° half-pipe
+                                                    // logs) is an open trough — you can see its INSIDE. dirplayer
+                                                    // back-face-culls, so looking into the open end showed THROUGH the
+                                                    // single-sided wall to the water (the "gap in the caps"). Director
+                                                    // renders the trough two-sided (wood inside). Emit reversed faces
+                                                    // for the wall + caps when sectioned so the interior is solid. A
+                                                    // full cylinder (Coke can / Pacman pipe) stays single-sided.
+                                                    let two_sided = sweep < (2.0 * PI - 1e-3);
                                                     // Director's #cylinder is THREE mesh groups: side wall, top cap,
                                                     // bottom cap — so shaderList[1]/[2]/[3] can each differ (the Coke
                                                     // can is the cokeT label on the side and silver canTop on the
@@ -1742,21 +1867,29 @@ impl Shockwave3dObjectDatumHandlers {
                                                             let (y, r) = if ring == 0 { (hy, top_r) } else { (-hy, bottom_r) };
                                                             for i in 0..=segs {
                                                                 let u = i as f32 / segs as f32;
-                                                                let theta = u * 2.0 * PI;
-                                                                let (c, s) = (theta.cos(), theta.sin());
-                                                                pos.push([c * r, y, s * r]);
-                                                                nrm.push([c, 0.0, s]);
+                                                                let l = start + sweep * u;
+                                                                let (sl, cl) = (l.sin(), l.cos());
+                                                                pos.push([-sl * r, y, cl * r]);
+                                                                nrm.push([-sl, 0.0, cl]);
                                                                 // pre-centre to cancel the shader CLOD remap; final UV
                                                                 // is (u, ring): v=0 at the top ring, v=1 at the bottom
                                                                 // edge (where GTEX bakes its black sawtooth).
                                                                 uvs.push([u - 0.5, 0.5 - ring as f32]);
                                                             }
                                                         }
+                                                        // segs quads connect slice i→i+1; a full sweep's last vertex
+                                                        // coincides with the first so it closes, a partial sweep stops
+                                                        // at endAngle leaving the cut open.
                                                         for i in 0..segs {
                                                             let a = i;
                                                             let b = a + stride;
                                                             faces.push([a, a + 1, b]);
                                                             faces.push([a + 1, b + 1, b]);
+                                                            if two_sided {
+                                                                // reversed winding → inner trough surface
+                                                                faces.push([a, b, a + 1]);
+                                                                faces.push([a + 1, b, b + 1]);
+                                                            }
                                                         }
                                                         out.push(ClodDecodedMesh {
                                                             name: s3d_ref.name.clone(), positions: pos, normals: nrm,
@@ -1765,21 +1898,30 @@ impl Shockwave3dObjectDatumHandlers {
                                                             bone_indices: vec![], bone_weights: vec![],
                                                         });
                                                     }
-                                                    // group 1 → shaderList[2]: top cap (+Y), fan, disc UV pre-centred
+                                                    // group 1 → shaderList[2]: top cap (+Y), disc UV pre-centred.
+                                                    // SEAL with a FULL disc (0..2π), not just the swept arc: a half-disc
+                                                    // cap leaves the trough side of the END open, so a sideways log
+                                                    // (axis along X) showed the open trough at its ends ("caps open").
+                                                    // A full cylinder's cap is already a full circle, so it's unchanged.
+                                                    // Use 2× segments when sectioned so the +arc half stays as smooth as
+                                                    // the wall.
                                                     if res.primitive_top_cap {
+                                                        let cap_segs = if two_sided { segs * 2 } else { segs };
                                                         let mut pos: Vec<[f32; 3]> = vec![[0.0, hy, 0.0]];
                                                         let mut nrm: Vec<[f32; 3]> = vec![[0.0, 1.0, 0.0]];
                                                         let mut uvs: Vec<[f32; 2]> = vec![[0.0, 0.0]];
                                                         let mut faces = Vec::new();
-                                                        for i in 0..=segs {
-                                                            let theta = i as f32 / segs as f32 * 2.0 * PI;
-                                                            let (c, s) = (theta.cos(), theta.sin());
-                                                            pos.push([c * top_r, hy, s * top_r]);
+                                                        for i in 0..=cap_segs {
+                                                            let l = 2.0 * PI * (i as f32 / cap_segs as f32);
+                                                            let (sl, cl) = (l.sin(), l.cos());
+                                                            pos.push([-sl * top_r, hy, cl * top_r]);
                                                             nrm.push([0.0, 1.0, 0.0]);
-                                                            uvs.push([c * 0.5, -s * 0.5]);
+                                                            uvs.push([-sl * 0.5, cl * 0.5]);
                                                         }
-                                                        for i in 0..segs {
+                                                        // +Y outward winding for x=-sin,z=cos is [center, i+1, i].
+                                                        for i in 0..cap_segs {
                                                             faces.push([0u32, 1 + i + 1, 1 + i]);
+                                                            if two_sided { faces.push([0u32, 1 + i, 1 + i + 1]); }
                                                         }
                                                         out.push(ClodDecodedMesh {
                                                             name: s3d_ref.name.clone(), positions: pos, normals: nrm,
@@ -1788,21 +1930,23 @@ impl Shockwave3dObjectDatumHandlers {
                                                             bone_indices: vec![], bone_weights: vec![],
                                                         });
                                                     }
-                                                    // group 2 → shaderList[3]: bottom cap (-Y)
+                                                    // group 2 → shaderList[3]: bottom cap (-Y) — full disc seal (see top cap)
                                                     if res.primitive_bottom_cap {
+                                                        let cap_segs = if two_sided { segs * 2 } else { segs };
                                                         let mut pos: Vec<[f32; 3]> = vec![[0.0, -hy, 0.0]];
                                                         let mut nrm: Vec<[f32; 3]> = vec![[0.0, -1.0, 0.0]];
                                                         let mut uvs: Vec<[f32; 2]> = vec![[0.0, 0.0]];
                                                         let mut faces = Vec::new();
-                                                        for i in 0..=segs {
-                                                            let theta = i as f32 / segs as f32 * 2.0 * PI;
-                                                            let (c, s) = (theta.cos(), theta.sin());
-                                                            pos.push([c * bottom_r, -hy, s * bottom_r]);
+                                                        for i in 0..=cap_segs {
+                                                            let l = 2.0 * PI * (i as f32 / cap_segs as f32);
+                                                            let (sl, cl) = (l.sin(), l.cos());
+                                                            pos.push([-sl * bottom_r, -hy, cl * bottom_r]);
                                                             nrm.push([0.0, -1.0, 0.0]);
-                                                            uvs.push([c * 0.5, -s * 0.5]);
+                                                            uvs.push([-sl * 0.5, cl * 0.5]);
                                                         }
-                                                        for i in 0..segs {
+                                                        for i in 0..cap_segs {
                                                             faces.push([0u32, 1 + i, 1 + i + 1]);
+                                                            if two_sided { faces.push([0u32, 1 + i + 1, 1 + i]); }
                                                         }
                                                         out.push(ClodDecodedMesh {
                                                             name: s3d_ref.name.clone(), positions: pos, normals: nrm,
@@ -1812,6 +1956,55 @@ impl Shockwave3dObjectDatumHandlers {
                                                         });
                                                     }
                                                     out
+                                                },
+                                                "plane" => {
+                                                    // Director #plane lies in the XY plane: width=X, length=Y,
+                                                    // centred, normal +Z (the default-facing plane is two-sided:
+                                                    // front mesh +Z, back mesh -Z, so shaderList[1]/[2] address the
+                                                    // two faces — the water sets shaderList[2]). The dimension
+                                                    // setter had no plane case, so width/length never rebuilt the
+                                                    // mesh and every large plane (road 42×18, water, banks, sides,
+                                                    // front/back) stayed at the 1×1 default — rendering tiny.
+                                                    let hw = res.primitive_width / 2.0;   // X half (width)
+                                                    let hl = res.primitive_length / 2.0;  // Y half (length)
+                                                    // UVs are PRE-CENTERED to [-0.5, 0.5]. The shared 3D vertex
+                                                    // shader applies the CLOD remap `base_uv = (u+0.5, 0.5-v)` to
+                                                    // every non-overlay mesh, so a plain [0,1] plane gets shifted
+                                                    // half a texture in both axes (the road's pavement bands landed
+                                                    // in the middle: "2 lanes / 2 sidewalks / 2 lanes" instead of
+                                                    // "sidewalk / 2 lanes / 2 lanes / sidewalk"). Storing
+                                                    // (u-0.5, 0.5-v) makes the shader reconstruct the intended [0,1]
+                                                    // — same convention the #sphere/#cylinder primitives use.
+                                                    //
+                                                    // MESH ORDER MUST MATCH DIRECTOR: a meshDeform dump of a real
+                                                    // Director #plane shows mesh[1].normal = (0,0,-1) and
+                                                    // mesh[2].normal = (0,0,+1). So shaderList[1] is the -Z face and
+                                                    // shaderList[2] the +Z face. frog01's walls set one face to
+                                                    // clearS (transparent) and the other to a texture; with the order
+                                                    // reversed, every clearS/texture landed on the wrong face (the
+                                                    // game-over `back` wall showed its opaque side toward the camera
+                                                    // and filled the view; `front`'s banner was on the culled side).
+                                                    // Emit -Z FIRST (shaderList[1]) then +Z (shaderList[2]).
+                                                    vec![
+                                                        ClodDecodedMesh {
+                                                            name: s3d_ref.name.clone(),
+                                                            positions: vec![[-hw,-hl,0.0],[hw,-hl,0.0],[hw,hl,0.0],[-hw,hl,0.0]],
+                                                            normals: vec![[0.0,0.0,-1.0]; 4],
+                                                            tex_coords: vec![vec![[0.5,-0.5],[-0.5,-0.5],[-0.5,0.5],[0.5,0.5]]],
+                                                            faces: vec![[0,2,1],[0,3,2]],
+                                                            diffuse_colors: vec![], specular_colors: vec![],
+                                                            bone_indices: vec![], bone_weights: vec![],
+                                                        },
+                                                        ClodDecodedMesh {
+                                                            name: s3d_ref.name.clone(),
+                                                            positions: vec![[-hw,-hl,0.0],[hw,-hl,0.0],[hw,hl,0.0],[-hw,hl,0.0]],
+                                                            normals: vec![[0.0,0.0,1.0]; 4],
+                                                            tex_coords: vec![vec![[-0.5,-0.5],[0.5,-0.5],[0.5,0.5],[-0.5,0.5]]],
+                                                            faces: vec![[0,1,2],[0,2,3]],
+                                                            diffuse_colors: vec![], specular_colors: vec![],
+                                                            bone_indices: vec![], bone_weights: vec![],
+                                                        },
+                                                    ]
                                                 },
                                                 _ => vec![],
                                             };
@@ -2019,15 +2212,33 @@ impl Shockwave3dObjectDatumHandlers {
                 },
                 "pointAt" => {
                     if !args.is_empty() {
-                        if let Datum::Vector(target) = player.get_datum(&args[0]) {
-                            let target = *target;
+                        // Director's pointAt accepts EITHER a vector OR a node
+                        // (model/group/light/camera) — in the node case it aims at that
+                        // node's worldPosition. frog01's death camera uses
+                        // `camera.pointAt(s.model("frog"))` (a model) while normal play uses
+                        // `camera.pointAt(frog.worldPosition)` (a vector); handling only the
+                        // vector form left the death camera at the right spot but never
+                        // rotated to face the frog ("camera moves, view wrong"). Also fixes
+                        // `light("spot2").pointAt(s.model("frog"))`, same handler.
+                        let target_opt: Option<[f32; 3]> = match player.get_datum(&args[0]) {
+                            Datum::Vector(target) => {
+                                Some([target[0] as f32, target[1] as f32, target[2] as f32])
+                            }
+                            Datum::Shockwave3dObjectRef(r) => {
+                                let name = r.name.clone();
+                                let wp = get_world_position(player, &member_ref, &name);
+                                Some([wp[0] as f32, wp[1] as f32, wp[2] as f32])
+                            }
+                            _ => None,
+                        };
+                        if let Some(target) = target_opt {
                             let (ux, uy, uz) = if args.len() > 1 {
                                 if let Datum::Vector(up) = player.get_datum(&args[1]) {
                                     (up[0] as f32, up[1] as f32, up[2] as f32)
                                 } else { (0.0f32, 1.0, 0.0) }
                             } else { (0.0f32, 1.0, 0.0) };
                             apply_point_at(player, &member_ref, &s3d_ref.name,
-                                target[0] as f32, target[1] as f32, target[2] as f32,
+                                target[0], target[1], target[2],
                                 ux, uy, uz);
                         }
                     }
@@ -2240,30 +2451,209 @@ impl Shockwave3dObjectDatumHandlers {
                 },
                 // ─── Scene management ───
                 "clone" | "cloneDeep" => {
-                    // Return a new model ref with the cloned name and add node to scene
+                    // Director 11.5 Scripting Dictionary (clone): "creates a copy of the
+                    // model, group, light, or camera AND ALL OF ITS CHILDREN. The clone
+                    // shares the parent ... and is assigned the same shaderList as the
+                    // original." The previous implementation copied only the single node,
+                    // so `clone.child[n]` was VOID and the cloned subtree lost its shaders
+                    // (frog01 crashed on `s.model(cn).child[1].shaderList[5] = ...`).
+                    // Recursively clone the whole subtree here.
                     let clone_name = if !args.is_empty() {
                         player.get_datum(&args[0]).string_value().unwrap_or_default()
                     } else {
-                        format!("{}_clone", s3d_ref.name)
+                        String::new()
                     };
                     let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
-                    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
-                        if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            if let Some(scene) = w3d.scene_mut() {
-                                let source_node = scene.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(&s3d_ref.name)).cloned();
-                                if let Some(mut new_node) = source_node {
-                                    // Per Director docs: clone shares the same parent as original
-                                    // If name is empty, clone has no parent (temporary instance)
-                                    if clone_name.is_empty() {
-                                        new_node.parent_name = String::new();
+                    let source_name = s3d_ref.name.clone();
+                    let source_lower = source_name.to_ascii_lowercase();
+
+                    // 1. Snapshot the source node + its descendant subtree (in scene.nodes
+                    //    order, so the clone's child[n] indexing matches the source's — the
+                    //    child accessor filters scene.nodes in iteration order). Also grab
+                    //    every existing node name so auto-generated clone names stay unique.
+                    let (root_snapshot, descendants, mut used_names) = {
+                        let scene_opt = player.movie.cast_manager.find_member_by_ref(&member_ref)
+                            .and_then(|m| m.member_type.as_shockwave3d())
+                            .and_then(|w3d| w3d.parsed_scene.as_ref());
+                        if let Some(scene) = scene_opt {
+                            let root = scene.nodes.iter()
+                                .find(|n| n.name.eq_ignore_ascii_case(&source_name)).cloned();
+                            // Parent-chain closure: a node is in the subtree if some
+                            // ancestor is the source. (Parents may appear after their
+                            // children in scene.nodes order, so iterate to a fixpoint.)
+                            let pairs: Vec<(String, String)> = scene.nodes.iter()
+                                .map(|n| (n.name.to_ascii_lowercase(), n.parent_name.to_ascii_lowercase()))
+                                .collect();
+                            let mut in_set: std::collections::HashSet<String> = std::collections::HashSet::new();
+                            in_set.insert(source_lower.clone());
+                            let mut changed = true;
+                            while changed {
+                                changed = false;
+                                for (nm, pn) in &pairs {
+                                    if !in_set.contains(nm) && in_set.contains(pn) {
+                                        in_set.insert(nm.clone());
+                                        changed = true;
                                     }
-                                    // Otherwise keep original parent_name (already copied from source)
-                                    new_node.name = clone_name.clone();
-                                    scene.nodes.push(new_node);
-                                } else {
-                                    use crate::director::chunks::w3d::types::*;
+                                }
+                            }
+                            let descendants: Vec<crate::director::chunks::w3d::types::W3dNode> = scene.nodes.iter()
+                                .filter(|n| {
+                                    let nl = n.name.to_ascii_lowercase();
+                                    nl != source_lower && in_set.contains(&nl)
+                                })
+                                .cloned()
+                                .collect();
+                            let used: std::collections::HashSet<String> = pairs.into_iter().map(|(nm, _)| nm).collect();
+                            (root, descendants, used)
+                        } else {
+                            (None, Vec::new(), std::collections::HashSet::new())
+                        }
+                    };
+
+                    // The clone root takes the explicit name. Director keeps an anonymous
+                    // "" clone in the scene (just uncounted), so synthesize a stable key
+                    // for it rather than leaving it nameless.
+                    let effective_root_name = if clone_name.is_empty() {
+                        format!("{}_clone", source_name)
+                    } else {
+                        clone_name.clone()
+                    };
+
+                    // Director rejects a clone whose name already names a node:
+                    // `frog.clone("evil")` a second time errors "Object with duplicate
+                    // name already exists" rather than appending a phantom subtree.
+                    // `used_names` was seeded from every existing node, so a hit means
+                    // the target name is taken. (In normal play this never fires —
+                    // beginSprite calls resetWorld first, which clears the prior clone.)
+                    if used_names.contains(&effective_root_name.to_ascii_lowercase()) {
+                        return Err(ScriptError::new(
+                            "Object with duplicate name already exists".to_string(),
+                        ));
+                    }
+
+                    if let Some(root_node) = root_snapshot {
+                        // 2. Pass 1 — assign every clone a name. Auto-named children use
+                        //    Director's "<original>-copy<N>" convention (frog01 relies on
+                        //    it, e.g. s.model("axe-copy2")); N is a per-clone counter that
+                        //    skips any name already taken so repeated clones of the same
+                        //    subtree (16 cars × {acar, wheel1..4}) never collide — runtime
+                        //    state here is keyed by node name, so collisions would corrupt
+                        //    sibling clones.
+                        let mut name_map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+                        name_map.insert(source_lower.clone(), effective_root_name.clone());
+                        used_names.insert(effective_root_name.to_ascii_lowercase());
+                        // Director assigns "-copyN" by walking the source descendants in
+                        // creation (scene.nodes) order and, for each not-yet-named node,
+                        // naming it AND THEN its parent (when the parent is also in the
+                        // cloned subtree and still unnamed). Verified against real
+                        // Director's `frog.clone("evil")`: frog01 creates the bones
+                        // connector-first (body, ll, rl, lc, …) with their joints last
+                        // (…, lhip, lk, la, rhip, rk, ra, axe), so the (node, parent)
+                        // pairing yields body=copy1, axe=copy2, ll=copy3, lhip=copy4,
+                        // rl=copy5, rhip=copy6, … — exactly the names the walk-cycle
+                        // hard-codes (s.model("lhip-copy4").rotate(…)). Plain creation-
+                        // order numbering put the joints last (lhip-copy15) so the lookups
+                        // returned VOID. The loop skips names already taken so repeated
+                        // clones of the same subtree (16 cars × {acar,wheel1..4}) never
+                        // collide; those address children by index, not by copyN name.
+                        fn name_one(
+                            orig: &crate::director::chunks::w3d::types::W3dNode,
+                            name_map: &mut std::collections::HashMap<String, String>,
+                            used_names: &mut std::collections::HashSet<String>,
+                            counter: &mut usize,
+                        ) {
+                            let cand = loop {
+                                let c = format!("{}-copy{}", orig.name, *counter);
+                                *counter += 1;
+                                if used_names.insert(c.to_ascii_lowercase()) { break c; }
+                            };
+                            name_map.insert(orig.name.to_ascii_lowercase(), cand);
+                        }
+                        let mut counter = 1usize;
+                        for d in &descendants {
+                            if !name_map.contains_key(&d.name.to_ascii_lowercase()) {
+                                name_one(d, &mut name_map, &mut used_names, &mut counter);
+                            }
+                            let pl = d.parent_name.to_ascii_lowercase();
+                            if pl != source_lower && !name_map.contains_key(&pl) {
+                                if let Some(parent) = descendants.iter()
+                                    .find(|n| n.name.eq_ignore_ascii_case(&pl)) {
+                                    name_one(parent, &mut name_map, &mut used_names, &mut counter);
+                                }
+                            }
+                        }
+
+                        // 3. Pass 2 — build the cloned nodes with re-parented names and
+                        //    collect the per-node runtime state to copy (live transform +
+                        //    shader overrides + visibility). Read under an immutable borrow.
+                        type ClonedNode = (crate::director::chunks::w3d::types::W3dNode, [f32; 16], Option<std::collections::HashMap<usize, String>>, Option<u8>);
+                        let mut planned: Vec<ClonedNode> = Vec::with_capacity(descendants.len() + 1);
+                        // (orig_node, new_name, new_parent): root keeps the source's parent
+                        // ("clone shares the parent"); descendants map their parent through
+                        // the complete name_map built in pass 1.
+                        let mut work: Vec<(&crate::director::chunks::w3d::types::W3dNode, String, String)> =
+                            Vec::with_capacity(descendants.len() + 1);
+                        work.push((&root_node, effective_root_name.clone(), root_node.parent_name.clone()));
+                        for d in &descendants {
+                            let new_name = name_map.get(&d.name.to_ascii_lowercase()).cloned().unwrap();
+                            let new_parent = name_map.get(&d.parent_name.to_ascii_lowercase()).cloned()
+                                .unwrap_or_else(|| d.parent_name.clone());
+                            work.push((d, new_name, new_parent));
+                        }
+                        for (orig, new_name, new_parent) in &work {
+                            let transform = get_node_transform_live(player, &member_ref, &orig.name);
+                            let (shaders, visibility) = {
+                                let w3d = player.movie.cast_manager.find_member_by_ref(&member_ref)
+                                    .and_then(|m| m.member_type.as_shockwave3d());
+                                let shaders = w3d.and_then(|w| {
+                                    w.runtime_state.node_shaders.get(&orig.name)
+                                        .or_else(|| w.runtime_state.node_shaders.iter()
+                                            .find(|(k, _)| k.eq_ignore_ascii_case(&orig.name)).map(|(_, v)| v))
+                                        .cloned()
+                                });
+                                let visibility = w3d.and_then(|w| {
+                                    w.runtime_state.node_visibility.get(&orig.name)
+                                        .or_else(|| w.runtime_state.node_visibility.iter()
+                                            .find(|(k, _)| k.eq_ignore_ascii_case(&orig.name)).map(|(_, v)| v))
+                                        .copied()
+                                });
+                                (shaders, visibility)
+                            };
+                            let mut node = (*orig).clone();
+                            node.name = new_name.clone();
+                            node.parent_name = new_parent.clone();
+                            node.transform = transform;
+                            planned.push((node, transform, shaders, visibility));
+                        }
+
+                        // 4. Commit — push cloned nodes and their runtime state.
+                        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                for (node, transform, shaders, visibility) in &planned {
+                                    w3d.runtime_state.node_transforms.insert(node.name.clone(), *transform);
+                                    if let Some(sh) = shaders {
+                                        w3d.runtime_state.node_shaders.insert(node.name.clone(), sh.clone());
+                                    }
+                                    if let Some(v) = visibility {
+                                        w3d.runtime_state.node_visibility.insert(node.name.clone(), *v);
+                                    }
+                                }
+                                if let Some(scene) = w3d.scene_mut() {
+                                    for (node, _, _, _) in planned {
+                                        scene.nodes.push(node);
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // Source not in the scene graph — keep the returned ref valid by
+                        // creating a bare model node (mirrors the old fallback).
+                        use crate::director::chunks::w3d::types::*;
+                        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                if let Some(scene) = w3d.scene_mut() {
                                     scene.nodes.push(W3dNode {
-                                        name: clone_name.clone(), node_type: W3dNodeType::Model,
+                                        name: effective_root_name.clone(), node_type: W3dNodeType::Model,
                                         parent_name: "World".to_string(),
                                         resource_name: String::new(), model_resource_name: String::new(),
                                         shader_name: String::new(),
@@ -2279,7 +2669,7 @@ impl Shockwave3dObjectDatumHandlers {
                         cast_lib: s3d_ref.cast_lib,
                         cast_member: s3d_ref.cast_member,
                         object_type: s3d_ref.object_type.clone(),
-                        name: clone_name,
+                        name: effective_root_name,
                     })))
                 },
                 "addChild" => {
@@ -2291,17 +2681,24 @@ impl Shockwave3dObjectDatumHandlers {
                             Datum::String(s) => s.clone(),
                             _ => String::new(),
                         };
-                        // 2nd arg selects transform handling. Default #preserveParent keeps
-                        // the child's LOCAL transform. #preserveWorld keeps the child's WORLD
-                        // transform, recomputing local = inverse(parentWorld) * childWorld.
-                        // Required by the Pacman maze (pipes parented to pipePink1) and the
-                        // ghosts (top/eyes parented to the body) — without it each child
-                        // inherited the parent's transform on top of its own (misplaced maze,
-                        // ghost parts floating off the body).
+                        // 2nd arg selects transform handling. Director's DEFAULT (no symbol)
+                        // is #preserveWorld: the child keeps its WORLD transform and its
+                        // parent-relative (local) transform is recomputed
+                        // (local = inverse(parentWorld) * childWorld). Only #preserveParent
+                        // keeps the child's existing LOCAL transform (the child JUMPS in world
+                        // space). Dict line 18344: "#preserveParent ... the parent-relative
+                        // transform of the child remains unchanged"; "#preserveWorld ... the
+                        // world transform of the child remains unchanged. Its parent-relative
+                        // transform is recalculated." Used by the Pacman maze (pipes parented
+                        // to pipePink1) and ghosts (top/eyes parented to the body), AND frog01:
+                        // it sets each wake's transform in WORLD space then `log.addChild(wake)`
+                        // with NO symbol — real Director rebases it under the log (local ≈
+                        // (0.1,0,0)). Defaulting to #preserveParent kept the world transform AS
+                        // the local, double-transforming the wake off-screen edge-on.
                         let preserve_world = match args.get(1).map(|a| player.get_datum(a)) {
-                            Some(Datum::Symbol(s)) => s.eq_ignore_ascii_case("preserveWorld"),
-                            Some(Datum::String(s)) => s.eq_ignore_ascii_case("preserveWorld"),
-                            _ => false,
+                            Some(Datum::Symbol(s)) => !s.eq_ignore_ascii_case("preserveParent"),
+                            Some(Datum::String(s)) => !s.eq_ignore_ascii_case("preserveParent"),
+                            _ => true, // Director default = #preserveWorld
                         };
                         if !child_name.is_empty() {
                             let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
@@ -2413,6 +2810,18 @@ impl Shockwave3dObjectDatumHandlers {
                                         .or_insert_with(crate::player::cast_member::LodState::default);
                                 }
                             }
+                        } else if mod_name == "collision" {
+                            // Native #collision modifier: register state so
+                            // `model.collision` resolves to a collision object and
+                            // events::tick_w3d_collisions includes this model.
+                            let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
+                            if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                                if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                    w3d.runtime_state.collision_modifiers
+                                        .entry(s3d_ref.name.clone())
+                                        .or_default();
+                                }
+                            }
                         } else if mod_name == "meshDeform" {
                             let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
                             let (mesh_count, node_found, res_found) = {
@@ -2450,6 +2859,32 @@ impl Shockwave3dObjectDatumHandlers {
                 },
                 "removeModifier" => Ok(player.alloc_datum(Datum::Void)),
                 "registerScript" | "registerForEvent" => Ok(player.alloc_datum(Datum::Void)),
+                "setCollisionCallback" => {
+                    // model.collision.setCollisionCallback(#handler, scriptInstance):
+                    // register the handler that events::tick_w3d_collisions fires
+                    // when this model is involved in a collision.
+                    if s3d_ref.object_type == "collision" && args.len() >= 2 {
+                        let handler = player.get_datum(&args[0]).string_value()
+                            .unwrap_or_default().trim_start_matches('#').to_string();
+                        let instance = match player.get_datum(&args[1]) {
+                            Datum::ScriptInstanceRef(r) => Some(r.clone()),
+                            _ => None,
+                        };
+                        let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
+                        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                let key = w3d.runtime_state.collision_modifiers.keys()
+                                    .find(|k| k.eq_ignore_ascii_case(&s3d_ref.name))
+                                    .cloned()
+                                    .unwrap_or_else(|| s3d_ref.name.clone());
+                                let cm = w3d.runtime_state.collision_modifiers.entry(key).or_default();
+                                cm.callback_handler = Some(handler);
+                                cm.callback_instance = instance;
+                            }
+                        }
+                    }
+                    Ok(player.alloc_datum(Datum::Void))
+                },
                 "isInWorld" => Ok(player.alloc_datum(Datum::Int(1))),
                 // ─── Camera methods ───
                 "modelUnderLoc" => {
@@ -3713,7 +4148,14 @@ impl Shockwave3dObjectDatumHandlers {
                                         }
                                     )))
                                 } else {
-                                    Some(player.alloc_datum(Datum::Void))
+                                    // Director quirk: out-of-range child[N] acts as IDENTITY in a
+                                    // chain — it returns the node itself, so e.g. (verified in
+                                    // real Director) evil.child[2].child[1].child[1] resolves to the
+                                    // body even though evil has only one child (child[2] collapses,
+                                    // continuing from evil). frog01's evil-frog black/red shader
+                                    // setup addresses evil.child[2] (evil has 1 child) and relies on
+                                    // this; without it the chain dies to VOID and no shaders apply.
+                                    Some(player.alloc_datum(Datum::Shockwave3dObjectRef(s3d_ref.clone())))
                                 }
                             }
                             _ => None, // Not a known collection, fall through to general get_prop_inner
@@ -4285,6 +4727,25 @@ impl Shockwave3dObjectDatumHandlers {
 
         match_ci!(prop, {
             "name" => Ok(player.alloc_datum(Datum::String(model_name.to_string()))),
+            "collision" => {
+                // model.collision — returns the #collision modifier object if one
+                // was added via addModifier(#collision), else VOID (Director).
+                let has = player.movie.cast_manager.find_member_by_ref(member_ref)
+                    .and_then(|m| m.member_type.as_shockwave3d())
+                    .map(|w3d| w3d.runtime_state.collision_modifiers.keys()
+                        .any(|k| k.eq_ignore_ascii_case(model_name)))
+                    .unwrap_or(false);
+                if has {
+                    Ok(player.alloc_datum(Datum::Shockwave3dObjectRef(crate::director::lingo::datum::Shockwave3dObjectRef {
+                        cast_lib: member_ref.cast_lib,
+                        cast_member: member_ref.cast_member,
+                        object_type: "collision".to_string(),
+                        name: model_name.to_string(),
+                    })))
+                } else {
+                    Ok(player.alloc_datum(Datum::Void))
+                }
+            },
             "visible" | "visibility" => Ok(player.alloc_datum(Datum::Int(1))),
             "pointAtOrientation" | "pointatorientation" => {
                 let member = player.movie.cast_manager.find_member_by_ref(member_ref);
@@ -5269,7 +5730,34 @@ impl Shockwave3dObjectDatumHandlers {
 
         match_ci!(prop, {
             "name" => Ok(player.alloc_datum(Datum::String(resource_name.to_string()))),
-            "type" => Ok(player.alloc_datum(Datum::Symbol("fromFile".to_string()))),
+            "type" => {
+                // Real primitive type (#plane/#box/#sphere/#cylinder); fall back to
+                // #fromFile for loaded/mesh resources. Was hardcoded to "fromFile".
+                let t = res.and_then(|r| r.primitive_type.clone())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| "fromFile".to_string());
+                Ok(player.alloc_datum(Datum::Symbol(t)))
+            },
+            "topCap" => Ok(player.alloc_datum(Datum::Int(
+                res.map(|r| if r.primitive_top_cap { 1 } else { 0 }).unwrap_or(0)))),
+            "bottomCap" => Ok(player.alloc_datum(Datum::Int(
+                res.map(|r| if r.primitive_bottom_cap { 1 } else { 0 }).unwrap_or(0)))),
+            "topRadius" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_top_radius as f64).unwrap_or(0.0)))),
+            "bottomRadius" | "radius" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_radius as f64).unwrap_or(0.0)))),
+            "height" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_height as f64).unwrap_or(0.0)))),
+            "width" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_width as f64).unwrap_or(0.0)))),
+            "length" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_length as f64).unwrap_or(0.0)))),
+            "startAngle" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_start_angle as f64).unwrap_or(0.0)))),
+            "endAngle" => Ok(player.alloc_datum(Datum::Float(
+                res.map(|r| r.primitive_end_angle as f64).unwrap_or(360.0)))),
+            "resolution" => Ok(player.alloc_datum(Datum::Int(
+                res.map(|r| r.primitive_resolution as i32).unwrap_or(0)))),
             "vertexList" => {
                 // For meshes built via newMesh()+build(), the positions live
                 // in scene.clod_meshes keyed by the resource name. Director
@@ -5660,13 +6148,20 @@ fn get_world_position(
         if let Some(w3d) = member.member_type.as_shockwave3d() {
             if let Some(ref scene) = w3d.parsed_scene {
                 if let Some(node) = scene.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(node_name)) {
-                    let local = get_node_transform(player, member_ref, &node.name);
+                    // Use the LIVE transform (persistent datum), not the once-per-frame
+                    // node_transforms cache: a script may read `model.worldPosition`
+                    // immediately after `model.transform.position = v` (e.g. frog01 does
+                    // `snakeBox.position = snakedown.worldPosition + offset` right after
+                    // positioning snakedown). Reading the stale cache returns the model's
+                    // load-time (clone source) transform, which then poisons the
+                    // subsequent addChild #preserveWorld math. Mirrors node_world_transform.
+                    let local = get_node_transform_live(player, member_ref, &node.name);
                     let mut result = local;
                     let mut current_parent = node.parent_name.clone();
                     for _ in 0..20 {
                         if current_parent.is_empty() || current_parent.eq_ignore_ascii_case("World") { break; }
                         if let Some(pn) = scene.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(&current_parent)) {
-                            let pt = get_node_transform(player, member_ref, &pn.name);
+                            let pt = get_node_transform_live(player, member_ref, &pn.name);
                             result = mat4_mul_f32(&pt, &result);
                             current_parent = pn.parent_name.clone();
                         } else { break; }
@@ -6081,9 +6576,22 @@ fn apply_translation(
         // slide relies on this — rz=90 puts local +X along world +Y, so
         // translate(0.5,0,0) lifts him up (worldPosition.y climbs to the respawn
         // threshold) instead of sliding sideways.
-        m[12] += m[0] * dx + m[4] * dy + m[8] * dz;
-        m[13] += m[1] * dx + m[5] * dy + m[9] * dz;
-        m[14] += m[2] * dx + m[6] * dy + m[10] * dz;
+        //
+        // The axes are the UNIT rotation directions, NOT scaled by the node's own
+        // scale: Director 11.5 dict (translate/#self) moves "x, y, z units along the
+        // [local] axes". A scaled node must still move the full distance — frog01's
+        // snake is cloned at scale 0.11 and animated with translate(0,±5,0); using the
+        // scaled columns moved it 0.55 instead of 5 and broke its worldPosition.y
+        // thresholds, and the logs (scale = log length) drifted at the wrong speed.
+        let sx = (m[0]*m[0] + m[1]*m[1] + m[2]*m[2]).sqrt();
+        let sy = (m[4]*m[4] + m[5]*m[5] + m[6]*m[6]).sqrt();
+        let sz = (m[8]*m[8] + m[9]*m[9] + m[10]*m[10]).sqrt();
+        let sx = if sx > 1e-8 { sx } else { 1.0 };
+        let sy = if sy > 1e-8 { sy } else { 1.0 };
+        let sz = if sz > 1e-8 { sz } else { 1.0 };
+        m[12] += (m[0]/sx) * dx + (m[4]/sy) * dy + (m[8]/sz) * dz;
+        m[13] += (m[1]/sx) * dx + (m[5]/sy) * dy + (m[9]/sz) * dz;
+        m[14] += (m[2]/sx) * dx + (m[6]/sy) * dy + (m[10]/sz) * dz;
     }
     set_node_transform(player, member_ref, node_name, m);
 }
@@ -6105,11 +6613,51 @@ fn apply_rotation(
         // #world / #parent: compose in the world/parent frame (rot · R).
         mat4_mul_f32(&rot, &m)
     } else {
-        // #self (the node-reference default): compose in the node's LOCAL frame
-        // (R · rot), so the rotation runs about the node's own axes. Pacman's
-        // death spin uses rotate(5,0,0): about local X (which rz=90 aligns with
-        // world +Y), so local X stays fixed and his upward slide doesn't drift.
-        mat4_mul_f32(&m, &rot)
+        // #self (the node-reference default): rotate about the node's own axes.
+        //
+        // Director PRESERVES the per-axis scale when the basis is a clean rotation×scale
+        // (orthogonal columns): it composes the delta into the ROTATION part and re-applies
+        // the scale — M' = (R·R_delta)·S. Rasterwerks' Z-up base map un-rotates m_si_fi_7
+        // with rotate(-origRot.x,0,0); its grille (clean basis, scale (1.196,1.0,1.196))
+        // must keep that scale, but the naive M·R_delta (=R·S·R_delta) put it on the wrong
+        // axes → (1.196,1.196,1.0), too shallow, so it sat in front of its pipe. This mirrors
+        // the existing transform.rotation SETTER (transform3d.rs ~126: R(v)·diag(sx,sy,sz)).
+        //
+        // An already-SHEARED basis (non-orthogonal columns — frog01's skeletal limbs, whose
+        // bones bake scale in a rotated frame) can't be cleanly decomposed; re-orthonormalizing
+        // it every frame compounds error and visibly stretches the limbs. Those fall back to the
+        // post-multiply M·R_delta, which preserves the shear. For a UNIFORM scale both paths give
+        // s·(R·R_delta), so ordinary rotates (Pacman's death spin etc.) are unaffected.
+        let c0 = [m[0], m[1], m[2]];
+        let c1 = [m[4], m[5], m[6]];
+        let c2 = [m[8], m[9], m[10]];
+        let sx = (c0[0]*c0[0] + c0[1]*c0[1] + c0[2]*c0[2]).sqrt();
+        let sy = (c1[0]*c1[0] + c1[1]*c1[1] + c1[2]*c1[2]).sqrt();
+        let sz = (c2[0]*c2[0] + c2[1]*c2[1] + c2[2]*c2[2]).sqrt();
+        let scale_prod = (sx*sy).max(sx*sz).max(sy*sz).max(1e-6);
+        let max_dot = (c0[0]*c1[0] + c0[1]*c1[1] + c0[2]*c1[2]).abs()
+            .max((c0[0]*c2[0] + c0[1]*c2[1] + c0[2]*c2[2]).abs())
+            .max((c1[0]*c2[0] + c1[1]*c2[1] + c1[2]*c2[2]).abs());
+        let orthogonal = (max_dot / scale_prod) < 1e-3;
+        if orthogonal && sx > 1e-8 && sy > 1e-8 && sz > 1e-8 {
+            // Clean basis: rebuild the rotation (R·R_delta) and re-apply the per-axis scale.
+            let rotm = [
+                c0[0]/sx, c0[1]/sx, c0[2]/sx, 0.0,
+                c1[0]/sy, c1[1]/sy, c1[2]/sy, 0.0,
+                c2[0]/sz, c2[1]/sz, c2[2]/sz, 0.0,
+                0.0, 0.0, 0.0, 1.0,
+            ];
+            let rn = mat4_mul_f32(&rotm, &rot);
+            [
+                rn[0]*sx, rn[1]*sx, rn[2]*sx, 0.0,
+                rn[4]*sy, rn[5]*sy, rn[6]*sy, 0.0,
+                rn[8]*sz, rn[9]*sz, rn[10]*sz, 0.0,
+                0.0, 0.0, 0.0, 1.0,
+            ]
+        } else {
+            // Sheared (or degenerate) basis: preserve it with a plain post-multiply.
+            mat4_mul_f32(&m, &rot)
+        }
     };
     // Keep the node positioned in place (m * rot already preserves translation,
     // but restore explicitly for the world-frame branch).
@@ -6297,19 +6845,58 @@ fn euler_to_matrix_f32(rx_deg: f32, ry_deg: f32, rz_deg: f32) -> [f32; 16] {
     ]
 }
 
-/// Invert a column-major affine transform
+/// Invert a column-major affine transform (handles rotation, SCALE and
+/// translation). A previous version transposed the upper-3×3 (assuming a pure
+/// rotation, Rᵀ = R⁻¹), which is wrong when the matrix carries scale: for a 3×3
+/// of R·S the transpose is S·Rᵀ, not the true inverse S⁻¹·Rᵀ. That made
+/// `addChild #preserveWorld` (`inverse(parentWorld) × childWorld`) multiply the
+/// parent's scale in instead of dividing it out, so scale compounded down a deep
+/// hierarchy and shrank every limb toward a point (the frog01 frog: `body` at the
+/// frog's 0.08 scale, but `ll` collapsed to ~0.01). Use a full 3×3 inverse via
+/// the adjugate; falls back to the rigid inverse for a (near-)singular matrix.
 fn invert_transform_f32(m: &[f32; 16]) -> [f32; 16] {
-    // Column-major: R[row][col] = m[col*4 + row]
+    // Upper-3×3 A (column-major: A[row][col] = m[col*4 + row]).
+    let (a, b, c) = (m[0], m[4], m[8]);   // row 0
+    let (d, e, f) = (m[1], m[5], m[9]);   // row 1
+    let (g, h, i) = (m[2], m[6], m[10]);  // row 2
     let (tx, ty, tz) = (m[12], m[13], m[14]);
-    // -R^T * t
-    let itx = -(m[0]*tx + m[1]*ty + m[2]*tz);
-    let ity = -(m[4]*tx + m[5]*ty + m[6]*tz);
-    let itz = -(m[8]*tx + m[9]*ty + m[10]*tz);
+
+    let det = a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g);
+    if det.abs() < 1e-12 {
+        // Singular — fall back to the rigid (rotation-only) inverse.
+        let itx = -(a * tx + d * ty + g * tz);
+        let ity = -(b * tx + e * ty + h * tz);
+        let itz = -(c * tx + f * ty + i * tz);
+        return [
+            a, b, c, 0.0,
+            d, e, f, 0.0,
+            g, h, i, 0.0,
+            itx, ity, itz, 1.0,
+        ];
+    }
+    let inv_det = 1.0 / det;
+    // inverse(A)[row][col] = cofactor / det
+    let r00 = (e * i - f * h) * inv_det;
+    let r01 = (c * h - b * i) * inv_det;
+    let r02 = (b * f - c * e) * inv_det;
+    let r10 = (f * g - d * i) * inv_det;
+    let r11 = (a * i - c * g) * inv_det;
+    let r12 = (c * d - a * f) * inv_det;
+    let r20 = (d * h - e * g) * inv_det;
+    let r21 = (b * g - a * h) * inv_det;
+    let r22 = (a * e - b * d) * inv_det;
+
+    // Inverse translation = -inverse(A) · t.
+    let itx = -(r00 * tx + r01 * ty + r02 * tz);
+    let ity = -(r10 * tx + r11 * ty + r12 * tz);
+    let itz = -(r20 * tx + r21 * ty + r22 * tz);
+
+    // Repack column-major: out[col*4 + row] = inverse(A)[row][col].
     [
-        m[0], m[4], m[8],  0.0,  // R^T col 0
-        m[1], m[5], m[9],  0.0,  // R^T col 1
-        m[2], m[6], m[10], 0.0,  // R^T col 2
-        itx,  ity,  itz,   1.0,
+        r00, r10, r20, 0.0, // col 0
+        r01, r11, r21, 0.0, // col 1
+        r02, r12, r22, 0.0, // col 2
+        itx, ity, itz, 1.0, // col 3
     ]
 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -2818,26 +2818,35 @@ impl Shockwave3dObjectDatumHandlers {
                     }
                     Ok(player.alloc_datum(Datum::Void))
                 },
-                "addOverlay" | "addBackdrop" => {
+                "addOverlay" | "addBackdrop" | "insertOverlay" | "insertBackdrop" => {
                     // addOverlay(texture, point, rotation)
-                    let is_overlay = handler_name == "addOverlay";
-                    let tex_name = if !args.is_empty() {
-                        match player.get_datum(&args[0]) {
+                    // insertOverlay(index, texture, point, rotation) — the 1-based
+                    // index shifts texture/loc/rotation one slot right and the new
+                    // overlay is INSERTED at that index instead of appended.
+                    // PacMan3D2's intro builds its 5 ffTitle title images this way.
+                    let is_overlay = handler_name.contains("Overlay");
+                    let is_insert = handler_name.starts_with("insert");
+                    let arg_off = if is_insert { 1 } else { 0 };
+                    let insert_index = if is_insert && !args.is_empty() {
+                        player.get_datum(&args[0]).int_value().unwrap_or(1).max(1) as usize
+                    } else { 0 };
+                    let tex_name = if args.len() > arg_off {
+                        match player.get_datum(&args[arg_off]) {
                             Datum::Shockwave3dObjectRef(r) if r.object_type == "texture" => r.name.clone(),
                             Datum::String(s) => s.clone(),
                             _ => String::new(),
                         }
                     } else { String::new() };
-                    let loc = if args.len() > 1 {
-                        match player.get_datum(&args[1]) {
+                    let loc = if args.len() > arg_off + 1 {
+                        match player.get_datum(&args[arg_off + 1]) {
                             Datum::Point(vals, _flags) => {
                                 [vals[0], vals[1]]
                             }
                             _ => [0.0, 0.0],
                         }
                     } else { [0.0, 0.0] };
-                    let rotation = if args.len() > 2 {
-                        player.get_datum(&args[2]).to_float().unwrap_or(0.0)
+                    let rotation = if args.len() > arg_off + 2 {
+                        player.get_datum(&args[arg_off + 2]).to_float().unwrap_or(0.0)
                     } else { 0.0 };
 
                     let camera_name = s3d_ref.name.clone();
@@ -2877,7 +2886,13 @@ impl Shockwave3dObjectDatumHandlers {
                             } else {
                                 w3d.runtime_state.camera_backdrops.entry(cam_key).or_insert_with(Vec::new)
                             };
-                            list.push(overlay);
+                            if is_insert {
+                                // 1-based index → 0-based, clamped to the list end.
+                                let idx = insert_index.saturating_sub(1).min(list.len());
+                                list.insert(idx, overlay);
+                            } else {
+                                list.push(overlay);
+                            }
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -413,18 +413,48 @@ impl Shockwave3dObjectDatumHandlers {
                         }
                     },
                     "face" => {
-                        let face_count = scene.nodes.iter().find(|n| n.name == *model_name)
-                            .and_then(|n| {
-                                let rn = if !n.model_resource_name.is_empty() { &n.model_resource_name } else { &n.resource_name };
-                                scene.model_resources.get(rn.as_str())
-                            })
-                            .and_then(|res| res.mesh_infos.get(mesh_idx))
-                            .map(|m| m.num_faces)
-                            .unwrap_or(0);
-                        // Return a PropList with #count
-                        let count_key = player.alloc_datum(Datum::Symbol("count".to_string()));
-                        let count_val = player.alloc_datum(Datum::Int(face_count as i32));
-                        Ok(player.alloc_datum(Datum::PropList(VecDeque::from(vec![(count_key, count_val)]), false)))
+                        // Return a LIST of faces, each a 3-element list of 1-based vertex
+                        // indices [v1,v2,v3] (Director's meshDeform face[] convention). This
+                        // makes BOTH `face.count` (list length) and `face[j]` (the j-th triple)
+                        // work, matching Director's message-window output [1,2,3],[4,5,6],…
+                        let node = scene.nodes.iter().find(|n| n.name == *model_name);
+                        let model_res = node.map(|n| n.model_resource_name.as_str()).unwrap_or("");
+                        let res = node.map(|n| n.resource_name.as_str()).unwrap_or("");
+                        let keys: Vec<&str> = [model_res, res].iter()
+                            .filter(|k| !k.is_empty() && **k != ".")
+                            .copied().collect();
+                        let mut faces: Vec<[u32; 3]> = Vec::new();
+                        for key in &keys {
+                            if let Some(meshes) = scene.clod_meshes.get(*key) {
+                                if let Some(mesh) = meshes.get(mesh_idx) {
+                                    faces = mesh.faces.clone();
+                                }
+                            }
+                            if !faces.is_empty() { break; }
+                        }
+                        if faces.is_empty() {
+                            for key in &keys {
+                                for raw in &scene.raw_meshes {
+                                    if raw.name == *key && raw.chain_index as usize == mesh_idx {
+                                        faces = raw.faces.clone();
+                                        break;
+                                    }
+                                }
+                                if !faces.is_empty() { break; }
+                            }
+                        }
+                        let mut items = VecDeque::new();
+                        for f in &faces {
+                            let tri = VecDeque::from(vec![
+                                player.alloc_datum(Datum::Int(f[0] as i32 + 1)),
+                                player.alloc_datum(Datum::Int(f[1] as i32 + 1)),
+                                player.alloc_datum(Datum::Int(f[2] as i32 + 1)),
+                            ]);
+                            items.push_back(player.alloc_datum(Datum::List(
+                                crate::director::lingo::datum::DatumType::List, tri, false)));
+                        }
+                        Ok(player.alloc_datum(Datum::List(
+                            crate::director::lingo::datum::DatumType::List, items, false)))
                     },
                     "vertexList" => {
                         // Return a list of vertex vectors from clod_meshes or raw_meshes
@@ -455,6 +485,42 @@ impl Shockwave3dObjectDatumHandlers {
                                     if raw.name == *key && raw.chain_index as usize == mesh_idx {
                                         for pos in &raw.positions {
                                             items.push_back(player.alloc_datum(Datum::Vector([pos[0] as f64, pos[1] as f64, pos[2] as f64])));
+                                        }
+                                        break;
+                                    }
+                                }
+                                if !items.is_empty() { break; }
+                            }
+                        }
+                        Ok(player.alloc_datum(Datum::List(
+                            crate::director::lingo::datum::DatumType::List, items, false,
+                        )))
+                    },
+                    "normalList" => {
+                        // Full list of per-vertex normal vectors (parallels vertexList).
+                        let mut items = VecDeque::new();
+                        let node = scene.nodes.iter().find(|n| n.name == *model_name);
+                        let model_res_name = node.map(|n| n.model_resource_name.as_str()).unwrap_or("");
+                        let res_name = node.map(|n| n.resource_name.as_str()).unwrap_or("");
+                        let keys_to_try: Vec<&str> = [model_res_name, res_name].iter()
+                            .filter(|k| !k.is_empty() && **k != ".")
+                            .copied().collect();
+                        for key in &keys_to_try {
+                            if let Some(meshes) = scene.clod_meshes.get(*key) {
+                                if let Some(mesh) = meshes.get(mesh_idx) {
+                                    for n in &mesh.normals {
+                                        items.push_back(player.alloc_datum(Datum::Vector([n[0] as f64, n[1] as f64, n[2] as f64])));
+                                    }
+                                }
+                                if !items.is_empty() { break; }
+                            }
+                        }
+                        if items.is_empty() {
+                            for key in &keys_to_try {
+                                for raw in &scene.raw_meshes {
+                                    if raw.name == *key && raw.chain_index as usize == mesh_idx {
+                                        for n in &raw.normals {
+                                            items.push_back(player.alloc_datum(Datum::Vector([n[0] as f64, n[1] as f64, n[2] as f64])));
                                         }
                                         break;
                                     }
@@ -4092,6 +4158,55 @@ impl Shockwave3dObjectDatumHandlers {
                                             if idx < raw.positions.len() {
                                                 let pos = &raw.positions[idx];
                                                 return Ok(player.alloc_datum(Datum::Vector([pos[0] as f64, pos[1] as f64, pos[2] as f64])));
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                                Some(player.alloc_datum(Datum::Void))
+                            }
+                            // meshDeformMesh.face[j] — return the j-th face's 1-based vertex
+                            // indices [v1,v2,v3] (Director's meshDeform face[] convention; the
+                            // Director message-window shows e.g. [1,2,3],[4,5,6],…). Lets us diff
+                            // dirplayer's decoded triangulation against Director's.
+                            "face" if s3d_ref.object_type == "meshDeformMesh" => {
+                                let parts: Vec<&str> = s3d_ref.name.splitn(2, ':').collect();
+                                let model_name = parts.get(0).unwrap_or(&"").to_string();
+                                let mesh_idx: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+                                let node = scene.nodes.iter().find(|n| n.name == *model_name);
+                                let model_res = node.map(|n| n.model_resource_name.as_str()).unwrap_or("");
+                                let res = node.map(|n| n.resource_name.as_str()).unwrap_or("");
+                                let keys: Vec<&str> = [model_res, res].iter()
+                                    .filter(|k| !k.is_empty() && **k != ".")
+                                    .copied().collect();
+                                for key in &keys {
+                                    if let Some(meshes) = scene.clod_meshes.get(*key) {
+                                        if let Some(mesh) = meshes.get(mesh_idx) {
+                                            if idx < mesh.faces.len() {
+                                                let f = mesh.faces[idx];
+                                                let items = VecDeque::from(vec![
+                                                    player.alloc_datum(Datum::Int(f[0] as i32 + 1)),
+                                                    player.alloc_datum(Datum::Int(f[1] as i32 + 1)),
+                                                    player.alloc_datum(Datum::Int(f[2] as i32 + 1)),
+                                                ]);
+                                                return Ok(player.alloc_datum(Datum::List(
+                                                    crate::director::lingo::datum::DatumType::List, items, false)));
+                                            }
+                                        }
+                                    }
+                                }
+                                for key in &keys {
+                                    for raw in &scene.raw_meshes {
+                                        if raw.name == *key && raw.chain_index as usize == mesh_idx {
+                                            if idx < raw.faces.len() {
+                                                let f = raw.faces[idx];
+                                                let items = VecDeque::from(vec![
+                                                    player.alloc_datum(Datum::Int(f[0] as i32 + 1)),
+                                                    player.alloc_datum(Datum::Int(f[1] as i32 + 1)),
+                                                    player.alloc_datum(Datum::Int(f[2] as i32 + 1)),
+                                                ]);
+                                                return Ok(player.alloc_datum(Datum::List(
+                                                    crate::director::lingo::datum::DatumType::List, items, false)));
                                             }
                                             break;
                                         }

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -3025,7 +3025,7 @@ impl Shockwave3dObjectDatumHandlers {
                             // Fall back to mesh-triangle intersection
                             if let Some(hit) = raycast::raycast_scene_multi(
                                 &ray, &scene, 100000.0, 1,
-                                Some(&runtime_state.node_transforms), None,
+                                Some(&runtime_state.node_transforms), None, None,
                             ).into_iter().next() {
                                 debug!(
                                     "[modelUnderLoc] MESH HIT '{}'", hit.model_name
@@ -3103,7 +3103,7 @@ impl Shockwave3dObjectDatumHandlers {
                             let ray = raycast::screen_to_ray_shockwave(sx, sy, width, height, orig_w, orig_h, fov_deg, &cam_world);
                             let hits = raycast::raycast_scene_multi(
                                 &ray, &scene, 100000.0, max_models,
-                                Some(&node_transforms), Some(&excluded),
+                                Some(&node_transforms), Some(&excluded), None,
                             );
 
                             if !hits.is_empty() {

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -292,7 +292,7 @@ impl Shockwave3dObjectDatumHandlers {
                             .and_then(|m| m.member_type.as_shockwave3d())
                             .and_then(|w3d| {
                                 let scene = w3d.parsed_scene.as_ref()?;
-                                let skeleton = scene.skeletons.first()?;
+                                let skeleton = find_skeleton_for_model(scene, model_name)?;
                                 if bone_idx >= skeleton.bones.len() { return None; }
                                 let motion = w3d.runtime_state.current_motion.as_deref()
                                     .and_then(|name| scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(name)));
@@ -329,7 +329,7 @@ impl Shockwave3dObjectDatumHandlers {
                             .and_then(|m| m.member_type.as_shockwave3d())
                             .and_then(|w3d| {
                                 let scene = w3d.parsed_scene.as_ref()?;
-                                let skeleton = scene.skeletons.first()?;
+                                let skeleton = find_skeleton_for_model(scene, model_name)?;
                                 if bone_idx >= skeleton.bones.len() { return None; }
                                 let motion = w3d.runtime_state.current_motion.as_deref()
                                     .and_then(|name| scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(name)));
@@ -351,7 +351,7 @@ impl Shockwave3dObjectDatumHandlers {
                         let name = player.movie.cast_manager.find_member_by_ref(member_ref)
                             .and_then(|m| m.member_type.as_shockwave3d())
                             .and_then(|w3d| w3d.parsed_scene.as_ref())
-                            .and_then(|s| s.skeletons.first())
+                            .and_then(|s| find_skeleton_for_model(s, model_name))
                             .and_then(|skel| skel.bones.get(bone_idx))
                             .map(|b| b.name.clone())
                             .unwrap_or_else(|| format!("bone_{}", bone_idx));
@@ -4425,6 +4425,13 @@ impl Shockwave3dObjectDatumHandlers {
                             "group" => scene.nodes.iter().filter(|n| n.node_type == W3dNodeType::Group).count(),
                             "motion" => scene.motions.len(),
                             "modelResource" => scene.model_resources.len(),
+                            "bone" => {
+                                // bonesPlayer.bone.count / resource.bone.count — the
+                                // owning model's (or resource's) skeleton bone count.
+                                find_skeleton_for_model(&scene, &s3d_ref.name)
+                                    .map(|s| s.bones.len())
+                                    .unwrap_or(0)
+                            }
                             "playList" => {
                                 // Director's playList includes the currently playing motion
                                 // as entry [1], then the queued motions.
@@ -4886,6 +4893,36 @@ impl Shockwave3dObjectDatumHandlers {
 
         match_ci!(prop, {
             "name" => Ok(player.alloc_datum(Datum::String(model_name.to_string()))),
+            "bone.count" | "boneCount" => {
+                let count = find_skeleton_for_model(scene, model_name)
+                    .map(|s| s.bones.len()).unwrap_or(0);
+                Ok(player.alloc_datum(Datum::Int(count as i32)))
+            },
+            "bone" => {
+                // bonesPlayer.bone — return a LIST of bone refs (one per skeleton bone),
+                // so `bone.count` and `bone[i]` (and `bone[i].worldTransform`) work from
+                // the console/Lingo. Lingo `bone[1]` → items[0] → the root bone, matching
+                // both Director and the compiled indexed path. The skeleton is resolved by
+                // the model's OWN resource (each cloned bot has its own skeleton), fixing
+                // the previous `bonesPlayer.bone` = VOID / `bone.count` = 0 for clones.
+                let count = find_skeleton_for_model(scene, model_name)
+                    .map(|s| s.bones.len())
+                    .unwrap_or(0);
+                let mut items = VecDeque::new();
+                for i in 0..count {
+                    items.push_back(player.alloc_datum(Datum::Shockwave3dObjectRef(
+                        crate::director::lingo::datum::Shockwave3dObjectRef {
+                            cast_lib: member_ref.cast_lib,
+                            cast_member: member_ref.cast_member,
+                            object_type: "bone".to_string(),
+                            name: format!("{}:{}", model_name, i),
+                        },
+                    )));
+                }
+                Ok(player.alloc_datum(Datum::List(
+                    crate::director::lingo::datum::DatumType::List, items, false,
+                )))
+            },
             "collision" => {
                 // model.collision — returns the #collision modifier object if one
                 // was added via addModifier(#collision), else VOID (Director).
@@ -6257,6 +6294,39 @@ fn get_member_default_rect_size(
         }
     }
     (320.0, 240.0)
+}
+
+/// Resolve the skeleton that belongs to a model node, by its resource name — the same
+/// match `setup_skinning_for_resource` uses for the renderer. Falls back to a skeleton
+/// named after the model itself, then to the first skeleton (single-skeleton scenes).
+///
+/// Fixes `bone[]` / `bone.count` / `resource.bone.count` for CLONED skinned models:
+/// Rasterwerks spawns many bots, each a clone with its OWN cloned skeleton, so the old
+/// `scene.skeletons.first()` returned the wrong (or original) skeleton and bone access
+/// failed (`resource.bone.count = 0`). `model_or_resource_name` may be a model NODE name
+/// (bonesPlayer.bone…) or a resource name (resource.bone…); both resolve here.
+fn find_skeleton_for_model<'a>(
+    scene: &'a crate::director::chunks::w3d::types::W3dScene,
+    model_or_resource_name: &str,
+) -> Option<&'a crate::director::chunks::w3d::types::W3dSkeleton> {
+    // Model node → its resource → skeleton named after that resource.
+    if let Some(node) = scene.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(model_or_resource_name)) {
+        let res = if !node.model_resource_name.is_empty() {
+            node.model_resource_name.as_str()
+        } else {
+            node.resource_name.as_str()
+        };
+        if !res.is_empty() {
+            if let Some(sk) = scene.skeletons.iter().find(|s| s.name.eq_ignore_ascii_case(res)) {
+                return Some(sk);
+            }
+        }
+    }
+    // Direct name match (resource.bone… passes the resource name, which IS the skeleton name).
+    if let Some(sk) = scene.skeletons.iter().find(|s| s.name.eq_ignore_ascii_case(model_or_resource_name)) {
+        return Some(sk);
+    }
+    scene.skeletons.first()
 }
 
 fn get_node_transform(

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -294,9 +294,15 @@ impl Shockwave3dObjectDatumHandlers {
                                 let scene = w3d.parsed_scene.as_ref()?;
                                 let skeleton = find_skeleton_for_model(scene, model_name)?;
                                 if bone_idx >= skeleton.bones.len() { return None; }
-                                let motion = w3d.runtime_state.current_motion.as_deref()
+                                let bp = w3d.runtime_state.bones_player(model_name)
+                                    .filter(|b| b.current_motion.is_some());
+                                let motion = bp.and_then(|bp| bp.current_motion.as_deref())
+                                    .or_else(|| w3d.runtime_state.current_motion.as_deref())
                                     .and_then(|name| scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(name)));
-                                let t = compute_motion_t(motion, &w3d.runtime_state);
+                                let t = match bp {
+                                    Some(bp) => compute_motion_t_bp(motion, bp),
+                                    None => compute_motion_t(motion, &w3d.runtime_state),
+                                };
                                 let matrices = crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, motion, t);
                                 matrices.get(bone_idx).copied()
                             });
@@ -331,9 +337,15 @@ impl Shockwave3dObjectDatumHandlers {
                                 let scene = w3d.parsed_scene.as_ref()?;
                                 let skeleton = find_skeleton_for_model(scene, model_name)?;
                                 if bone_idx >= skeleton.bones.len() { return None; }
-                                let motion = w3d.runtime_state.current_motion.as_deref()
+                                let bp = w3d.runtime_state.bones_player(model_name)
+                                    .filter(|b| b.current_motion.is_some());
+                                let motion = bp.and_then(|bp| bp.current_motion.as_deref())
+                                    .or_else(|| w3d.runtime_state.current_motion.as_deref())
                                     .and_then(|name| scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(name)));
-                                let t = compute_motion_t(motion, &w3d.runtime_state);
+                                let t = match bp {
+                                    Some(bp) => compute_motion_t_bp(motion, bp),
+                                    None => compute_motion_t(motion, &w3d.runtime_state),
+                                };
                                 let matrices = crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, motion, t);
                                 matrices.get(bone_idx).copied()
                             });
@@ -911,9 +923,11 @@ impl Shockwave3dObjectDatumHandlers {
                         Datum::Int(i) => *i as f32,
                         _ => 1.0,
                     };
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.play_rate = rate;
+                            w3d.runtime_state.bones_player_mut(&model_name).play_rate = rate;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(())
@@ -924,18 +938,22 @@ impl Shockwave3dObjectDatumHandlers {
                         Datum::Int(i) => *i as f32,
                         _ => 0.0,
                     };
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.animation_blend_time = ms;
+                            w3d.runtime_state.bones_player_mut(&model_name).animation_blend_time = ms;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(())
                 },
                 "rootLock" => {
                     let locked = match value { Datum::Int(i) => *i != 0, _ => false };
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.root_lock = locked;
+                            w3d.runtime_state.bones_player_mut(&model_name).root_lock = locked;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(())
@@ -946,18 +964,22 @@ impl Shockwave3dObjectDatumHandlers {
                         Datum::Float(f) => *f as f32 / 1000.0,
                         _ => 0.0,
                     };
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.animation_time = time;
+                            w3d.runtime_state.bones_player_mut(&model_name).animation_time = time;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(())
                 },
                 "currentLoopState" => {
                     let looping = match value { Datum::Int(i) => *i != 0, _ => false };
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.animation_loop = looping;
+                            w3d.runtime_state.bones_player_mut(&model_name).animation_loop = looping;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(())
@@ -2371,48 +2393,53 @@ impl Shockwave3dObjectDatumHandlers {
                         Some((motion_name, is_loop, start_time_ms, end_time_ms, scale, offset_ms))
                     };
 
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
                             if let Some((motion_name, is_loop, start_time_ms, end_time_ms, scale, offset_ms)) = play_args {
-                                // Save interrupted motion into front of queue so it resumes later
-                                if let Some(ref cur) = w3d.runtime_state.current_motion {
-                                    if w3d.runtime_state.animation_playing {
-                                        let interrupted = crate::player::cast_member::QueuedMotion {
-                                            name: cur.clone(),
-                                            looped: w3d.runtime_state.animation_loop,
-                                            start_time: w3d.runtime_state.animation_start_time,
-                                            end_time: w3d.runtime_state.animation_end_time,
-                                            scale: w3d.runtime_state.animation_scale,
-                                            offset: w3d.runtime_state.animation_time, // resume from current position
-                                        };
-                                        w3d.runtime_state.motion_queue.insert(0, interrupted);
+                                {
+                                    let bp = w3d.runtime_state.bones_player_mut(&model_name);
+                                    // Save interrupted motion into front of queue so it resumes later
+                                    if let Some(ref cur) = bp.current_motion {
+                                        if bp.animation_playing {
+                                            let interrupted = crate::player::cast_member::QueuedMotion {
+                                                name: cur.clone(),
+                                                looped: bp.animation_loop,
+                                                start_time: bp.animation_start_time,
+                                                end_time: bp.animation_end_time,
+                                                scale: bp.animation_scale,
+                                                offset: bp.animation_time, // resume from current position
+                                            };
+                                            bp.motion_queue.insert(0, interrupted);
+                                        }
                                     }
-                                }
-                                // Set up crossfade blending using stored blendTime
-                                let blend_time = w3d.runtime_state.animation_blend_time;
-                                if blend_time > 0.0 && w3d.runtime_state.current_motion.is_some() {
-                                    w3d.runtime_state.previous_motion = w3d.runtime_state.current_motion.clone();
-                                    w3d.runtime_state.blend_duration = blend_time / 1000.0;
-                                    w3d.runtime_state.blend_elapsed = 0.0;
-                                    w3d.runtime_state.blend_weight = 0.0;
-                                } else {
-                                    w3d.runtime_state.previous_motion = None;
-                                    w3d.runtime_state.blend_weight = 1.0;
-                                }
+                                    // Set up crossfade blending using stored blendTime
+                                    let blend_time = bp.animation_blend_time;
+                                    if blend_time > 0.0 && bp.current_motion.is_some() {
+                                        bp.previous_motion = bp.current_motion.clone();
+                                        bp.blend_duration = blend_time / 1000.0;
+                                        bp.blend_elapsed = 0.0;
+                                        bp.blend_weight = 0.0;
+                                    } else {
+                                        bp.previous_motion = None;
+                                        bp.blend_weight = 1.0;
+                                    }
 
-                                w3d.runtime_state.current_motion = Some(motion_name);
-                                w3d.runtime_state.animation_playing = true;
-                                w3d.runtime_state.animation_loop = is_loop;
-                                w3d.runtime_state.animation_start_time = start_time_ms as f32 / 1000.0;
-                                w3d.runtime_state.animation_end_time = end_time_ms as f32 / 1000.0;
-                                w3d.runtime_state.animation_scale = scale as f32;
-                                w3d.runtime_state.motion_ended = false;
+                                    bp.current_motion = Some(motion_name);
+                                    bp.animation_playing = true;
+                                    bp.animation_loop = is_loop;
+                                    bp.animation_start_time = start_time_ms as f32 / 1000.0;
+                                    bp.animation_end_time = end_time_ms as f32 / 1000.0;
+                                    bp.animation_scale = scale as f32;
+                                    bp.motion_ended = false;
 
-                                // Determine initial animation time from offset
-                                if offset_ms >= 0.0 {
-                                    w3d.runtime_state.animation_time = offset_ms as f32 / 1000.0;
+                                    // Determine initial animation time from offset
+                                    if offset_ms >= 0.0 {
+                                        bp.animation_time = offset_ms as f32 / 1000.0;
+                                    }
+                                    // else: #synchronized — keep current relative position
                                 }
-                                // else: #synchronized — keep current relative position
+                                w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                             } else {
                                 // No args: Director's play() resumes a paused motion.
                                 // If nothing is current but a motion is queued (the
@@ -2423,21 +2450,25 @@ impl Shockwave3dObjectDatumHandlers {
                                 // which prepends current_motion, would show it twice). The
                                 // script's `if playList.count < 1` gate still sees count 1
                                 // (the now-current motion), so it does not re-queue.
-                                if w3d.runtime_state.current_motion.is_some() {
-                                    w3d.runtime_state.animation_playing = true;
-                                } else if !w3d.runtime_state.motion_queue.is_empty() {
-                                    let q = w3d.runtime_state.motion_queue.remove(0);
-                                    w3d.runtime_state.current_motion = Some(q.name);
-                                    w3d.runtime_state.animation_playing = true;
-                                    w3d.runtime_state.animation_loop = q.looped;
-                                    w3d.runtime_state.animation_start_time = q.start_time;
-                                    w3d.runtime_state.animation_end_time = q.end_time;
-                                    w3d.runtime_state.animation_scale = q.scale;
-                                    w3d.runtime_state.animation_time = if q.offset >= 0.0 { q.offset } else { q.start_time };
-                                    w3d.runtime_state.motion_ended = false;
-                                    w3d.runtime_state.previous_motion = None;
-                                    w3d.runtime_state.blend_weight = 1.0;
+                                {
+                                    let bp = w3d.runtime_state.bones_player_mut(&model_name);
+                                    if bp.current_motion.is_some() {
+                                        bp.animation_playing = true;
+                                    } else if !bp.motion_queue.is_empty() {
+                                        let q = bp.motion_queue.remove(0);
+                                        bp.current_motion = Some(q.name);
+                                        bp.animation_playing = true;
+                                        bp.animation_loop = q.looped;
+                                        bp.animation_start_time = q.start_time;
+                                        bp.animation_end_time = q.end_time;
+                                        bp.animation_scale = q.scale;
+                                        bp.animation_time = if q.offset >= 0.0 { q.offset } else { q.start_time };
+                                        bp.motion_ended = false;
+                                        bp.previous_motion = None;
+                                        bp.blend_weight = 1.0;
+                                    }
                                 }
+                                w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                             }
                         }
                     }
@@ -2466,9 +2497,11 @@ impl Shockwave3dObjectDatumHandlers {
                             scale: scale as f32,
                             offset: offset_ms as f32 / 1000.0,
                         };
+                        let model_name = s3d_ref.name.clone();
                         if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                             if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                                w3d.runtime_state.motion_queue.push(queued);
+                                w3d.runtime_state.bones_player_mut(&model_name).motion_queue.push(queued);
+                                w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                             }
                         }
                     }
@@ -2482,9 +2515,11 @@ impl Shockwave3dObjectDatumHandlers {
                     // form, so scripts that do `queue(x); playNext()` — e.g. Rasterwerks
                     // C_BonesControl — never drained the queue; it accumulated until
                     // TrimPlayList()/removeLast() deleted the pile.)
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            let rs = &mut w3d.runtime_state;
+                            {
+                            let rs = w3d.runtime_state.bones_player_mut(&model_name);
                             // Blend out of the interrupted motion if autoBlend/blendTime set.
                             if rs.current_motion.is_some() && rs.animation_blend_time > 0.0 {
                                 rs.previous_motion = rs.current_motion.clone();
@@ -2510,6 +2545,8 @@ impl Shockwave3dObjectDatumHandlers {
                                 rs.current_motion = None;
                                 rs.animation_playing = false;
                             }
+                            }
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
@@ -2518,38 +2555,52 @@ impl Shockwave3dObjectDatumHandlers {
                     // removeLast() — remove the LAST entry of the playList. The playList is
                     // `[current_motion] ++ motion_queue`, so drop the queue's tail; if the
                     // queue is empty the last (and only) entry is the current motion itself.
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            if w3d.runtime_state.motion_queue.pop().is_none() {
-                                w3d.runtime_state.current_motion = None;
-                                w3d.runtime_state.animation_playing = false;
+                            {
+                                let bp = w3d.runtime_state.bones_player_mut(&model_name);
+                                if bp.motion_queue.pop().is_none() {
+                                    bp.current_motion = None;
+                                    bp.animation_playing = false;
+                                }
                             }
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "pause" => {
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.animation_playing = false;
+                            w3d.runtime_state.bones_player_mut(&model_name).animation_playing = false;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "resume" => {
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.animation_playing = true;
+                            w3d.runtime_state.bones_player_mut(&model_name).animation_playing = true;
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "stop" => {
+                    let model_name = s3d_ref.name.clone();
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.animation_playing = false;
-                            w3d.runtime_state.animation_time = 0.0;
-                            w3d.runtime_state.current_motion = None;
+                            {
+                                let bp = w3d.runtime_state.bones_player_mut(&model_name);
+                                bp.animation_playing = false;
+                                bp.animation_time = 0.0;
+                                bp.current_motion = None;
+                            }
+                            w3d.runtime_state.sync_legacy_from_bones_player(&model_name);
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
@@ -4437,9 +4488,10 @@ impl Shockwave3dObjectDatumHandlers {
                                 // as entry [1], then the queued motions.
                                 let member = player.movie.cast_manager.find_member_by_ref(&member_ref);
                                 member.and_then(|m| m.member_type.as_shockwave3d())
-                                    .map(|w3d| {
-                                        (if w3d.runtime_state.current_motion.is_some() { 1 } else { 0 })
-                                            + w3d.runtime_state.motion_queue.len()
+                                    .map(|w3d| match w3d.runtime_state.bones_player(&s3d_ref.name).filter(|b| b.current_motion.is_some()) {
+                                        Some(bp) => (if bp.current_motion.is_some() { 1 } else { 0 }) + bp.motion_queue.len(),
+                                        None => (if w3d.runtime_state.current_motion.is_some() { 1 } else { 0 })
+                                            + w3d.runtime_state.motion_queue.len(),
                                     })
                                     .unwrap_or(0)
                             }
@@ -5216,14 +5268,14 @@ impl Shockwave3dObjectDatumHandlers {
             "playing" => {
                 let playing = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| if w3d.runtime_state.animation_playing { 1 } else { 0 })
+                    .map(|w3d| if w3d.runtime_state.bones_player(model_name).filter(|b| b.current_motion.is_some()).map(|bp| bp.animation_playing).unwrap_or(w3d.runtime_state.animation_playing) { 1 } else { 0 })
                     .unwrap_or(0);
                 Ok(player.alloc_datum(Datum::Int(playing)))
             },
             "currentTime" => {
                 let time = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| w3d.runtime_state.animation_time)
+                    .map(|w3d| w3d.runtime_state.bones_player(model_name).filter(|b| b.current_motion.is_some()).map(|bp| bp.animation_time).unwrap_or(w3d.runtime_state.animation_time))
                     .unwrap_or(0.0);
                 // Director returns currentTime in milliseconds
                 Ok(player.alloc_datum(Datum::Int((time * 1000.0) as i32)))
@@ -5231,21 +5283,21 @@ impl Shockwave3dObjectDatumHandlers {
             "playRate" => {
                 let rate = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| w3d.runtime_state.play_rate)
+                    .map(|w3d| w3d.runtime_state.bones_player(model_name).filter(|b| b.current_motion.is_some()).map(|bp| bp.play_rate).unwrap_or(w3d.runtime_state.play_rate))
                     .unwrap_or(1.0);
                 Ok(player.alloc_datum(Datum::Float(rate as f64)))
             },
             "rootLock" => {
                 let locked = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| if w3d.runtime_state.root_lock { 1 } else { 0 })
+                    .map(|w3d| if w3d.runtime_state.bones_player(model_name).filter(|b| b.current_motion.is_some()).map(|bp| bp.root_lock).unwrap_or(w3d.runtime_state.root_lock) { 1 } else { 0 })
                     .unwrap_or(0);
                 Ok(player.alloc_datum(Datum::Int(locked)))
             },
             "currentLoopState" => {
                 let looping = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| if w3d.runtime_state.animation_loop { 1 } else { 0 })
+                    .map(|w3d| if w3d.runtime_state.bones_player(model_name).filter(|b| b.current_motion.is_some()).map(|bp| bp.animation_loop).unwrap_or(w3d.runtime_state.animation_loop) { 1 } else { 0 })
                     .unwrap_or(0);
                 Ok(player.alloc_datum(Datum::Int(looping)))
             },
@@ -5256,7 +5308,7 @@ impl Shockwave3dObjectDatumHandlers {
                 // blend_weight is 0.0-1.0, Director uses 0.0-100.0
                 let factor = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| w3d.runtime_state.blend_weight * 100.0)
+                    .map(|w3d| w3d.runtime_state.bones_player(model_name).filter(|b| b.current_motion.is_some()).map(|bp| bp.blend_weight).unwrap_or(w3d.runtime_state.blend_weight) * 100.0)
                     .unwrap_or(0.0);
                 Ok(player.alloc_datum(Datum::Float(factor as f64)))
             },
@@ -5307,18 +5359,25 @@ impl Shockwave3dObjectDatumHandlers {
                     .and_then(|m| m.member_type.as_shockwave3d())
                     .map(|w3d| {
                         let rs = &w3d.runtime_state;
+                        // Prefer the per-model bonesPlayer state; fall back to legacy fields.
+                        let (cur, loop_, start, end, scale, time, queue) = match rs.bones_player(model_name).filter(|b| b.current_motion.is_some()) {
+                            Some(bp) => (bp.current_motion.clone(), bp.animation_loop, bp.animation_start_time,
+                                bp.animation_end_time, bp.animation_scale, bp.animation_time, bp.motion_queue.clone()),
+                            None => (rs.current_motion.clone(), rs.animation_loop, rs.animation_start_time,
+                                rs.animation_end_time, rs.animation_scale, rs.animation_time, rs.motion_queue.clone()),
+                        };
                         let mut list: Vec<crate::player::cast_member::QueuedMotion> = Vec::new();
-                        if let Some(ref name) = rs.current_motion {
+                        if let Some(name) = cur {
                             list.push(crate::player::cast_member::QueuedMotion {
-                                name: name.clone(),
-                                looped: rs.animation_loop,
-                                start_time: rs.animation_start_time,
-                                end_time: rs.animation_end_time,
-                                scale: rs.animation_scale,
-                                offset: rs.animation_time,
+                                name,
+                                looped: loop_,
+                                start_time: start,
+                                end_time: end,
+                                scale,
+                                offset: time,
                             });
                         }
-                        list.extend(rs.motion_queue.iter().cloned());
+                        list.extend(queue.into_iter());
                         list
                     })
                     .unwrap_or_default();
@@ -6215,6 +6274,28 @@ fn compute_motion_t(
     if range <= 0.0 { return 0.0; }
     let time = rs.animation_time;
     if rs.animation_loop {
+        eff_start + ((time - eff_start) % range + range) % range
+    } else {
+        time.clamp(eff_start, eff_end)
+    }
+}
+
+/// Per-model variant of `compute_motion_t` reading a model's own
+/// [`BonesPlayerState`] (each model animates independently).
+fn compute_motion_t_bp(
+    motion: Option<&crate::director::chunks::w3d::types::W3dMotion>,
+    bp: &crate::player::cast_member::BonesPlayerState,
+) -> f32 {
+    let Some(motion) = motion else { return 0.0; };
+    let duration = motion.duration();
+    let end_time = bp.animation_end_time;
+    let start_time = bp.animation_start_time;
+    let eff_end = if end_time >= 0.0 { end_time.min(duration) } else { duration };
+    let eff_start = start_time.min(eff_end);
+    let range = eff_end - eff_start;
+    if range <= 0.0 { return 0.0; }
+    let time = bp.animation_time;
+    if bp.animation_loop {
         eff_start + ((time - eff_start) % range + range) % range
     } else {
         time.clamp(eff_start, eff_end)

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -651,6 +651,26 @@ impl Shockwave3dObjectDatumHandlers {
                 cast_member: s3d_ref.cast_member,
             };
 
+            // `bonesPlayer.bone[i].transform = t` — store a manual per-bone LOCAL
+            // override (ref name is "modelName:boneIndex"). Director 11.5: the bone
+            // is no longer driven by the current motion; updateBoneRotation-style
+            // scripts re-set it every frame for procedural animation (the SweeTarts
+            // snake's S-wiggle). The skeleton build substitutes it, resolving the
+            // bone's rest length for the (typically zero) translation.
+            if s3d_ref.object_type == "bone" && prop_name.eq_ignore_ascii_case("transform") {
+                if let Datum::Transform3d(m) = value {
+                    let mut mat = [0.0f32; 16];
+                    for i in 0..16 { mat[i] = m[i] as f32; }
+                    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                        if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                            w3d.runtime_state.bone_transform_overrides
+                                .insert(s3d_ref.name.to_ascii_lowercase(), mat);
+                        }
+                    }
+                }
+                return Ok(());
+            }
+
             // Setters on a #collision modifier object ref:
             // `model.collision.enabled = 1`, `.resolve`, `.immovable`, `.mode`.
             // Handled before the generic match_ci! (it can't guard prop names by
@@ -7035,11 +7055,34 @@ pub fn sync_persistent_transforms(player: &mut crate::player::DirPlayer) {
 
 /// Sync persistent shader textureList DatumRefs back to shader.texture_layers in the scene.
 /// This ensures the renderer sees textures assigned via Lingo (shader.textureList[n] = tex).
+/// Invert the 2×2 UV-linear (scale/rotation) part of a texture transform and
+/// cast to f32. Director's `textureTransform.scale` is the texture's APPARENT
+/// size (0.125 = the texture tiles 8×), the inverse of the coordinate scale the
+/// shader multiplies onto the UVs. Translation (m12,m13) is preserved so a
+/// scrolling `textureTransform.position` still works.
+fn invert_tex_uv_scale(m: &[f64; 16]) -> [f32; 16] {
+    let (a, b, c, d) = (m[0], m[1], m[4], m[5]); // u' = a*u + c*v, v' = b*u + d*v
+    let det = a * d - c * b;
+    let mut out = [0.0f32; 16];
+    for i in 0..16 {
+        out[i] = m[i] as f32;
+    }
+    if det.abs() >= 1e-8 {
+        let inv = 1.0 / det;
+        out[0] = (d * inv) as f32;
+        out[1] = (-b * inv) as f32;
+        out[4] = (-c * inv) as f32;
+        out[5] = (a * inv) as f32;
+    }
+    out
+}
+
 pub fn sync_shader_texture_lists(player: &mut crate::player::DirPlayer) {
     // Collect (cast_lib, member_num, shader_name, list_ref) tuples
     let mut entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
     let mut mode_entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
     let mut blend_entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
+    let mut transform_entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
     for cast in &player.movie.cast_manager.casts {
         for (member_num, member) in &cast.members {
             if let Some(w3d) = member.member_type.as_shockwave3d() {
@@ -7051,6 +7094,9 @@ pub fn sync_shader_texture_lists(player: &mut crate::player::DirPlayer) {
                 }
                 for (shader_name, list_ref) in &w3d.runtime_state.shader_blend_constant_lists {
                     blend_entries.push((cast.number as i32, *member_num, shader_name.clone(), list_ref.clone()));
+                }
+                for (shader_name, list_ref) in &w3d.runtime_state.shader_texture_transform_lists {
+                    transform_entries.push((cast.number as i32, *member_num, shader_name.clone(), list_ref.clone()));
                 }
             }
         }
@@ -7115,6 +7161,39 @@ pub fn sync_shader_texture_lists(player: &mut crate::player::DirPlayer) {
                         }
                         for (i, mode) in modes.iter().enumerate() {
                             shader.texture_layers[i].tex_mode = *mode;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Sync textureTransformList → shader.texture_layers[].tex_transform. Runtime
+    // shaders set shader.textureTransform.scale on a Transform3d datum; the
+    // renderer only reads texture_layers[].tex_transform, so without this the
+    // transform is dropped (SweeTarts' skybox cloud tile mapped once around the
+    // cylinder → blurry; runtime edits had no visible effect). Scale is inverted
+    // to a tile factor (see invert_tex_uv_scale).
+    for (cast_lib, cast_member, shader_name, list_ref) in transform_entries {
+        let mats: Vec<[f32; 16]> = if let Datum::List(_, items, _) = player.get_datum(&list_ref) {
+            items.iter().map(|item_ref| match player.get_datum(item_ref) {
+                Datum::Transform3d(m) => invert_tex_uv_scale(m),
+                _ => [1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0],
+            }).collect()
+        } else {
+            continue;
+        };
+        let member_ref = CastMemberRef { cast_lib, cast_member: cast_member as i32 };
+        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                if let Some(scene) = w3d.scene_mut() {
+                    if let Some(shader) = scene.shaders.iter_mut().find(|s| s.name == shader_name) {
+                        use crate::director::chunks::w3d::types::W3dTextureLayer;
+                        while shader.texture_layers.len() < mats.len() {
+                            shader.texture_layers.push(W3dTextureLayer::default());
+                        }
+                        for (i, m) in mats.iter().enumerate() {
+                            shader.texture_layers[i].tex_transform = *m;
                         }
                     }
                 }

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -6882,16 +6882,11 @@ fn apply_point_at(
             .copied()
     };
 
-    let m = get_or_init_node_transform(player, member_ref, node_name);
+    // Ensure the node has a runtime transform entry (side effect of get_or_init).
+    let _ = get_or_init_node_transform(player, member_ref, node_name);
     // Use WORLD position for direction computation (target is in world coordinates)
     let world_pos = get_world_position(player, member_ref, node_name);
     let pos_w = [world_pos[0] as f32, world_pos[1] as f32, world_pos[2] as f32];
-    // Local position preserved for the output matrix
-    let local_pos = [
-        if m[12].is_finite() { m[12] } else { 0.0 },
-        if m[13].is_finite() { m[13] } else { 0.0 },
-        if m[14].is_finite() { m[14] } else { 0.0 },
-    ];
 
     if !tx.is_finite() || !ty.is_finite() || !tz.is_finite() { return; }
 
@@ -6931,6 +6926,37 @@ fn apply_point_at(
         if l > 1e-6 { [v[0]/l, v[1]/l, v[2]/l] } else { v }
     };
 
+    // pointAt orients the node in WORLD space, but set_node_transform stores the
+    // node's LOCAL transform (re-accumulated up the parent chain by
+    // getWorldTransform / worldPosition). Convert the world-space look-at into the
+    // parent's frame so a node with a non-identity parent — e.g. an aim/muzzle
+    // group parented to a view-rotated weapon model (Rasterwerks PlayerAimUtil) —
+    // aims correctly. For a node at the world root this is a strict no-op.
+    let parent_world = {
+        let parent_name = player.movie.cast_manager.find_member_by_ref(member_ref)
+            .and_then(|m| m.member_type.as_shockwave3d())
+            .and_then(|w| w.parsed_scene.as_ref())
+            .and_then(|s| s.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(node_name)))
+            .map(|n| n.parent_name.clone())
+            .unwrap_or_default();
+        if parent_name.is_empty() || parent_name.eq_ignore_ascii_case("World") {
+            IDENTITY
+        } else {
+            node_world_transform(player, member_ref, &parent_name)
+        }
+    };
+    let inv_parent = invert_transform_f32(&parent_world);
+    // world_mat carries the look-at rotation + the node's WORLD position; converting
+    // by inverse(parent) yields the LOCAL transform (and restores the local position,
+    // since inverse(parent)·pos_w == local_pos), so pointAt never moves the node.
+    let to_local = |world_mat: [f32; 16]| -> [f32; 16] {
+        if inv_parent.iter().all(|v| v.is_finite()) {
+            mat4_mul_f32(&inv_parent, &world_mat)
+        } else {
+            world_mat
+        }
+    };
+
     if let Some((front_axis, up_axis)) = custom_orientation {
         // Custom pointAtOrientation: map the specified local axes to world directions.
         // front_axis defines which local axis points toward the target.
@@ -6961,18 +6987,18 @@ fn apply_point_at(
             -front_sign * up_sign
         };
 
-        let mut result = [0.0f32; 16];
-        result[front_col * 4 + 0] = fwd[0] * front_sign;
-        result[front_col * 4 + 1] = fwd[1] * front_sign;
-        result[front_col * 4 + 2] = fwd[2] * front_sign;
-        result[up_col * 4 + 0] = up_world[0] * up_sign;
-        result[up_col * 4 + 1] = up_world[1] * up_sign;
-        result[up_col * 4 + 2] = up_world[2] * up_sign;
-        result[right_col * 4 + 0] = right_world[0] * right_sign;
-        result[right_col * 4 + 1] = right_world[1] * right_sign;
-        result[right_col * 4 + 2] = right_world[2] * right_sign;
-        result[12] = local_pos[0]; result[13] = local_pos[1]; result[14] = local_pos[2]; result[15] = 1.0;
-        set_node_transform(player, member_ref, node_name, result);
+        let mut world_mat = [0.0f32; 16];
+        world_mat[front_col * 4 + 0] = fwd[0] * front_sign;
+        world_mat[front_col * 4 + 1] = fwd[1] * front_sign;
+        world_mat[front_col * 4 + 2] = fwd[2] * front_sign;
+        world_mat[up_col * 4 + 0] = up_world[0] * up_sign;
+        world_mat[up_col * 4 + 1] = up_world[1] * up_sign;
+        world_mat[up_col * 4 + 2] = up_world[2] * up_sign;
+        world_mat[right_col * 4 + 0] = right_world[0] * right_sign;
+        world_mat[right_col * 4 + 1] = right_world[1] * right_sign;
+        world_mat[right_col * 4 + 2] = right_world[2] * right_sign;
+        world_mat[12] = pos_w[0]; world_mat[13] = pos_w[1]; world_mat[14] = pos_w[2]; world_mat[15] = 1.0;
+        set_node_transform(player, member_ref, node_name, to_local(world_mat));
     } else {
         // Default orientation: -Z toward target, Y up (standard look-at convention).
         // This matches the working camera behavior where cameras look along -Z.
@@ -6980,13 +7006,13 @@ fn apply_point_at(
         let right = normalize(cross(up_hint, neg_fwd));
         let up2 = normalize(cross(neg_fwd, right));
 
-        let result = [
+        let world_mat = [
             right[0],   right[1],   right[2],   0.0,
             up2[0],     up2[1],     up2[2],     0.0,
             neg_fwd[0], neg_fwd[1], neg_fwd[2], 0.0,
-            local_pos[0], local_pos[1], local_pos[2], 1.0,
+            pos_w[0],   pos_w[1],   pos_w[2],   1.0,
         ];
-        set_node_transform(player, member_ref, node_name, result);
+        set_node_transform(player, member_ref, node_name, to_local(world_mat));
     }
 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -568,7 +568,29 @@ impl Shockwave3dObjectDatumHandlers {
                             crate::director::lingo::datum::DatumType::List, items, false,
                         )))
                     },
-                    _ => Ok(player.alloc_datum(Datum::Void)),
+                    // `mesh[m].face.count` is resolved as a single compound property
+                    // "face.count" (not `.face` then `.count`), so handle it here by
+                    // reading the actual triangle count of this mesh group from the
+                    // built geometry. (`.vertexList.count` / `.normalList.count` are
+                    // handled by Lingo's list `.count` since those return real lists.)
+                    "face.count" | "facecount" | "faceCount" => {
+                        let node = scene.nodes.iter().find(|n| n.name == *model_name);
+                        let model_res_name = node.map(|n| n.model_resource_name.as_str()).unwrap_or("");
+                        let res_name = node.map(|n| n.resource_name.as_str()).unwrap_or("");
+                        let keys_to_try: Vec<&str> = [model_res_name, res_name].iter()
+                            .filter(|k| !k.is_empty() && **k != ".")
+                            .copied().collect();
+                        let count = keys_to_try.iter()
+                            .find_map(|k| scene.clod_meshes.get(*k).and_then(|ms| ms.get(mesh_idx)).map(|m| m.faces.len()))
+                            .or_else(|| keys_to_try.iter().find_map(|k| scene.raw_meshes.iter()
+                                .find(|raw| raw.name == **k && raw.chain_index as usize == mesh_idx)
+                                .map(|raw| raw.faces.len())))
+                            .unwrap_or(0);
+                        Ok(player.alloc_datum(Datum::Int(count as i32)))
+                    },
+                    _ => {
+                        Ok(player.alloc_datum(Datum::Void))
+                    },
                 })
             },
             "meshDeformTexLayer" => {
@@ -1857,8 +1879,20 @@ impl Shockwave3dObjectDatumHandlers {
                                                     let start = res.primitive_start_angle.to_radians();
                                                     let mut sweep = (res.primitive_end_angle - res.primitive_start_angle).to_radians();
                                                     if sweep <= 0.0 { sweep = 2.0 * PI; }
-                                                    let stacks = 20u32;
-                                                    let slices = ((sweep / (2.0 * PI)) * 28.0).round().max(8.0) as u32;
+                                                    // Director's #sphere tessellation vs `resolution`, dumped from real
+                                                    // Director via meshDeform across res 2..50 (verts=(stacks+1)(slices+1)):
+                                                    //   slices = resolution + 3,  stacks = round((2·res + 5) / 3).
+                                                    // When resolution is unset (0) keep the legacy default density
+                                                    // (stacks=20, slices=28 → 609 verts) that PacMan3D's spheres rely on.
+                                                    // Partial sweeps (Pacman mouth / ghost dome) scale slices by the swept
+                                                    // fraction so angular density stays constant.
+                                                    let (stacks, full_slices) = if res.primitive_resolution >= 1 {
+                                                        let rn = res.primitive_resolution;
+                                                        ((((2 * rn + 5) as f32) / 3.0).round() as u32, rn + 3)
+                                                    } else {
+                                                        (20u32, 28u32)
+                                                    };
+                                                    let slices = ((sweep / (2.0 * PI)) * full_slices as f32).round().max(3.0) as u32;
                                                     let stride = slices + 1;
                                                     let mut pos = Vec::new();
                                                     let mut nrm = Vec::new();
@@ -2269,6 +2303,53 @@ impl Shockwave3dObjectDatumHandlers {
                                     "[W3D-UV2-SET] model=\"{}\" resource={:?} mesh_idx={} layer_idx={} uv_count={} clod_key={:?} found={}",
                                     model_name, resource_name, mesh_idx, _layer_idx, uv_count, clod_key, found
                                 ));
+                            }
+                        }
+                        return Ok(());
+                    }
+                    // meshDeformMesh.vertexList / .normalList = list — deform the
+                    // mesh (Director: "get or set the list of vertices/normals used
+                    // by the specified mesh"). Write the new vectors into the model's
+                    // CLOD mesh and bump the content version so the renderer
+                    // re-uploads. Splat's pip tower hides eaten dots and the text
+                    // models deform their glyphs this way.
+                    if s3d_ref.object_type == "meshDeformMesh"
+                        && (prop_name.eq_ignore_ascii_case("vertexList")
+                            || prop_name.eq_ignore_ascii_case("normalList"))
+                    {
+                        let is_normals = prop_name.eq_ignore_ascii_case("normalList");
+                        let parts: Vec<&str> = s3d_ref.name.splitn(2, ':').collect();
+                        let model_name = parts.get(0).unwrap_or(&"").to_string();
+                        let mesh_idx: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+                        let verts: Vec<[f32; 3]> = if let Datum::List(_, items, _) = value {
+                            items.iter().map(|item_ref| match player.get_datum(item_ref) {
+                                Datum::Vector(v) => [v[0] as f32, v[1] as f32, v[2] as f32],
+                                _ => [0.0, 0.0, 0.0],
+                            }).collect()
+                        } else { vec![] };
+                        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                let key = w3d.parsed_scene.as_ref().and_then(|scene| {
+                                    let rn = scene.nodes.iter()
+                                        .find(|n| n.name.eq_ignore_ascii_case(&model_name))
+                                        .map(|n| if !n.model_resource_name.is_empty() {
+                                            n.model_resource_name.clone()
+                                        } else { n.resource_name.clone() });
+                                    rn.filter(|k| scene.clod_meshes.contains_key(k))
+                                        .or_else(|| if scene.clod_meshes.contains_key(&model_name) {
+                                            Some(model_name.clone())
+                                        } else { None })
+                                });
+                                if let (Some(key), false) = (key, verts.is_empty()) {
+                                    if let Some(scene) = w3d.scene_mut() {
+                                        if let Some(mesh) = scene.clod_meshes.get_mut(&key)
+                                            .and_then(|meshes| meshes.get_mut(mesh_idx))
+                                        {
+                                            if is_normals { mesh.normals = verts; } else { mesh.positions = verts; }
+                                            scene.mesh_content_version = scene.mesh_content_version.wrapping_add(1);
+                                        }
+                                    }
+                                }
                             }
                         }
                         return Ok(());
@@ -3046,7 +3127,8 @@ impl Shockwave3dObjectDatumHandlers {
                     if s3d_ref.object_type == "collision" && args.len() >= 2 {
                         let handler = player.get_datum(&args[0]).string_value()
                             .unwrap_or_default().trim_start_matches('#').to_string();
-                        let instance = match player.get_datum(&args[1]) {
+                        let target_datum = player.get_datum(&args[1]).clone();
+                        let instance = match &target_datum {
                             Datum::ScriptInstanceRef(r) => Some(r.clone()),
                             _ => None,
                         };
@@ -3060,6 +3142,7 @@ impl Shockwave3dObjectDatumHandlers {
                                 let cm = w3d.runtime_state.collision_modifiers.entry(key).or_default();
                                 cm.callback_handler = Some(handler);
                                 cm.callback_instance = instance;
+                                cm.callback_target = Some(target_datum);
                             }
                         }
                     }
@@ -3566,6 +3649,55 @@ impl Shockwave3dObjectDatumHandlers {
                                     }
                                 }
                             }
+                        }
+
+                        // meshDeformMesh.vertexList[idx] / .normalList[idx] = vector
+                        // — deform a single vertex/normal, persisting into the CLOD
+                        // mesh (the transient-list update below never reaches the
+                        // geometry). Splat's pip tower hides eaten dots by setting
+                        // their verts to vector(0,1000,0).
+                        if s3d_ref.object_type == "meshDeformMesh"
+                            && (prop.eq_ignore_ascii_case("vertexList") || prop.eq_ignore_ascii_case("normalList"))
+                        {
+                            let is_normals = prop.eq_ignore_ascii_case("normalList");
+                            let v = match &value_datum {
+                                Datum::Vector(vec) => [vec[0] as f32, vec[1] as f32, vec[2] as f32],
+                                _ => [0.0, 0.0, 0.0],
+                            };
+                            let parts: Vec<&str> = s3d_ref.name.splitn(2, ':').collect();
+                            let model_name = parts.get(0).unwrap_or(&"").to_string();
+                            let mesh_idx: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+                            let vidx = (index as usize).saturating_sub(1);
+                            let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
+                            if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                                if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                                    let key = w3d.parsed_scene.as_ref().and_then(|scene| {
+                                        let rn = scene.nodes.iter()
+                                            .find(|n| n.name.eq_ignore_ascii_case(&model_name))
+                                            .map(|n| if !n.model_resource_name.is_empty() {
+                                                n.model_resource_name.clone()
+                                            } else { n.resource_name.clone() });
+                                        rn.filter(|k| scene.clod_meshes.contains_key(k))
+                                            .or_else(|| if scene.clod_meshes.contains_key(&model_name) {
+                                                Some(model_name.clone())
+                                            } else { None })
+                                    });
+                                    if let Some(key) = key {
+                                        if let Some(scene) = w3d.scene_mut() {
+                                            if let Some(mesh) = scene.clod_meshes.get_mut(&key)
+                                                .and_then(|m| m.get_mut(mesh_idx))
+                                            {
+                                                let target = if is_normals { &mut mesh.normals } else { &mut mesh.positions };
+                                                if vidx < target.len() {
+                                                    target[vidx] = v;
+                                                    scene.mesh_content_version = scene.mesh_content_version.wrapping_add(1);
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            return Ok(player.alloc_datum(Datum::Void));
                         }
 
                         // Also update the transient list
@@ -4326,6 +4458,7 @@ impl Shockwave3dObjectDatumHandlers {
                                         }
                                     }
                                 }
+
                                 Some(player.alloc_datum(Datum::Void))
                             }
                             // camera.overlay[n] / camera.backdrop[n] — indexed overlay access.
@@ -4575,6 +4708,54 @@ impl Shockwave3dObjectDatumHandlers {
                                 }
                                 count
                             }
+                            "face" => {
+                                // meshDeformMesh.face.count — triangle count of this mesh
+                                // group. Compiled as the `count(obj, #face)` builtin (objcall),
+                                // NOT a property getter, so it must be resolved here. Mirrors
+                                // the vertexList case but reads `faces`. Without this,
+                                // `mesh[m].face.count` returned 0 (newMesh-from-primitive code
+                                // like Splat's pip tower then built an empty mesh → crash).
+                                let parts: Vec<&str> = s3d_ref.name.splitn(2, ':').collect();
+                                let mdl_name = parts.get(0).unwrap_or(&"").to_string();
+                                let m_idx: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+                                let node = scene.nodes.iter().find(|n| n.name == *mdl_name);
+                                let model_res = node.map(|n| n.model_resource_name.as_str()).unwrap_or("");
+                                let res = node.map(|n| n.resource_name.as_str()).unwrap_or("");
+                                let keys: Vec<&str> = [model_res, res].iter()
+                                    .filter(|k| !k.is_empty() && **k != ".")
+                                    .copied().collect();
+                                let mut count = 0usize;
+                                for key in &keys {
+                                    if let Some(meshes) = scene.clod_meshes.get(*key) {
+                                        if let Some(mesh) = meshes.get(m_idx) {
+                                            count = mesh.faces.len();
+                                        }
+                                        break;
+                                    }
+                                }
+                                if count == 0 {
+                                    for key in &keys {
+                                        for raw in &scene.raw_meshes {
+                                            if raw.name == *key && raw.chain_index as usize == m_idx {
+                                                count = raw.faces.len();
+                                                break;
+                                            }
+                                        }
+                                        if count > 0 { break; }
+                                    }
+                                }
+                                if count == 0 {
+                                    for key in &keys {
+                                        if let Some(res_info) = scene.model_resources.get(*key) {
+                                            if let Some(info) = res_info.mesh_infos.get(m_idx) {
+                                                count = info.num_faces as usize;
+                                            }
+                                            break;
+                                        }
+                                    }
+                                }
+                                count
+                            }
                             "child" => {
                                 scene.nodes.iter().filter(|n| n.parent_name.eq_ignore_ascii_case(&s3d_ref.name)).count()
                             }
@@ -4728,6 +4909,7 @@ impl Shockwave3dObjectDatumHandlers {
                             .and_then(|w3d| w3d.runtime_state.shader_texture_lists.get(&face_key))
                             .cloned()
                     };
+                    let dbg_had_face_list = face_list_ref.is_some();
 
                     // 2. Read build data (vertexList, textureCoordinateList, etc.)
                     let build_data = {
@@ -4758,7 +4940,13 @@ impl Shockwave3dObjectDatumHandlers {
 
                                     for (k_ref, v_ref) in &props {
                                         let key = player.get_datum(k_ref).string_value().unwrap_or_default();
-                                        match key.as_str() {
+                                        // Director is case-insensitive and accepts the abbreviated
+                                        // `texCoords` (what Splat's spike build uses) as well as the
+                                        // full `textureCoordinates`. Match lowercase so the authored
+                                        // per-face texcoord indices are actually read (otherwise every
+                                        // face defaults to index 0 → all-identical UVs → the GPU
+                                        // upload's all_same check regenerates positional UVs).
+                                        match key.to_ascii_lowercase().as_str() {
                                             "shader" => {
                                                 match player.get_datum(v_ref) {
                                                     Datum::Shockwave3dObjectRef(r) => shader_name = r.name.clone(),
@@ -4773,11 +4961,17 @@ impl Shockwave3dObjectDatumHandlers {
                                                     }
                                                 }
                                             }
-                                            "textureCoordinates" => {
+                                            "texturecoordinates" | "texcoords" => {
                                                 if let Datum::List(_, items, _) = player.get_datum(v_ref) {
-                                                    for (i, item) in items.iter().enumerate().take(3) {
-                                                        let idx = player.get_datum(item).int_value().unwrap_or(1);
-                                                        tcs[i] = (idx.max(1) - 1) as u32; // 1-based → 0-based
+                                                    // Only overwrite when this key actually carries data —
+                                                    // the proplist holds BOTH an empty "textureCoordinates"
+                                                    // (initial) and the authored "texCoords"; the empty one
+                                                    // must not clobber the real indices.
+                                                    if !items.is_empty() {
+                                                        for (i, item) in items.iter().enumerate().take(3) {
+                                                            let idx = player.get_datum(item).int_value().unwrap_or(1);
+                                                            tcs[i] = (idx.max(1) - 1) as u32; // 1-based → 0-based
+                                                        }
                                                     }
                                                 }
                                             }
@@ -4790,6 +4984,7 @@ impl Shockwave3dObjectDatumHandlers {
                         }
                     }
 
+                    let _ = dbg_had_face_list;
                     if faces.is_empty() || build_data.vertex_list.is_empty() {
                         return Ok(player.alloc_datum(Datum::Void));
                     }
@@ -4800,12 +4995,16 @@ impl Shockwave3dObjectDatumHandlers {
                         shader_groups.entry(f.shader_name.clone()).or_default().push(i);
                     }
 
-                    // 5. Build ClodDecodedMesh per shader group
+                    // 5. Build ClodDecodedMesh per shader group. Track the group's
+                    // shader name in lock-step with `meshes` so mesh_infos /
+                    // shaderList / meshDeform.mesh[i] all index the same group.
                     use crate::director::chunks::w3d::types::ClodDecodedMesh;
                     let mut meshes: Vec<ClodDecodedMesh> = Vec::new();
+                    let mut group_names: Vec<String> = Vec::new();
                     let gen_normals = build_data.generate_normals_style;
 
-                    for (_shader_name, face_indices) in &shader_groups {
+                    for (shader_name, face_indices) in &shader_groups {
+                        group_names.push(shader_name.clone());
                         // Collect unique vertex indices used by this group
                         let mut vert_map: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
                         let mut positions: Vec<[f32; 3]> = Vec::new();
@@ -4893,6 +5092,16 @@ impl Shockwave3dObjectDatumHandlers {
                             }
                         }
 
+                        // newMesh UVs are authored in Director's standard [0,1] space; the 3D
+                        // vertex shader applies the CLOD remap (u+0.5, 0.5-v) which expects
+                        // pre-centered [-0.5,0.5] UVs. Pre-center so the remap yields (u, 1-v):
+                        // u-0.5 cancels the +0.5; the bare -0.5 leaves the shader's 0.5-v as a net
+                        // V flip (Director image v=0=top → our GL texture v=0=bottom). For Splat's
+                        // spikes this puts the texture's colored band (image bottom 35%) on the
+                        // spike TIPS (texcoord v≈0.01 at the apex) and the black band on the
+                        // base/core — Director's "black body, colored spike tips". Uniform
+                        // textures (the maze) are unaffected by the flip.
+                        for uv in tex_coords.iter_mut() { uv[0] -= 0.5; uv[1] -= 0.5; }
                         meshes.push(ClodDecodedMesh {
                             name: res_name.clone(),
                             positions,
@@ -4910,13 +5119,22 @@ impl Shockwave3dObjectDatumHandlers {
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
                             if let Some(scene) = w3d.scene_mut() {
-                                // Update model resource info
+                                // Update model resource info. Director exposes ONE
+                                // mesh per shader group (meshDeform.mesh.count ==
+                                // groups, shaderList[i] ↔ mesh[i]), so rebuild
+                                // mesh_infos with one entry per built mesh (was a
+                                // single entry, which made meshDeform.mesh.count
+                                // collapse to 1 and broke per-group deformation /
+                                // shader mapping — e.g. Splat's pip tower).
                                 if let Some(res_info) = scene.model_resources.get_mut(&res_name) {
-                                    let total_faces: u32 = meshes.iter().map(|m| m.faces.len() as u32).sum();
-                                    if !res_info.mesh_infos.is_empty() {
-                                        res_info.mesh_infos[0].num_faces = total_faces;
-                                    }
-                                    // Add shader bindings from face data
+                                    let template = res_info.mesh_infos.get(0).cloned().unwrap_or_default();
+                                    res_info.mesh_infos = meshes.iter().map(|m| {
+                                        let mut mi = template.clone();
+                                        mi.num_faces = m.faces.len() as u32;
+                                        mi.num_vertices = m.positions.len() as u32;
+                                        mi
+                                    }).collect();
+                                    // shader bindings, aligned 1:1 with `meshes` via group_names.
                                     res_info.shader_bindings.clear();
                                     let shader_names: Vec<String> = shader_groups.keys().cloned().collect();
                                     let mesh_bindings: Vec<String> = shader_names.iter().cloned().collect();
@@ -6105,6 +6323,7 @@ impl Shockwave3dObjectDatumHandlers {
                         let nv = player.alloc_datum(Datum::List(crate::director::lingo::datum::DatumType::List, VecDeque::new(), false));
                         items.push_back(player.alloc_datum(Datum::PropList(VecDeque::from(vec![(sk, sv), (vk, vv), (tk, tv), (ck, cv), (nk, nv)]), false)));
                     }
+                    let item_count = items.len();
                     let list_ref = player.alloc_datum(Datum::List(
                         crate::director::lingo::datum::DatumType::List, items, false,
                     ));
@@ -6114,6 +6333,7 @@ impl Shockwave3dObjectDatumHandlers {
                             w3d.runtime_state.shader_texture_lists.insert(face_key_owned, list_ref.clone());
                         }
                     }
+                    let _ = item_count;
                     Ok(list_ref)
                 }
             },
@@ -6752,7 +6972,8 @@ pub fn sync_persistent_transforms(player: &mut crate::player::DirPlayer) {
     }
 
     for (cast_lib, cast_member, node_name, datum_ref) in entries {
-        if !dirty_ids.contains(&datum_ref.unwrap()) { continue; } // Only sync dirty datums
+        let is_dirty = dirty_ids.contains(&datum_ref.unwrap());
+        if !is_dirty { continue; } // Only sync dirty datums
         if let Datum::Transform3d(m64) = player.get_datum(&datum_ref) {
             let m32: [f32; 16] = m64.map(|v| v as f32);
             if m32.iter().any(|v| !v.is_finite()) { continue; }

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -1994,7 +1994,14 @@ impl Shockwave3dObjectDatumHandlers {
                                                     // renders the trough two-sided (wood inside). Emit reversed faces
                                                     // for the wall + caps when sectioned so the interior is solid. A
                                                     // full cylinder (Coke can / Pacman pipe) stays single-sided.
-                                                    let two_sided = sweep < (2.0 * PI - 1e-3);
+                                                    // A sectioned cylinder (open trough) is two-sided, AND a
+                                                    // resource authored #back/#both (skybox cylinder viewed from
+                                                    // inside) must render its inward surface — otherwise the full
+                                                    // cylinder is single-sided outward and the inside is culled
+                                                    // to black. SweeTarts' skybox is newModelResource(#cylinder,#back).
+                                                    let facing = res.primitive_facing.as_str();
+                                                    let two_sided = sweep < (2.0 * PI - 1e-3)
+                                                        || facing == "back" || facing == "both";
                                                     // Director's #cylinder is THREE mesh groups: side wall, top cap,
                                                     // bottom cap — so shaderList[1]/[2]/[3] can each differ (the Coke
                                                     // can is the cokeT label on the side and silver canTop on the
@@ -2399,7 +2406,21 @@ impl Shockwave3dObjectDatumHandlers {
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "scale" => {
-                    let (sx, sy, sz) = read_xyz_args(player, args);
+                    // Director's model.scale() takes EITHER a single uniform factor
+                    // (`scale(9)` → 9,9,9), a vector, or three components. read_xyz_args
+                    // only handles the vector / 3-arg forms (a lone scalar fell through
+                    // to 0,0,0, collapsing the model — SweeTarts candies/snake vanished).
+                    let (sx, sy, sz) = if args.len() == 1 {
+                        match player.get_datum(&args[0]) {
+                            Datum::Vector(v) => (v[0] as f32, v[1] as f32, v[2] as f32),
+                            other => {
+                                let f = other.float_value().unwrap_or(1.0) as f32;
+                                (f, f, f)
+                            }
+                        }
+                    } else {
+                        read_xyz_args(player, args)
+                    };
                     apply_scale(player, &member_ref, &s3d_ref.name, sx, sy, sz);
                     Ok(player.alloc_datum(Datum::Void))
                 },
@@ -5310,7 +5331,22 @@ impl Shockwave3dObjectDatumHandlers {
             },
             "parent" => {
                 if let Some(n) = node {
-                    Ok(player.alloc_datum(Datum::String(n.parent_name.clone())))
+                    // A model removed from the world (removeFromWorld) keeps its
+                    // scene node + parent_name (so addToWorld can re-link it), but
+                    // Director reports `model.parent` as VOID while it's detached.
+                    // Without this, `voidp(model.parent)` stays false and callers
+                    // that gate on it loop forever — SweeTarts' collectobjects
+                    // re-collects a removeFromWorld'd number candy every frame.
+                    let detached = player.movie.cast_manager.find_member_by_ref(member_ref)
+                        .and_then(|m| m.member_type.as_shockwave3d())
+                        .map(|w3d| w3d.runtime_state.detached_nodes.iter()
+                            .any(|d| d.eq_ignore_ascii_case(&n.name)))
+                        .unwrap_or(false);
+                    if detached {
+                        Ok(player.alloc_datum(Datum::Void))
+                    } else {
+                        Ok(player.alloc_datum(Datum::String(n.parent_name.clone())))
+                    }
                 } else {
                     Ok(player.alloc_datum(Datum::Void))
                 }
@@ -6214,10 +6250,20 @@ impl Shockwave3dObjectDatumHandlers {
         match_ci!(prop, {
             "name" => Ok(player.alloc_datum(Datum::String(node_name.to_string()))),
             "parent" => {
-                let parent = scene.nodes.iter().find(|n| n.name == node_name)
-                    .map(|n| n.parent_name.clone())
-                    .unwrap_or_default();
-                Ok(player.alloc_datum(Datum::String(parent)))
+                // VOID while detached (removeFromWorld) — see get_model_prop.
+                let detached = player.movie.cast_manager.find_member_by_ref(member_ref)
+                    .and_then(|m| m.member_type.as_shockwave3d())
+                    .map(|w3d| w3d.runtime_state.detached_nodes.iter()
+                        .any(|d| d.eq_ignore_ascii_case(node_name)))
+                    .unwrap_or(false);
+                if detached {
+                    Ok(player.alloc_datum(Datum::Void))
+                } else {
+                    let parent = scene.nodes.iter().find(|n| n.name == node_name)
+                        .map(|n| n.parent_name.clone())
+                        .unwrap_or_default();
+                    Ok(player.alloc_datum(Datum::String(parent)))
+                }
             },
             "transform" => {
                 Ok(get_persistent_node_transform(player, member_ref, node_name))

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -2414,23 +2414,19 @@ impl Shockwave3dObjectDatumHandlers {
                                 }
                                 // else: #synchronized — keep current relative position
                             } else {
-                                // No args. Director docs (§Methods, play()):
-                                // resumes a paused motion. But if nothing is current
-                                // and playList[1] is queued, Director's playList
-                                // semantics implicitly treat playList[1] as the
-                                // active motion (queue() into an empty list begins
-                                // playback). ClubMarian + Coke Studios both rely on
-                                //   bonesPlayer.queue(name, ...) ; bonesPlayer.play()
-                                // — without this branch, current_motion stayed None
-                                // and the renderer evaluated no tracks (avatar T-pose).
-                                // We READ queue[0] but do NOT pop — Director's
-                                // playList includes the current motion at index 1,
-                                // and the script's `if playList.count < 1` gate
-                                // assumes that. Popping would make the script
-                                // re-queue every frame.
+                                // No args: Director's play() resumes a paused motion.
+                                // If nothing is current but a motion is queued (the
+                                // ClubMarian / Coke Studios pattern `queue(name); play()`),
+                                // PROMOTE queue[0] to the current motion. dirplayer models
+                                // the playList as `[current_motion] ++ motion_queue`, so we
+                                // POP queue[0] when promoting (otherwise the playList getter,
+                                // which prepends current_motion, would show it twice). The
+                                // script's `if playList.count < 1` gate still sees count 1
+                                // (the now-current motion), so it does not re-queue.
                                 if w3d.runtime_state.current_motion.is_some() {
                                     w3d.runtime_state.animation_playing = true;
-                                } else if let Some(q) = w3d.runtime_state.motion_queue.first().cloned() {
+                                } else if !w3d.runtime_state.motion_queue.is_empty() {
+                                    let q = w3d.runtime_state.motion_queue.remove(0);
                                     w3d.runtime_state.current_motion = Some(q.name);
                                     w3d.runtime_state.animation_playing = true;
                                     w3d.runtime_state.animation_loop = q.looped;
@@ -2447,7 +2443,8 @@ impl Shockwave3dObjectDatumHandlers {
                     }
                     Ok(player.alloc_datum(Datum::Void))
                 },
-                "playNext" | "queue" => {
+                "queue" => {
+                    // queue(name,...) — add the motion to the END of the playList.
                     if !args.is_empty() {
                         let motion_name = player.get_datum(&args[0]).string_value().unwrap_or_default();
                         let is_loop = args.get(1).map(|a| player.get_datum(a).int_value().unwrap_or(0) != 0).unwrap_or(false);
@@ -2471,20 +2468,62 @@ impl Shockwave3dObjectDatumHandlers {
                         };
                         if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                             if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                                if handler_name.eq_ignore_ascii_case("playNext") {
-                                    w3d.runtime_state.motion_queue.insert(0, queued);
-                                } else {
-                                    w3d.runtime_state.motion_queue.push(queued);
-                                }
+                                w3d.runtime_state.motion_queue.push(queued);
+                            }
+                        }
+                    }
+                    Ok(player.alloc_datum(Datum::Void))
+                },
+                "playNext" => {
+                    // playNext() — Director: interrupt and REMOVE the currently playing
+                    // motion (playList[1]) and begin the next one (playList[2]). dirplayer's
+                    // playList is `[current_motion] ++ motion_queue`, so drop current_motion
+                    // and promote motion_queue[0]. (Was previously a no-op for the no-arg
+                    // form, so scripts that do `queue(x); playNext()` — e.g. Rasterwerks
+                    // C_BonesControl — never drained the queue; it accumulated until
+                    // TrimPlayList()/removeLast() deleted the pile.)
+                    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                        if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                            let rs = &mut w3d.runtime_state;
+                            // Blend out of the interrupted motion if autoBlend/blendTime set.
+                            if rs.current_motion.is_some() && rs.animation_blend_time > 0.0 {
+                                rs.previous_motion = rs.current_motion.clone();
+                                rs.blend_duration = rs.animation_blend_time / 1000.0;
+                                rs.blend_elapsed = 0.0;
+                                rs.blend_weight = 0.0;
+                            } else {
+                                rs.previous_motion = None;
+                                rs.blend_weight = 1.0;
+                            }
+                            if !rs.motion_queue.is_empty() {
+                                let q = rs.motion_queue.remove(0);
+                                rs.current_motion = Some(q.name);
+                                rs.animation_loop = q.looped;
+                                rs.animation_start_time = q.start_time;
+                                rs.animation_end_time = q.end_time;
+                                rs.animation_scale = q.scale;
+                                rs.animation_time = if q.offset >= 0.0 { q.offset } else { q.start_time };
+                                rs.animation_playing = true;
+                                rs.motion_ended = false;
+                            } else {
+                                // Nothing left to play.
+                                rs.current_motion = None;
+                                rs.animation_playing = false;
                             }
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "removeLast" => {
+                    // removeLast() — remove the LAST entry of the playList. The playList is
+                    // `[current_motion] ++ motion_queue`, so drop the queue's tail; if the
+                    // queue is empty the last (and only) entry is the current motion itself.
                     if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            w3d.runtime_state.motion_queue.pop();
+                            if w3d.runtime_state.motion_queue.pop().is_none() {
+                                w3d.runtime_state.current_motion = None;
+                                w3d.runtime_state.animation_playing = false;
+                            }
                         }
                     }
                     Ok(player.alloc_datum(Datum::Void))
@@ -4387,9 +4426,14 @@ impl Shockwave3dObjectDatumHandlers {
                             "motion" => scene.motions.len(),
                             "modelResource" => scene.model_resources.len(),
                             "playList" => {
+                                // Director's playList includes the currently playing motion
+                                // as entry [1], then the queued motions.
                                 let member = player.movie.cast_manager.find_member_by_ref(&member_ref);
                                 member.and_then(|m| m.member_type.as_shockwave3d())
-                                    .map(|w3d| w3d.runtime_state.motion_queue.len())
+                                    .map(|w3d| {
+                                        (if w3d.runtime_state.current_motion.is_some() { 1 } else { 0 })
+                                            + w3d.runtime_state.motion_queue.len()
+                                    })
                                     .unwrap_or(0)
                             }
                             "overlay" | "backdrop" => {
@@ -5217,10 +5261,29 @@ impl Shockwave3dObjectDatumHandlers {
                 )))
             },
             "playList" => {
-                // bonesPlayer.playList — list of queued motions as property lists
+                // bonesPlayer.playList — list of motions as property lists. Director's
+                // playList includes the CURRENTLY PLAYING motion as entry [1], then the
+                // queued motions. dirplayer stores current_motion separately from
+                // motion_queue, so prepend it here so playList[1] is the active motion
+                // (the C_BonesControl `playList[1].name` / `.count` checks rely on this).
                 let queue = player.movie.cast_manager.find_member_by_ref(member_ref)
                     .and_then(|m| m.member_type.as_shockwave3d())
-                    .map(|w3d| w3d.runtime_state.motion_queue.clone())
+                    .map(|w3d| {
+                        let rs = &w3d.runtime_state;
+                        let mut list: Vec<crate::player::cast_member::QueuedMotion> = Vec::new();
+                        if let Some(ref name) = rs.current_motion {
+                            list.push(crate::player::cast_member::QueuedMotion {
+                                name: name.clone(),
+                                looped: rs.animation_loop,
+                                start_time: rs.animation_start_time,
+                                end_time: rs.animation_end_time,
+                                scale: rs.animation_scale,
+                                offset: rs.animation_time,
+                            });
+                        }
+                        list.extend(rs.motion_queue.iter().cloned());
+                        list
+                    })
                     .unwrap_or_default();
                 let mut items: VecDeque<DatumRef> = VecDeque::new();
                 for qm in &queue {

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -1207,6 +1207,51 @@ impl SoundChannel {
         None
     }
 
+    /// True when MP3 frames chain cleanly from offset 0 across (almost) the whole
+    /// buffer with a constant MPEG version / layer / sample-rate. Tells a real MP3
+    /// stream apart from raw PCM that merely contains a stray frame sync — genuine
+    /// PCM won't chain frame-to-frame all the way to the end. This recovers an MP3
+    /// that was mislabeled `raw_pcm` with a sampleCount set to dataSize/2 (so the
+    /// size heuristic alone wrongly concludes "PCM").
+    fn mp3_chain_spans_buffer(data: &[u8]) -> bool {
+        let mut offset = 0usize;
+        let mut frames = 0usize;
+        let mut vlr: Option<(u32, u32, u32)> = None;
+        while offset + 4 <= data.len() {
+            if data[offset] != 0xFF || (data[offset + 1] & 0xE0) != 0xE0 {
+                break;
+            }
+            let header = u32::from_be_bytes([
+                data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
+            ]);
+            let version = (header >> 19) & 0x3;
+            let layer = (header >> 17) & 0x3;
+            let bitrate_index = (header >> 12) & 0xF;
+            let sample_rate_index = (header >> 10) & 0x3;
+            if version == 1 || layer == 0 || bitrate_index == 0xF
+                || bitrate_index == 0 || sample_rate_index == 3
+            {
+                break;
+            }
+            // A real stream keeps version/layer/sample-rate constant (only the
+            // bitrate may vary for VBR).
+            match vlr {
+                None => vlr = Some((version, layer, sample_rate_index)),
+                Some(prev) if prev != (version, layer, sample_rate_index) => break,
+                _ => {}
+            }
+            let frame_size = Self::calculate_mp3_frame_size(header);
+            if frame_size == 0 || frame_size > 4096 {
+                break;
+            }
+            offset += frame_size;
+            frames += 1;
+        }
+        // Require several chained frames AND that they consumed nearly the whole
+        // buffer (Director may truncate the final frame in storage).
+        frames >= 3 && offset >= data.len().saturating_mul(9) / 10
+    }
+
     /// Validate multiple consecutive MP3 frames
     fn validate_mp3_sequence(data: &[u8], min_frames: usize) -> Option<bool> {
         let mut offset = 0;
@@ -1308,11 +1353,21 @@ impl SoundChannel {
         }
         
         let frame_size = if layer == 3 {
+            // Layer I: 384 samples/frame.
             ((12 * bitrate * 1000 / sample_rate) + padding) * 4
+        } else if layer == 1 && version != 3 {
+            // Layer III on MPEG-2 / MPEG-2.5: 576 samples/frame, NOT 1152. Using
+            // 144 here computes double the real frame length, so frame chaining
+            // overshoots the next sync and the detector re-locks further in —
+            // feeding the decoder a stream that starts mid-first-frame, so a
+            // 22 kHz / 16 kHz MP3 SFX drops its opening frame and sounds wrong.
+            // (version: 0 = MPEG-2.5, 2 = MPEG-2, 3 = MPEG-1.)
+            (72 * bitrate * 1000 / sample_rate) + padding
         } else {
+            // Layer II (all versions), or Layer III on MPEG-1: 1152 samples/frame.
             (144 * bitrate * 1000 / sample_rate) + padding
         };
-        
+
         frame_size as usize
     }
 
@@ -2422,8 +2477,54 @@ impl SoundChannel {
             ch.loop_count
         };
 
+        // Shockwave Audio (SWA) sounds are MP3 internally, but the Director snd
+        // header declares the true decoded length. Such sounds get mislabeled
+        // `raw_pcm` here (their MP3 stream starts a few bytes in, so the
+        // at-offset-0 sniff misses it), which leaves a NON-zero `sample_count`
+        // equal to that authoritative length. The MP3 always decodes to a
+        // frame-aligned length >= the real one, so playing it in full runs long
+        // with a garbage tail (the 'doteat' SFX: 88 ms declared, ~0.34 s
+        // decoded). Trim playback to the declared length to match Director.
+        // Genuine MP3 files are detected as MP3 with `sample_count == 0`, so this
+        // never truncates real music.
+        let declared_dur = {
+            let sc = sound_member.info.sample_count;
+            let sr = sound_member.info.sample_rate;
+            // A sample_count of 0 or 1 is Director's PLACEHOLDER for a compressed
+            // sound whose true decoded length it never recorded (e.g. Rasterwerks
+            // SFX carry sample_count=1). That is NOT a real length — deriving a
+            // duration from it would clamp a full sound to ~0s of silence. Only a
+            // genuine declared count (> 1, from a real snd header like 'doteat's
+            // 1936) yields a trim length.
+            if sc > 1 && sr > 0 { sc as f64 / sr as f64 } else { 0.0 }
+        };
+        let buffer_dur = if final_buffer.sample_rate() > 0.0 {
+            final_buffer.length() as f64 / final_buffer.sample_rate() as f64
+        } else {
+            0.0
+        };
+        // Require a plausible real duration (>= 10 ms) AND that the decode is
+        // meaningfully longer than declared. Never extends, never truncates a
+        // correctly-sized sound, and never fires on placeholder-length sounds.
+        let trim_dur = if declared_dur >= 0.010 && declared_dur + 0.005 < buffer_dur {
+            console::log_1(
+                &format!(
+                    "✂️ Trimming SWA/MP3 to declared {:.3}s (decoded {:.3}s)",
+                    declared_dur, buffer_dur
+                )
+                .into(),
+            );
+            Some(declared_dur)
+        } else {
+            None
+        };
+
         if loop_count == 0 {
             source.set_loop(true);
+            // Loop the trimmed region, not the padded tail.
+            if let Some(d) = trim_dur {
+                source.set_loop_end(d);
+            }
             debug!("🔁 Enabled native WebAudio looping (loop_count=0)");
         } else {
             source.set_loop(false);
@@ -2466,8 +2567,17 @@ impl SoundChannel {
         let _ = source.add_event_listener_with_callback("ended", closure.as_ref().unchecked_ref());
         closure.forget();
 
-        // Start playback
-        source.start()?;
+        // Start playback. For a one-shot SWA/MP3 with a declared length, play
+        // only that grain duration so the padded MP3 tail is never heard; for a
+        // looping one the loopEnd above already bounds it, so start normally.
+        match trim_dur {
+            Some(d) if loop_count != 0 => {
+                source.start_with_when_and_grain_offset_and_grain_duration(0.0, 0.0, d)?;
+            }
+            _ => {
+                source.start()?;
+            }
+        }
         debug!("▶️ MP3 source.start() called");
 
         // Store nodes in channel state AFTER starting (only once!)
@@ -3062,7 +3172,10 @@ impl SoundChannel {
         let data_likely_pcm = expected_pcm_size.map_or(false, |expected| {
             data.len() >= expected * 4 / 5 && data.len() <= expected.saturating_mul(2)
         });
-        let is_mp3 = if data_likely_pcm { false } else { Self::find_mp3_start(data).is_some() };
+        let is_mp3 = match Self::find_mp3_start(data) {
+            Some(start) => !data_likely_pcm || Self::mp3_chain_spans_buffer(&data[start..]),
+            None => false,
+        };
         let is_probably_adpcm = !is_mp3 && codec.contains("ima");
         // Only use byte-distribution heuristic when bits_per_sample is unknown (0).
         // When metadata explicitly says 16-bit, trust it — the heuristic can false-positive
@@ -3308,10 +3421,19 @@ impl SoundChannel {
         let data_likely_pcm = expected_pcm_size.map_or(false, |expected| {
             sound_bytes.len() >= expected * 4 / 5 && sound_bytes.len() <= expected.saturating_mul(2)
         });
-        let mp3_start = if data_likely_pcm {
-            None
-        } else {
-            Self::find_mp3_start(sound_bytes)
+        // A real MP3 can be mislabeled `raw_pcm` with sampleCount == dataSize/2,
+        // so the size heuristic alone says "PCM" (e.g. the 'doteat' SFX: 4324
+        // bytes == 2162 16-bit samples, yet the bytes are a 48 kbps / 16 kHz
+        // MPEG-2 Layer III stream starting 4 bytes in). Only trust the PCM size
+        // match when the bytes do NOT chain as MP3 frames across the whole buffer.
+        let mp3_start = match Self::find_mp3_start(sound_bytes) {
+            Some(start)
+                if !data_likely_pcm
+                    || Self::mp3_chain_spans_buffer(&sound_bytes[start..]) =>
+            {
+                Some(start)
+            }
+            _ => None,
         };
 
         if let Some(mp3_start) = mp3_start {

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -1820,6 +1820,16 @@ impl SoundChannel {
                 this.sample_rate = sound_member.info.sample_rate;
                 this.sample_count = sound_member.info.sample_count;
                 this.channel_count = sound_member.info.channels;
+                // Mark the channel busy SYNCHRONOUSLY so `soundBusy(channel)`
+                // returns true on the very next frame. The decode/resample runs
+                // in a spawn_local task that only flips status to Loading AFTER
+                // the current Lingo dispatch returns — leaving a 1-frame Idle
+                // window in which Storyscramble's soundQueue.checkPlayList
+                // (`pPlaying and not soundBusy(ch)`) advanced past this sound and
+                // dropped it (the "read it" sequence skipped tile 1's audio, only
+                // playing 2-3). The async task / error paths below take over the
+                // Loading → Playing/Idle transitions from here.
+                this.status = SoundStatus::Loading;
             }
             // Stash sound_member + cue cursor are set further below, inside
             // the async resampling completion block — at the exact moment we

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -18,7 +18,6 @@ use std::convert::TryInto;
 use wasm_bindgen::prelude::*;
 
 use wasm_bindgen::JsValue;
-use web_sys::console;
 
 use crate::player::cast_member::SoundMember;
 use binary_reader::BinaryReader;
@@ -414,13 +413,10 @@ impl SoundChannelDatumHandlers {
         let channel = Self::get_sound_channel_mut(player, datum)?;
         let mut ch = channel.borrow_mut();
 
-        console::log_1(
-            &format!(
-                "🎬 handle_play() - Channel {} has {} items in playlist",
-                ch.channel_num,
-                ch.playlist_segments.len()
-            )
-            .into(),
+        debug!(
+            "🎬 handle_play() - Channel {} has {} items in playlist",
+            ch.channel_num,
+            ch.playlist_segments.len()
         );
 
         ch.stop_playback_nodes();
@@ -569,8 +565,6 @@ impl SoundChannelDatumHandlers {
         datum: &DatumRef,
         list_ref: &DatumRef,
     ) -> Result<DatumRef, ScriptError> {
-        use web_sys::console;
-
         // Convert Lingo list or proplist
         let list_datum = player.get_datum(list_ref);
         let lingo_list = match list_datum {
@@ -659,10 +653,7 @@ impl SoundChannelDatumHandlers {
 
                     // ⚠️ loopCount negative (invalid)
                     (Some(_), loop_count) if loop_count < 0 => {
-                        console::log_1(
-                            &format!("  ⚠️ Skipped: invalid negative loopCount ({})", loop_count)
-                                .into(),
-                        );
+                        debug!("  ⚠️ Skipped: invalid negative loopCount ({})", loop_count);
                     }
 
                     // ⚠️ missing member entirely
@@ -672,9 +663,7 @@ impl SoundChannelDatumHandlers {
 
                     // 🧩 fallback (compiler exhaustiveness guard)
                     _ => {
-                        console::log_1(
-                            &"  ⚠️ Unexpected combination of properties — skipped".into(),
-                        );
+                        debug!("  ⚠️ Unexpected combination of properties — skipped");
                     }
                 }
             } else {
@@ -1000,7 +989,7 @@ impl WebAudioBackend {
     pub fn new() -> Result<Self, String> {
         let context = getAudioContext();
 
-        console::log_1(&JsValue::from_str("🎵 AudioContext created"));
+        debug!("🎵 AudioContext created");
 
         Ok(Self { context })
     }
@@ -1008,7 +997,7 @@ impl WebAudioBackend {
     pub fn resume_context(&self) -> Result<(), String> {
         // Resume context (required for autoplay policy)
         // The resume() call will handle suspended state internally
-        console::log_1(&JsValue::from_str("▶️ Resuming AudioContext..."));
+        debug!("▶️ Resuming AudioContext...");
         self.context
             .resume()
             .map_err(|e| format!("Failed to resume context: {:?}", e))?;
@@ -1016,9 +1005,7 @@ impl WebAudioBackend {
     }
 
     pub fn resume_sound(&mut self) {
-        console::log_1(&JsValue::from_str(
-            "▶️ resume_sound Resuming AudioContext...",
-        ));
+        debug!("▶️ resume_sound Resuming AudioContext...");
         let _ = self.context.resume();
     }
 }
@@ -1176,10 +1163,10 @@ impl SoundChannel {
         
         // Skip if data is suspiciously small
         if data.len() < MIN_MP3_SIZE {
-            console::log_1(&format!(
+            debug!(
                 "⚠️ Data too small for MP3 ({} bytes < {} min)",
                 data.len(), MIN_MP3_SIZE
-            ).into());
+            );
             return None;
         }
         
@@ -1195,10 +1182,10 @@ impl SoundChannel {
                 
                 if let Some(valid) = Self::validate_mp3_sequence(&data[i..], MIN_FRAMES_TO_VALIDATE) {
                     if valid {
-                        console::log_1(&format!(
+                        debug!(
                             "✅ Valid MP3 sequence found at offset {} ({} bytes remaining, validated {} frames)",
                             i, remaining, MIN_FRAMES_TO_VALIDATE
-                        ).into());
+                        );
                         return Some(i);
                     }
                 }
@@ -1522,8 +1509,6 @@ impl SoundChannel {
     /// Updated play_current_segment_async that uses per-channel decoding guard and
     /// avoids double-spawning overlapping decode/play tasks.
     async fn play_current_segment_async(channel_rc: Rc<RefCell<Self>>) {
-        use web_sys::console;
-
         // `current_segment_index` may have been reset to `None` between
         // `handle_play`'s spawn and this task actually running.
         // Canonical trigger: JunkbotUndercover's intro — `handle_play`
@@ -1559,13 +1544,10 @@ impl SoundChannel {
 
         // If decode in-progress, skip
         if *is_decoding.borrow() {
-            console::log_1(
-                &format!(
+            debug!(
                     "⏳ Channel {} is currently decoding — skipping play_current_segment_async",
                     channel_num
-                )
-                .into(),
-            );
+                );
             return;
         }
 
@@ -1749,13 +1731,10 @@ impl SoundChannel {
                 }
             }
             other => {
-                console::log_1(
-                    &format!(
+                debug!(
                         "⚠️ #member is not a CastMember, it's {:?}",
                         other.type_str()
-                    )
-                    .into(),
-                );
+                    );
                 None
             }
         }
@@ -1769,16 +1748,13 @@ impl SoundChannel {
         {
             let mut channel = self_rc.borrow_mut();
 
-            web_sys::console::log_1(
-                &format!(
+            debug!(
                     "play_file(): channel={} status={:?} queued={} current_idx={:?}",
                     channel.channel_num,
                     channel.status,
                     channel.queued_members.len(),
                     channel.current_segment_index
-                )
-                .into(),
-            );
+                );
 
             // Stop any currently playing sound
             if channel.status == SoundStatus::Playing || channel.status == SoundStatus::Loading {
@@ -1806,13 +1782,10 @@ impl SoundChannel {
                     }
                 }
             } else {
-                web_sys::console::log_1(
-                    &format!(
+                debug!(
                         "🔒 Keeping existing current_segment_index={:?}",
                         channel.current_segment_index
-                    )
-                    .into(),
-                );
+                    );
             }
         }
 
@@ -1833,13 +1806,10 @@ impl SoundChannel {
                 }
             }
 
-            console::log_1(
-                &format!(
+            debug!(
                     "▶️ SoundChannel::start_sound() called with {:?}",
                     member_ref
-                )
-                .into(),
-            );
+                );
 
             // Reset status
             if this.status != SoundStatus::Idle {
@@ -1961,13 +1931,10 @@ impl SoundChannel {
             let target_sample_rate = audio_context.sample_rate();
             let num_channels = audio_data.num_channels;
 
-            console::log_1(
-                &format!(
+            debug!(
                     "📊 Source: {} Hz, Target: {} Hz, Channels: {}",
                     source_sample_rate, target_sample_rate, num_channels
-                )
-                .into(),
-            );
+                );
 
             // Create buffer at SOURCE sample rate first
             let num_frames = audio_data.samples.len() / num_channels as usize;
@@ -2057,9 +2024,7 @@ impl SoundChannel {
                 let source = match ch.audio_context().create_buffer_source() {
                     Ok(s) => s,
                     Err(_) => {
-                        web_sys::console::log_1(
-                            &"❌ Failed to create AudioBufferSourceNode".into(),
-                        );
+                        debug!("❌ Failed to create AudioBufferSourceNode");
                         return;
                     }
                 };
@@ -2161,7 +2126,7 @@ impl SoundChannel {
 
                     // Only proceed if we were actually playing (not stopped early)
                     if ch.status != SoundStatus::Playing {
-                        warn!("⚠️ Channel {} was already stopped, ignoring ended event", channel_num);
+                        debug!("⚠️ Channel {} was already stopped, ignoring ended event", channel_num);
                         return;
                     }
 
@@ -2176,15 +2141,12 @@ impl SoundChannel {
                 // Start playback (ONLY ONCE)
                 let _ = source.start();
 
-                web_sys::console::log_1(
-                    &format!(
+                debug!(
                         "✅ Channel {} started playback: {} samples @ {} Hz",
                         channel_num,
                         audio_data.samples.len(),
                         resampled_buffer.sample_rate()
-                    )
-                    .into(),
-                );
+                    );
             });
             debug!("🚀 Spawned MP3 decode task (start_sound #2)");
         } else {
@@ -2219,13 +2181,10 @@ impl SoundChannel {
         let original_length = buffer.length();
         let new_length = ((original_length as f32) * (target_rate / current_rate)).ceil() as u32;
 
-        console::log_1(
-            &format!(
+        debug!(
                 "📐 Resampling: {} samples → {} samples ({} channels)",
                 original_length, new_length, num_channels
-            )
-            .into(),
-        );
+            );
 
         // Create offline context at target rate
         let offline = OfflineAudioContext::new_with_number_of_channels_and_length_and_sample_rate(
@@ -2249,14 +2208,11 @@ impl SoundChannel {
         let rendered = wasm_bindgen_futures::JsFuture::from(render_promise).await?;
         let resampled = AudioBuffer::from(rendered);
 
-        console::log_1(
-            &format!(
+        debug!(
                 "✅ Resampling complete: {} Hz, {} samples",
                 resampled.sample_rate(),
                 resampled.length()
-            )
-            .into(),
-        );
+            );
 
         Ok(resampled)
     }
@@ -2267,8 +2223,6 @@ impl SoundChannel {
         mp3_bytes: Vec<u8>,
         sound_member: SoundMember,
     ) -> Result<(), JsValue> {
-        use web_sys::console;
-
         // Guard: prevent re-entrant decode/play
         {
             let ch = self_rc.borrow();
@@ -2314,13 +2268,10 @@ impl SoundChannel {
             let bitrate_index = (header >> 12) & 0xF;
             let sample_rate_index = (header >> 10) & 0x3;
 
-            console::log_1(
-                &format!(
+            debug!(
                     "🎵 MP3 Header Analysis: version={}, layer={}, bitrate_idx={}, sr_idx={}",
                     version, layer, bitrate_index, sample_rate_index
-                )
-                .into(),
-            );
+                );
 
             // Check for issues
             if clean_mp3.len() < 100 {
@@ -2338,14 +2289,11 @@ impl SoundChannel {
             (ch.audio_context.clone().unwrap(), ch.channel_num)
         };
 
-        console::log_1(
-            &format!(
+        debug!(
                 "🔄 Starting MP3 decode for channel {} ({} bytes)",
                 channel_num,
                 clean_mp3.len()
-            )
-            .into(),
-        );
+            );
 
         // Decode audio data
         let decode_promise = ctx.decode_audio_data(&buf)?;
@@ -2354,32 +2302,24 @@ impl SoundChannel {
             Err(e) => {
                 // NEW: Better error reporting
                 error!("❌ MP3 decoding failed: {:?}", e);
-                console::log_1(
-                    &format!(
+                debug!(
                         "📊 Data size: {} bytes, First 16 bytes: {:02X?}",
                         clean_mp3.len(),
                         &clean_mp3[0..16.min(clean_mp3.len())]
-                    )
-                    .into(),
-                );
-                console::log_1(
-                    &"ℹ️ This might be Director-specific encoding. Falling back to PCM.".into(),
-                );
+                    );
+                debug!("ℹ️ This might be Director-specific encoding. Falling back to PCM.");
                 clear_flag();
                 return Err(e);
             }
         };
 
         let audio_buffer: AudioBuffer = AudioBuffer::from(decoded_js);
-        console::log_1(
-            &format!(
+        debug!(
                 "✅ MP3 decoded: {} channels, {} samples, {} Hz",
                 audio_buffer.number_of_channels(),
                 audio_buffer.length(),
                 audio_buffer.sample_rate()
-            )
-            .into(),
-        );
+            );
 
         let final_buffer = audio_buffer;
 
@@ -2389,37 +2329,33 @@ impl SoundChannel {
         //     ch.expected_sample_rate
         // };
 
-        // console::log_1(
-        //     &format!(
+        // debug!("{}", //     &format!(
         //         "✅ Using browser-decoded MP3 at {} Hz (no resampling needed)",
         //         audio_buffer.sample_rate()
         //     )
         //     .into(),
-        // );
+        //);
 
         // let final_buffer = if let Some(expected_rate) = expected_rate_opt {
         //     let expected_rate_f = expected_rate as f32;
         //     if (audio_buffer.sample_rate() as f32 - expected_rate_f).abs() > 1.0 {
-        //         console::log_1(
-        //             &format!(
+        //         debug!("{}", //             &format!(
         //                 "🔄 Resampling {} -> {} Hz",
         //                 audio_buffer.sample_rate(),
         //                 expected_rate_f
         //             )
         //             .into(),
-        //         );
+        //);
 
         //         match Self::resample_audio_buffer(&audio_buffer, expected_rate_f).await {
         //             Ok(rbuf) => {
-        //                 console::log_1(
-        //                     &format!("✅ Resampled buffer: {} samples", rbuf.length()).into(),
-        //                 );
+        //                 debug!("{}", //                     &format!("✅ Resampled buffer: {} samples", rbuf.length()).into(),
+        //);
         //                 rbuf
         //             }
         //             Err(e) => {
-        //                 console::log_1(
-        //                     &format!("⚠️ Resample failed: {:?}, using original", e).into(),
-        //                 );
+        //                 debug!("{}", //                     &format!("⚠️ Resample failed: {:?}, using original", e).into(),
+        //);
         //                 audio_buffer
         //             }
         //         }
@@ -2507,13 +2443,10 @@ impl SoundChannel {
         // meaningfully longer than declared. Never extends, never truncates a
         // correctly-sized sound, and never fires on placeholder-length sounds.
         let trim_dur = if declared_dur >= 0.010 && declared_dur + 0.005 < buffer_dur {
-            console::log_1(
-                &format!(
+            debug!(
                     "✂️ Trimming SWA/MP3 to declared {:.3}s (decoded {:.3}s)",
                     declared_dur, buffer_dur
-                )
-                .into(),
-            );
+                );
             Some(declared_dur)
         } else {
             None
@@ -2555,7 +2488,7 @@ impl SoundChannel {
 
             // Only proceed if we were actually playing (not stopped early)
             if ch.status != SoundStatus::Playing {
-                warn!("⚠️ Channel {} was already stopped, ignoring ended event", channel_num);
+                debug!("⚠️ Channel {} was already stopped, ignoring ended event", channel_num);
                 return;
             }
 
@@ -2680,15 +2613,12 @@ impl SoundChannel {
                 }
             };
 
-            console::log_1(
-                &format!(
+            debug!(
                     "✅ PCM fallback: {} samples, {} Hz, {} channels",
                     audio_data.samples.len(),
                     audio_data.sample_rate,
                     audio_data.num_channels
-                )
-                .into(),
-            );
+                );
 
             // Handle empty samples
             if audio_data.samples.is_empty() {
@@ -2705,13 +2635,10 @@ impl SoundChannel {
             let resample_ratio = target_sample_rate / source_sample_rate;
             let resampled_frames = (num_frames as f32 * resample_ratio).round() as usize;
 
-            console::log_1(
-                &format!(
+            debug!(
                     "🔄 Resampling {} frames -> {} frames (ratio: {:.3})",
                     num_frames, resampled_frames, resample_ratio
-                )
-                .into(),
-            );
+                );
 
             // Create buffer at target sample rate
             let buffer = match audio_context.create_buffer(
@@ -2882,13 +2809,10 @@ impl SoundChannel {
         // First, find where MP3 data starts
         let mp3_start = Self::find_mp3_start(data)?;
 
-        console::log_1(
-            &format!(
+        debug!(
                 "📍 MP3 data starts at offset {} (0x{:04X})",
                 mp3_start, mp3_start
-            )
-            .into(),
-        );
+            );
 
         // From the MP3 start position, extract all remaining data
         // Most Director MP3s are complete streams after the header
@@ -2900,13 +2824,10 @@ impl SoundChannel {
         if mp3_data.len() >= 4 {
             let header = [mp3_data[0], mp3_data[1], mp3_data[2], mp3_data[3]];
             if let Some((frame_size, sample_rate)) = Self::get_mp3_frame_info(&header) {
-                console::log_1(
-                    &format!(
+                debug!(
                         "✅ First MP3 frame validated: size={}, rate={}Hz",
                         frame_size, sample_rate
-                    )
-                    .into(),
-                );
+                    );
                 return Some(mp3_data.to_vec());
             }
         }
@@ -3016,10 +2937,10 @@ impl SoundChannel {
 
     //     let data = &sound_bytes[header_size..];
 
-    //     console::log_1(&format!(
+    //     debug!(
     //         "load_director_sound_from_bytes → codec='{}', header_skip={}, total_len={}, bits_per_sample={}",
     //         codec, header_size, sound_bytes.len(), bits_per_sample
-    //     ).into());
+    //     );
 
     //     // --- STEP 2: Detect actual format ---
     //     let is_mp3 = data.len() > 2 && data[0] == 0xFF && (data[1] & 0xE0) == 0xE0;
@@ -3031,10 +2952,10 @@ impl SoundChannel {
     //         data[0..100].iter().filter(|&&b| b >= 0x60 && b <= 0xA0).count() > 50
     //     );
 
-    //     console::log_1(&format!(
+    //     debug!(
     //         "Detected: MP3={}, ADPCM={}, 8-bit={}, bits={}, rate={}, ch={}",
     //         is_mp3, is_probably_adpcm, is_probably_8bit, bits_per_sample, sample_rate, channels
-    //     ).into());
+    //     );
 
     //     // --- STEP 3: Decode/normalize ---
     //     let pcm_data = if is_mp3 {
@@ -3099,14 +3020,14 @@ impl SoundChannel {
     //     wav.extend_from_slice(&data_len.to_le_bytes());
     //     wav.extend_from_slice(&pcm_data);
 
-    //     console::log_1(&format!(
+    //     debug!(
     //         "✅ Final WAV: {} bytes, {} Hz, {}-bit, {} ch, {:.2}s",
     //         wav.len(),
     //         sample_rate,
     //         bits,
     //         channels,
     //         sample_count as f64 / sample_rate as f64
-    //     ).into());
+    //     );
 
     //     Ok(wav)
     // }
@@ -3121,7 +3042,6 @@ impl SoundChannel {
         expected_samples: Option<u32>,
         big_endian: bool,
     ) -> Result<Vec<u8>, String> {
-        use web_sys::console;
         if sound_bytes.is_empty() {
             return Err("sound_bytes empty".into());
         }
@@ -3143,18 +3063,15 @@ impl SoundChannel {
         };
         let data = &sound_bytes[header_size..];
 
-        console::log_1(
-            &format!(
+        debug!(
                 "🔍 First 32 audio bytes: {:02X?}",
                 &data[0..data.len().min(32)]
-            )
-            .into(),
-        );
+            );
 
-        console::log_1(&format!(
+        debug!(
             "load_director_sound_from_bytes → codec='{}', header_skip={}, total_len={}, bits_per_sample={}",
             codec, header_size, sound_bytes.len(), bits_per_sample
-        ).into());
+        );
 
         // --- STEP 2: Detect actual format ---
         // Check for MP3, but skip when data size matches expected raw PCM size.
@@ -3192,13 +3109,10 @@ impl SoundChannel {
 
         let (is_mp3, is_probably_adpcm, is_probably_8bit) = (is_mp3, is_probably_adpcm, is_probably_8bit);
 
-        console::log_1(
-            &format!(
+        debug!(
                 "Detected: MP3={}, ADPCM={}, 8-bit={}, bits={}, rate={}, ch={}",
                 is_mp3, is_probably_adpcm, is_probably_8bit, bits_per_sample, sample_rate, channels
-            )
-            .into(),
-        );
+            );
 
         // --- STEP 3: Decode/normalize ---
         let pcm_data = if is_mp3 {
@@ -3214,13 +3128,10 @@ impl SoundChannel {
             let initial_predictor = i16::from_le_bytes([data[0], data[1]]) as i32;
             let initial_index = data[2] as i32;
 
-            console::log_1(
-                &format!(
+            debug!(
                     "🎵 ADPCM state: predictor={}, index={}",
                     initial_predictor, initial_index
-                )
-                .into(),
-            );
+                );
 
             let adpcm_samples = &data[4..];
             let decoded_pcm_samples =
@@ -3288,16 +3199,13 @@ impl SoundChannel {
         wav.extend_from_slice(&data_len.to_le_bytes());
         wav.extend_from_slice(&pcm_data);
 
-        console::log_1(
-            &format!(
+        debug!(
                 "✅ Final WAV: {} bytes, {} Hz, {}-bit, {} ch",
                 wav.len(),
                 sample_rate,
                 bits,
                 channels
-            )
-            .into(),
-        );
+            );
 
         Ok(wav)
     }
@@ -3399,10 +3307,10 @@ impl SoundChannel {
         expected_samples: Option<u32>,
         big_endian: bool,
     ) -> Result<AudioData, String> {
-        console::log_1(&format!(
+        debug!(
             "=== load_director_audio_data ===\nTotal file size: {} bytes\nChannels: {}, Sample Rate: {} Hz, Bits: {}, Codec: '{}', Expected samples: {:?}",
             sound_bytes.len(), channels, sample_rate, bits_per_sample, codec, expected_samples
-        ).into());
+        );
         
         // Check for MP3, but skip when data size matches expected raw PCM.
         // sndH/sndS headers sometimes claim "raw_pcm" when data is actually MP3-compressed.
@@ -3437,13 +3345,10 @@ impl SoundChannel {
         };
 
         if let Some(mp3_start) = mp3_start {
-            console::log_1(
-                &format!(
+            debug!(
                     "✅ Valid MP3 sequence found at offset {} (0x{:04X}) - using MP3 decoder (codec was '{}')",
                     mp3_start, mp3_start, codec
-                )
-                .into(),
-            );
+                );
             let mp3_data = sound_bytes[mp3_start..].to_vec();
             return Ok(AudioData {
                 samples: vec![],
@@ -3469,13 +3374,10 @@ impl SoundChannel {
 
     /// Play MP3 data using HtmlAudioElement (browser handles decoding)
     pub async fn play_mp3_data(mp3_bytes: &[u8]) -> Result<(), JsValue> {
-        console::log_1(
-            &format!(
+        debug!(
                 "🎵 Creating Blob from {} bytes of MP3 data",
                 mp3_bytes.len()
-            )
-            .into(),
-        );
+            );
 
         // Create a Uint8Array from the MP3 bytes
         let uint8_array = js_sys::Uint8Array::from(mp3_bytes);
@@ -3493,7 +3395,7 @@ impl SoundChannel {
 
         // Create an object URL for the Blob
         let url = Url::create_object_url_with_blob(&blob).map_err(|e| {
-            console::error_1(&format!("Failed to create object URL: {:?}", e).into());
+            error!("Failed to create object URL: {:?}", e);
             e
         })?;
 
@@ -3501,7 +3403,7 @@ impl SoundChannel {
 
         // Create an audio element and play it
         let audio = HtmlAudioElement::new().map_err(|e| {
-            console::error_1(&"Failed to create audio element".into());
+            error!("Failed to create audio element");
             e
         })?;
 
@@ -3509,7 +3411,7 @@ impl SoundChannel {
 
         // Play the audio
         audio.play().map_err(|e| {
-            console::error_1(&format!("Failed to play audio: {:?}", e).into());
+            error!("Failed to play audio: {:?}", e);
             e
         })?;
 
@@ -3536,7 +3438,7 @@ impl SoundChannel {
         let decode_promise = audio_context
             .decode_audio_data(&array_buffer)
             .map_err(|e| {
-                console::error_1(&format!("Failed to start decoding: {:?}", e).into());
+                error!("Failed to start decoding: {:?}", e);
                 e
             })?;
 
@@ -3544,25 +3446,22 @@ impl SoundChannel {
         let audio_buffer = wasm_bindgen_futures::JsFuture::from(decode_promise)
             .await
             .map_err(|e| {
-                console::error_1(&format!("MP3 decode failed: {:?}", e).into());
+                error!("MP3 decode failed: {:?}", e);
                 e
             })?;
 
         // The result should be an AudioBuffer
         let buffer = audio_buffer.dyn_into::<AudioBuffer>().map_err(|e| {
-            console::error_1(&"Decode result is not an AudioBuffer".into());
+            error!("Decode result is not an AudioBuffer");
             e
         })?;
 
-        console::log_1(
-            &format!(
+        debug!(
                 "✅ MP3 decoded successfully: {} channels, {} samples, {} Hz",
                 buffer.number_of_channels(),
                 buffer.length(),
                 buffer.sample_rate()
-            )
-            .into(),
-        );
+            );
 
         Ok(buffer)
     }
@@ -3635,15 +3534,12 @@ impl SoundChannel {
     }
 
     pub fn load_director_sound(data: &[u8]) -> Result<AudioData, String> {
-        console::log_1(
-            &format!(
+        debug!(
                 "ℹ️ load_director_sound: data_len={}, is_wav={}, is_aiff={}",
                 data.len(),
                 Self::is_wav_format(data),
                 Self::is_aiff_format(data)
-            )
-            .into(),
-        );
+            );
 
         let wrapped = Self::wrap_director_wav(data);
         debug!("ℹ️ Wrapped WAV length: {} bytes", wrapped.len());
@@ -3699,13 +3595,10 @@ impl SoundChannel {
         wav.extend_from_slice(b"data");
         wav.extend_from_slice(&(data.len() as u32).to_le_bytes());
 
-        console::log_1(
-            &format!(
+        debug!(
                 "🧪 First 8 bytes of PCM: {:02X?}",
                 &data[0..8.min(data.len())]
-            )
-            .into(),
-        );
+            );
 
         // Convert 16-bit big-endian to little-endian
         for chunk in data.chunks_exact(2) {
@@ -3737,16 +3630,13 @@ impl SoundChannel {
         let num_channels = u16::from_le_bytes([data[22], data[23]]);
         let bits_per_sample = u16::from_le_bytes([data[34], data[35]]);
 
-        console::log_1(
-            &format!(
+        debug!(
                 "🎵 load_wav: sample_rate={}, num_channels={}, bits_per_sample={}, data_len={}",
                 sample_rate,
                 num_channels,
                 bits_per_sample,
                 data.len()
-            )
-            .into(),
-        );
+            );
 
         let audio_data = &data[44..];
         let samples: Vec<f32> = if bits_per_sample == 16 {
@@ -3815,16 +3705,12 @@ impl SoundChannel {
     }
 
     pub fn queue(&mut self, datum_ref: DatumRef, player: &DirPlayer) {
-        use web_sys::console;
-
         let datum = player.get_datum(&datum_ref);
 
         let props = match datum {
             Datum::PropList(p, _) if !p.is_empty() => p,
             _ => {
-                console::log_1(
-                    &"⚠️ queue(): called with non-propList or empty list — ignored".into(),
-                );
+                debug!("⚠️ queue(): called with non-propList or empty list — ignored");
                 return;
             }
         };
@@ -3857,23 +3743,17 @@ impl SoundChannel {
         self.start_time = start_time_ms.max(0.0);
 
         if loop_count <= 0 {
-            console::log_1(
-                &format!(
+            debug!(
                     "⚠️ queue(): invalid loopCount={} — skipping entry",
                     loop_count
-                )
-                .into(),
-            );
+                );
             return;
         }
 
-        console::log_1(
-            &format!(
+        debug!(
                 "➕ queue() - Adding to channel {} | loop_count={} | current status: {:?}",
                 self.channel_num, loop_count, self.status
-            )
-            .into(),
-        );
+            );
 
         let segment = SoundSegment {
             member_ref: datum_ref.clone(),
@@ -3884,14 +3764,11 @@ impl SoundChannel {
         self.playlist_segments.push(segment);
         self.playlist.push(datum_ref.clone());
 
-        console::log_1(
-            &format!(
+        debug!(
                 "✅ Channel {} playlist now has {} items",
                 self.channel_num,
                 self.playlist_segments.len()
-            )
-            .into(),
-        );
+            );
 
         // DON'T auto-start or change current_segment_index here
         // That's the job of play() or playNext()
@@ -4213,15 +4090,12 @@ impl SoundChannel {
             .start()
             .map_err(|e| ScriptError::new(format!("Failed to start source: {:?}", e)))?;
 
-        console::log_1(
-            &format!(
+        debug!(
                 "✅ Channel {} playing: {} samples @ {} Hz",
                 self.channel_num,
                 audio_data.samples.len(),
                 audio_data.sample_rate
-            )
-            .into(),
-        );
+            );
 
         // Wrap nodes in Rc
         self.source_node = Some(Rc::new(source));
@@ -4299,14 +4173,11 @@ impl SoundChannel {
         num_channels: u32,
         sample_rate: f64,
     ) -> Result<(), JsValue> {
-        console::log_1(
-            &format!(
+        debug!(
                 "🎵 play_castmember: {} frames @ {}Hz",
                 samples.len() / num_channels as usize,
                 sample_rate
-            )
-            .into(),
-        );
+            );
 
         let context = self.audio_context.clone().expect("AudioContext not available (non-wasm target?)");
 
@@ -4459,7 +4330,7 @@ impl SoundChannel {
 
         if let Some(ref pan_node) = self.pan_node {
             let _ = pan_node.pan().set_value(clamped as f32);
-            console::log_1(&JsValue::from_str(&format!("🎚️ Pan set to {:.2}", clamped)));
+            debug!("🎚️ Pan set to {:.2}", clamped);
         }
 
         Ok(())
@@ -4484,7 +4355,7 @@ impl SoundChannel {
             
             // Only proceed if we were actually playing (not stopped early)
             if ch.status != SoundStatus::Playing {
-                warn!("⚠️ Channel {} was already stopped, ignoring ended event", channel_index);
+                debug!("⚠️ Channel {} was already stopped, ignoring ended event", channel_index);
                 return;
             }
             
@@ -4498,27 +4369,19 @@ impl SoundChannel {
 
     /// Called by onended callback to handle loops and playlist
     pub fn start_next_segment(&mut self) {
-        use web_sys::console;
-
-        console::log_1(
-            &format!(
+        debug!(
                 "🔄 start_next_segment called for channel {}",
                 self.channel_num
-            )
-            .into(),
-        );
+            );
 
         // Check for queued members first
         let queued_ref = self.queued_members.first().cloned();
         if let Some(queued_ref) = queued_ref {
             self.queued_members.remove(0); // Remove from queue
-            console::log_1(
-                &format!(
+            debug!(
                     "▶️ Playing queued member from start_next_segment ({} remaining in queue)",
                     self.queued_members.len()
-                )
-                .into(),
-            );
+                );
             let channel_num = self.channel_num;
             
             spawn_local(async move {
@@ -4533,13 +4396,10 @@ impl SoundChannel {
 
         // Handle direct playback looping (non-playlist sounds)
         if self.current_segment_index.is_none() {
-            console::log_1(
-                &format!(
+            debug!(
                     "🔁 Direct playback: loop_count={}, loops_remaining={}",
                     self.loop_count, self.loops_remaining
-                )
-                .into(),
-            );
+                );
 
             // Check if we should loop
             if self.loop_count == 0 {
@@ -4562,13 +4422,10 @@ impl SoundChannel {
             } else if self.loops_remaining > 1 {
                 // Still have loops remaining
                 self.loops_remaining -= 1;
-                console::log_1(
-                    &format!(
+                debug!(
                         "🔁 Looping: {} loops remaining",
                         self.loops_remaining
-                    )
-                    .into(),
-                );
+                    );
                 
                 if let Some(ref member_ref) = self.member {
                     let member_ref_clone = member_ref.clone();
@@ -4625,13 +4482,10 @@ impl SoundChannel {
 
         let segment = &mut self.playlist_segments[index];
 
-        console::log_1(
-            &format!(
+        debug!(
                 "🔄 start_next_segment: index={}, loops_remaining={}/{}",
                 index, segment.loops_remaining, segment.loop_count
-            )
-            .into(),
-        );
+            );
 
         // Loop logic - if loop_count is 0, loop forever
         if segment.loop_count == 0 || segment.loops_remaining > 1 {
@@ -4816,14 +4670,11 @@ impl SoundChannel {
         let num_channels: u32 = audio_data.num_channels as u32;
         let buffer_sample_rate = audio_data.sample_rate;
 
-        console::log_1(
-            &format!(
+        debug!(
                 "Audio buffer created at {} Hz. Context is {} Hz.",
                 buffer_sample_rate,
                 audio_context.sample_rate()
-            )
-            .into(),
-        );
+            );
 
         // Create AudioBuffer using the CORRECT sample rate
         let buffer = audio_context

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -3048,12 +3048,20 @@ impl SoundChannel {
 
         // --- STEP 2: Detect actual format ---
         // Check for MP3, but skip when data size matches expected raw PCM size.
+        // The sample count is treated as raw-PCM evidence ONLY when the data is
+        // actually about that size. Some Director sound members carry a
+        // placeholder sampleCount of 1 (`expected` then = a few bytes); without
+        // the upper-bound check that trivially satisfied `data >= expected*4/5`
+        // and suppressed MP3 sniffing, so Splat's MP3 SFX were decoded as raw
+        // bytes (loud noise). find_mp3_start still validates 3 chained frames,
+        // so genuine PCM reaching it is not mis-detected.
         let bytes_per_sample_est = if bits_per_sample > 0 { bits_per_sample as usize / 8 } else { 2 };
         let expected_pcm_size = expected_samples
-            .filter(|&s| s > 0)
+            .filter(|&s| s > 1)
             .map(|s| s as usize * channels as usize * bytes_per_sample_est);
-        let data_likely_pcm = expected_pcm_size
-            .map_or(false, |expected| data.len() >= expected * 4 / 5);
+        let data_likely_pcm = expected_pcm_size.map_or(false, |expected| {
+            data.len() >= expected * 4 / 5 && data.len() <= expected.saturating_mul(2)
+        });
         let is_mp3 = if data_likely_pcm { false } else { Self::find_mp3_start(data).is_some() };
         let is_probably_adpcm = !is_mp3 && codec.contains("ima");
         // Only use byte-distribution heuristic when bits_per_sample is unknown (0).
@@ -3286,13 +3294,20 @@ impl SoundChannel {
         // Check for MP3, but skip when data size matches expected raw PCM.
         // sndH/sndS headers sometimes claim "raw_pcm" when data is actually MP3-compressed.
         // We detect this by comparing data size to what raw PCM would need.
-        // If the data is close to expected PCM size, it IS PCM and MP3 patterns are false positives.
+        // Treat the data as PCM (and skip MP3 sniffing) ONLY when its size is in a
+        // sane neighbourhood of what the sample count implies. Some Director sound
+        // members carry a placeholder sampleCount of 1, making `expected` a few
+        // bytes; without the upper bound that trivially passed `data >= expected*4/5`
+        // and suppressed MP3 detection, so Splat's MP3 SFX (an MP3 stream behind a
+        // ~46-byte Mac sound header) were decoded as raw bytes — loud noise.
+        // find_mp3_start validates 3 chained frames, so genuine PCM isn't mis-detected.
         let bytes_per_sample_est = if bits_per_sample > 0 { bits_per_sample as usize / 8 } else { 2 };
         let expected_pcm_size = expected_samples
-            .filter(|&s| s > 0)
+            .filter(|&s| s > 1)
             .map(|s| s as usize * channels as usize * bytes_per_sample_est);
-        let data_likely_pcm = expected_pcm_size
-            .map_or(false, |expected| sound_bytes.len() >= expected * 4 / 5);
+        let data_likely_pcm = expected_pcm_size.map_or(false, |expected| {
+            sound_bytes.len() >= expected * 4 / 5 && sound_bytes.len() <= expected.saturating_mul(2)
+        });
         let mp3_start = if data_likely_pcm {
             None
         } else {

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -433,7 +433,7 @@ impl SoundChannelDatumHandlers {
             drop(ch);
 
             // Spawn async task that doesn't block
-            spawn_local(async move {
+            crate::player::spawn_player_local(async move {
                 SoundChannel::play_current_segment_async(channel_rc).await;
             });
         } else {
@@ -1555,7 +1555,7 @@ impl SoundChannel {
         // We call play_file with Rc to ensure no borrow conflicts
         let rc_clone = channel_rc.clone();
         debug!("🚀 About to spawn MP3 decode task (play_current_segment_async)");
-        wasm_bindgen_futures::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             debug!("mp3 task started");
             // call into existing play_file entry which handles MP3 and PCM paths
             SoundChannel::play_file(rc_clone, member_ref);
@@ -1825,11 +1825,25 @@ impl SoundChannel {
             (this.channel_num, this.audio_context.clone().unwrap(), this.loop_count)
         };
 
-        let player_opt = unsafe { crate::PLAYER_OPT.as_mut() };
+        // Resolve the member against the ACTIVE player, not always the host: a
+        // nested `#movie` sub-player's `puppetSound` runs under its own active id
+        // and its member_ref/datum + sound cast member live in the SUB's
+        // allocator/cast. Using PLAYER_OPT (host) looked up a different datum at
+        // that id (the "datum type: string/symbol/int" mismatch) and never found
+        // the sound member.
+        let player_opt = unsafe {
+            if crate::player::ACTIVE_PLAYER_ID == 0 {
+                crate::PLAYER_OPT.as_mut()
+            } else {
+                crate::player::NESTED_PLAYERS
+                    .get_mut(crate::player::ACTIVE_PLAYER_ID - 1)
+                    .and_then(|o| o.as_mut())
+            }
+        };
         let player = match player_opt {
             Some(p) => p,
             None => {
-                error!("❌ No global player found");
+                error!("❌ No active player found");
                 return;
             }
         };
@@ -1898,7 +1912,7 @@ impl SoundChannel {
                 let mp3_sound_member = sound_member.clone();
 
                 debug!("🚀 About to spawn MP3 decode task (start_sound)");
-                wasm_bindgen_futures::spawn_local(async move {
+                crate::player::spawn_player_local(async move {
                     {
                         let mut ch = self_rc_clone.borrow_mut();
                         ch.status = SoundStatus::Loading;
@@ -1986,7 +2000,7 @@ impl SoundChannel {
             // see the matching site further down.
             let sound_member_for_cues = sound_member.clone();
 
-            wasm_bindgen_futures::spawn_local(async move {
+            crate::player::spawn_player_local(async move {
 
                 {
                     let mut ch = self_rc_clone.borrow_mut();
@@ -2564,11 +2578,25 @@ impl SoundChannel {
         let mut this = self_rc.borrow_mut();
 
         // Get global player
-        let player_opt = unsafe { crate::PLAYER_OPT.as_mut() };
+        // Resolve the member against the ACTIVE player, not always the host: a
+        // nested `#movie` sub-player's `puppetSound` runs under its own active id
+        // and its member_ref/datum + sound cast member live in the SUB's
+        // allocator/cast. Using PLAYER_OPT (host) looked up a different datum at
+        // that id (the "datum type: string/symbol/int" mismatch) and never found
+        // the sound member.
+        let player_opt = unsafe {
+            if crate::player::ACTIVE_PLAYER_ID == 0 {
+                crate::PLAYER_OPT.as_mut()
+            } else {
+                crate::player::NESTED_PLAYERS
+                    .get_mut(crate::player::ACTIVE_PLAYER_ID - 1)
+                    .and_then(|o| o.as_mut())
+            }
+        };
         let player = match player_opt {
             Some(p) => p,
             None => {
-                error!("❌ No global player found");
+                error!("❌ No active player found");
                 return;
             }
         };
@@ -4384,7 +4412,7 @@ impl SoundChannel {
                 );
             let channel_num = self.channel_num;
             
-            spawn_local(async move {
+            crate::player::spawn_player_local(async move {
                 if let Some(player) = unsafe { crate::PLAYER_OPT.as_mut() } {
                     if let Some(channel_rc) = player.sound_manager.get_channel(channel_num as usize) {
                         SoundChannel::play_file(channel_rc, queued_ref);
@@ -4410,7 +4438,7 @@ impl SoundChannel {
                     let member_ref_clone = member_ref.clone();
                     let channel_num = self.channel_num;
                     
-                    spawn_local(async move {
+                    crate::player::spawn_player_local(async move {
                         if let Some(player) = unsafe { crate::PLAYER_OPT.as_mut() } {
                             if let Some(channel_rc) = player.sound_manager.get_channel(channel_num as usize) {
                                 SoundChannel::play_file(channel_rc, member_ref_clone);
@@ -4431,7 +4459,7 @@ impl SoundChannel {
                     let member_ref_clone = member_ref.clone();
                     let channel_num = self.channel_num;
                     
-                    spawn_local(async move {
+                    crate::player::spawn_player_local(async move {
                         if let Some(player) = unsafe { crate::PLAYER_OPT.as_mut() } {
                             if let Some(channel_rc) = player.sound_manager.get_channel(channel_num as usize) {
                                 SoundChannel::play_file(channel_rc, member_ref_clone);
@@ -4451,7 +4479,7 @@ impl SoundChannel {
                 if !self.replay_cached_buffer() {
                     let member_ref = self.playlist_segments[0].member_ref.clone();
                     let channel_num = self.channel_num;
-                    spawn_local(async move {
+                    crate::player::spawn_player_local(async move {
                         if let Some(player) = unsafe { crate::PLAYER_OPT.as_mut() } {
                             if let Some(channel_rc) =
                                 player.sound_manager.get_channel(channel_num as usize)
@@ -4503,7 +4531,7 @@ impl SoundChannel {
 
             // Fall back to full decode path
             let channel_num = self.channel_num;
-            spawn_local(async move {
+            crate::player::spawn_player_local(async move {
                 if let Some(player) = unsafe { crate::PLAYER_OPT.as_mut() } {
                     if let Some(channel_rc) = player.sound_manager.get_channel(channel_num as usize)
                     {
@@ -4533,7 +4561,7 @@ impl SoundChannel {
             if !self.replay_cached_buffer() {
                 // Fall back to full decode path
                 let channel_num = self.channel_num;
-                spawn_local(async move {
+                crate::player::spawn_player_local(async move {
                     if let Some(player) = unsafe { crate::PLAYER_OPT.as_mut() } {
                         if let Some(channel_rc) = player.sound_manager.get_channel(channel_num as usize)
                         {
@@ -4609,7 +4637,7 @@ impl SoundChannel {
         // For now, use a workaround with global player
         let channel_num = self.channel_num;
 
-        spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             let player_opt = unsafe { crate::PLAYER_OPT.as_mut() };
             if let Some(player) = player_opt {
                 if let Some(channel_rc) = player.sound_manager.get_channel(channel_num as usize) {

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -646,56 +646,74 @@ impl SpriteDatumHandlers {
                 Ok(DatumRef::Void)
             }
             "getvariable" => {
-                if let Some((sn, cl, cm)) = Self::resolve_sprite_flash_member(datum)? {
-                    let (path, return_as_object) = reserve_player_ref(|player| {
-                        if args.is_empty() { return Ok((String::new(), false)); }
-                        let p = player.get_datum(&args[0]).string_value()?;
-                        // Second arg: 0 = return as Flash object reference, otherwise string
-                        let as_obj = if args.len() >= 2 {
-                            player.get_datum(&args[1]).int_value().unwrap_or(1) == 0
-                        } else {
-                            false
-                        };
-                        Ok((p, as_obj))
-                    })?;
+                // Resolve the target sprite number FIRST, even if its cast
+                // member isn't resolvable at this instant. Director's
+                // getVariable(sprite(N), path, 0) yields a Flash object handle
+                // BOUND TO THAT SPRITE; it must not degrade to VOID just because
+                // the member/Ruffle instance isn't ready yet — a beginSprite can
+                // run before the Flash member is committed to the channel, and a
+                // VOID handle stored in a global (e.g. gDemoFlash) crashes the
+                // deferred `gDemoFlash.play()`. We capture the sprite's cast
+                // member when available (so cast-based lookups still work) but
+                // always bind the handle to the sprite number as the primary key.
+                let sn = reserve_player_ref(|player| player.get_datum(datum).to_sprite_ref())?;
+                let (cl, cm) = reserve_player_ref(|player| {
+                    player
+                        .movie
+                        .score
+                        .get_sprite(sn)
+                        .and_then(|s| s.member.as_ref())
+                        .map(|m| (m.cast_lib, m.cast_member))
+                        .unwrap_or((0, 0))
+                });
+                let (path, return_as_object) = reserve_player_ref(|player| {
+                    if args.is_empty() { return Ok((String::new(), false)); }
+                    let p = player.get_datum(&args[0]).string_value()?;
+                    // Second arg: 0 = return as Flash object reference, otherwise string
+                    let as_obj = if args.len() >= 2 {
+                        player.get_datum(&args[1]).int_value().unwrap_or(1) == 0
+                    } else {
+                        false
+                    };
+                    Ok((p, as_obj))
+                })?;
 
-                    if return_as_object {
-                        // In Director, getVariable(path, 0) returns an object reference.
-                        // But if the Flash variable is a simple string/number, Director
-                        // returns the value directly. We check via GetVariable first:
-                        // if it returns a JS string, return as Datum::String so that
-                        // stringp() works. If it returns an object or undefined, return
-                        // a FlashObjectRef for setCallback/call usage.
-                        match ruffle_get_variable(sn, &path) {
-                            Ok(val) => {
-                                if val.is_string() {
-                                    // Simple string variable - return as string
-                                    let s = val.as_string().unwrap();
-                                    return reserve_player_mut(|player| {
-                                        Ok(player.alloc_datum(Datum::String(s)))
-                                    });
-                                }
-                                // Object or other type - fall through to FlashObjectRef
-                            }
-                            Err(_) => {} // Fall through to FlashObjectRef
+                if return_as_object {
+                    // In Director, getVariable(path, 0) returns an object reference.
+                    // But if the Flash variable is a simple string/number, Director
+                    // returns the value directly. We check via GetVariable first:
+                    // if it returns a JS string, return as Datum::String so that
+                    // stringp() works. If it returns an object or undefined, return
+                    // a FlashObjectRef for setCallback/call usage.
+                    if let Ok(val) = ruffle_get_variable(sn as i32, &path) {
+                        if val.is_string() {
+                            // Simple string variable - return as string
+                            let s = val.as_string().unwrap();
+                            return reserve_player_mut(|player| {
+                                Ok(player.alloc_datum(Datum::String(s)))
+                            });
                         }
-                        // Return a FlashObjectRef for use with setCallback etc.
-                        return reserve_player_mut(|player| {
-                            use crate::director::lingo::datum::FlashObjectRef;
-                            Ok(player.alloc_datum(Datum::FlashObjectRef(FlashObjectRef::from_path_with_member(&path, cl, cm))))
-                        });
+                        // Object or other type - fall through to FlashObjectRef
                     }
+                    // Return a sprite-bound FlashObjectRef for use with
+                    // setCallback / call / play etc. Never VOID for the object form.
+                    return reserve_player_mut(|player| {
+                        use crate::director::lingo::datum::FlashObjectRef;
+                        Ok(player.alloc_datum(Datum::FlashObjectRef(
+                            FlashObjectRef::from_path_with_sprite(&path, cl, cm, sn as i32),
+                        )))
+                    });
+                }
 
-                    match ruffle_get_variable(sn, &path) {
-                        Ok(val) => {
-                            if let Some(s) = val.as_string() {
-                                return reserve_player_mut(|player| {
-                                    Ok(player.alloc_datum(Datum::String(s)))
-                                });
-                            }
+                match ruffle_get_variable(sn as i32, &path) {
+                    Ok(val) => {
+                        if let Some(s) = val.as_string() {
+                            return reserve_player_mut(|player| {
+                                Ok(player.alloc_datum(Datum::String(s)))
+                            });
                         }
-                        Err(e) => warn!("sprite.getVariable error: {:?}", e),
                     }
+                    Err(e) => warn!("sprite.getVariable error: {:?}", e),
                 }
                 Ok(DatumRef::Void)
             }

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -809,6 +809,24 @@ impl SpriteDatumHandlers {
                     });
                 }
 
+                // Member-swap guard: when the score has just swapped this
+                // sprite to a NEW Flash member, the PREVIOUS member's Ruffle
+                // instance can still be resident until the new one loads.
+                // Reading the old member's variables is wrong — e.g. BioBoxing's
+                // menu frame swaps sprite 1 loading.swf -> start.swf, and reading
+                // loading.swf's stale `/:cont="1"` (instead of start.swf's "00")
+                // skips the whole menu. If the sprite's CURRENT (cl,cm) isn't in
+                // `flash_sprite_loaded`, treat the value read as not-ready (VOID)
+                // so the frame's `if cont = 1 ... else go(the frame)` loop holds
+                // until the new member loads and its real value can be read.
+                let member_ready = reserve_player_ref(|player| {
+                    (cl == 0 && cm == 0)
+                        || player.flash_sprite_loaded.contains(&(sn, cl, cm))
+                });
+                if !member_ready {
+                    return Ok(DatumRef::Void);
+                }
+
                 match ruffle_get_variable(sn as i32, &root_flash_path(&path)) {
                     Ok(val) => {
                         // Convert the AS value to a Lingo datum. GetVariable's

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -10,7 +10,7 @@ use crate::player::{
     reserve_player_mut, reserve_player_ref,
     script::{script_get_prop, script_set_prop},
     script_ref::ScriptInstanceRef, DatumRef, DirPlayer, ScriptError, ScriptErrorCode,
-    score::get_concrete_sprite_rect,
+    score::{get_concrete_sprite_rect, get_sprite_rect_in_context},
 };
 
 use super::script_instance::ScriptInstanceUtils;
@@ -47,8 +47,10 @@ extern "C" {
     fn ruffle_set_variable(sprite_num: i32, path: &str, value: &str) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFunction", catch)]
     fn ruffle_call_function(sprite_num: i32, path: &str, args_xml: &str) -> Result<JsValue, JsValue>;
+    /// Classify what's under a sprite-local point: 0 = #background,
+    /// 1 = #normal, 2 = #button, 3 = #editText (Director Flash hitTest values).
     #[wasm_bindgen(js_name = "dirplayer_ruffleHitTest")]
-    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> bool;
+    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> i32;
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetFlashProperty", catch)]
     fn ruffle_get_flash_property(sprite_num: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetFlashProperty")]
@@ -724,11 +726,39 @@ impl SpriteDatumHandlers {
             }
             "hittest" => {
                 if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
-                    let x = reserve_player_ref(|player| player.get_datum(&args[0]).int_value())?;
-                    let y = reserve_player_ref(|player| player.get_datum(&args[1]).int_value())?;
-                    let result = ruffle_hit_test(sn, x as f64, y as f64);
+                    // Director's `sprite.hitTest(point)` takes a *stage* point
+                    // (e.g. `sprite(5).hitTest(_mouse.mouseLoc)`). Accept a
+                    // Point datum, or a legacy two-int (x, y) form. Rebase to
+                    // sprite-local pixels (the classifier's coordinate space)
+                    // by subtracting the sprite's top-left.
+                    let (sx, sy) = reserve_player_ref(|player| -> Result<(i32, i32), ScriptError> {
+                        match player.get_datum(&args[0]) {
+                            Datum::Point([px, py], _) => Ok((*px as i32, *py as i32)),
+                            other => {
+                                let x = other.int_value()?;
+                                let y = if let Some(a) = args.get(1) {
+                                    player.get_datum(a).int_value()?
+                                } else {
+                                    0
+                                };
+                                Ok((x, y))
+                            }
+                        }
+                    })?;
+                    let rect = reserve_player_ref(|player| {
+                        get_sprite_rect_in_context(player, sn as i16)
+                    });
+                    let lx = (sx - rect.0 as i32) as f64;
+                    let ly = (sy - rect.1 as i32) as f64;
+                    // 0 = #background, 1 = #normal, 2 = #button, 3 = #editText.
+                    let symbol = match ruffle_hit_test(sn, lx, ly) {
+                        2 => "button",
+                        3 => "editText",
+                        1 => "normal",
+                        _ => "background",
+                    };
                     return reserve_player_mut(|player| {
-                        Ok(player.alloc_datum(Datum::Int(if result { 1 } else { 0 })))
+                        Ok(player.alloc_datum(Datum::Symbol(symbol.to_string())))
                     });
                 }
                 Ok(DatumRef::Void)

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -1019,6 +1019,28 @@ impl SpriteDatumHandlers {
                             }
                         };
 
+                        // dirplayer LocalConnection: also record
+                        // (lc_path, method) -> (handler, target instance) so a
+                        // forwarded AS `LocalConnection.send` can dispatch the
+                        // Lingo handler on the ORIGINAL instance (keeps `me`
+                        // correct in `on myOnStatus me, aInfo, aMessage`). Harmless
+                        // for non-LC setCallbacks — never looked up unless a
+                        // matching connect()+send() arrives for that path/method.
+                        let lc_target = if args.len() >= 4 {
+                            match player.get_datum(&args[3]) {
+                                Datum::ScriptInstanceRef(r) => Some(r.clone()),
+                                _ => None,
+                            }
+                        } else {
+                            None
+                        };
+                        if let Some(target_ref) = lc_target {
+                            player.flash_lc_callbacks.insert(
+                                (translated_path.clone(), flash_method.clone()),
+                                (lingo_handler.clone(), target_ref),
+                            );
+                        }
+
                         // Call the JS bridge to register the callback in Ruffle.
                         // The export is exposed under the dirplayer_ prefix
                         // (see ruffle/web/src/lib.rs and the matching JS in

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -639,12 +639,28 @@ impl SpriteDatumHandlers {
                 }
                 Ok(DatumRef::Void)
             }
-            "rewind" | "hold" => {
+            "rewind" => {
                 if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     ruffle_rewind(sn);
                 }
                 Ok(DatumRef::Void)
             }
+            // Director 11.5 `hold()` — Flash sprite command. In Director the
+            // playhead advances a Flash sprite one SWF frame per Director frame;
+            // `hold` suppresses THAT Director-driven advance for the current
+            // frame while the SWF's own timeline and audio keep running. Movies
+            // call it every `exitFrame` (alongside `go the frame`) to stop the
+            // SWF being double-advanced.
+            //
+            // dirplayer doesn't drive the SWF frame-by-frame — the Ruffle
+            // instance free-runs its own timeline in real time — so there is no
+            // extra advance to suppress. Mapping `hold` to Ruffle `pause()`
+            // wrongly freezes an already-correctly-playing SWF (bogey_nights'
+            // characters stopped animating). The faithful behaviour here is a
+            // no-op: let Ruffle keep playing. Still recognised (not an error) so
+            // `hold(sprite N)` in a hot `exitFrame` loop doesn't abort the
+            // handler.
+            "hold" => Ok(DatumRef::Void),
             "getvariable" => {
                 // Resolve the target sprite number FIRST, even if its cast
                 // member isn't resolvable at this instant. Director's

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -57,6 +57,30 @@ extern "C" {
     fn ruffle_set_flash_property(sprite_num: i32, target: &str, prop_num: i32, value: &str);
 }
 
+/// Root a bare Flash variable/function path.
+///
+/// The Ruffle fork's GetVariable/SetVariable/CallFunction run on a
+/// `from_nothing` AVM1 activation where an unqualified timeline name does NOT
+/// resolve — only explicit `_root`/`_level0`/`_global`/`this`/slash paths do
+/// (confirmed empirically: `objMain` → undefined, `_root.objMain` → the
+/// object). Director's own Flash Asset resolves such names relative to
+/// `_level0`, so prefix a bare name with `_level0.` (JS translateLevel0 maps
+/// `_level0` → `_root` before it reaches Ruffle). Already-qualified paths are
+/// left untouched.
+fn root_flash_path(path: &str) -> String {
+    if path.is_empty()
+        || path.starts_with("_level0")
+        || path.starts_with("_root")
+        || path.starts_with("_global")
+        || path.starts_with("this")
+        || path.starts_with('/')
+    {
+        path.to_string()
+    } else {
+        format!("_level0.{}", path)
+    }
+}
+
 pub struct SpriteDatumHandlers {}
 
 pub struct SpriteDatumUtils {}
@@ -163,7 +187,7 @@ impl SpriteDatumHandlers {
         let is_sync_handler = matches!(name_lower.as_str(),
             "intersects" | "getprop" | "getat" | "setat" | "getaprop" | "setaprop" | "pointtoword" | "pointtoline" |
             "gotoframe" | "callframe" | "stop" | "play" | "rewind" | "hold" |
-            "getvariable" | "setvariable" | "callfunction" | "setcallback" |
+            "getvariable" | "setvariable" | "callfunction" | "setcallback" | "newobject" |
             "hittest" | "getflashproperty" | "setflashproperty" | "telltarget" |
             "findlabel" | "flashtostage" | "stagetoflash" | "mapstagetomember" | "getpropref" |
             "addcamera" | "removecamera" | "cameracount"
@@ -697,13 +721,19 @@ impl SpriteDatumHandlers {
                 })?;
 
                 if return_as_object {
+                    // Root a bare variable name so it addresses the real
+                    // timeline object — DGS `getVariable("objMain", 0)` returns a
+                    // handle used for `objMain.includeIsLoaded()` etc. See
+                    // root_flash_path for why bare names don't resolve.
+                    let rooted = root_flash_path(&path);
+
                     // In Director, getVariable(path, 0) returns an object reference.
                     // But if the Flash variable is a simple string/number, Director
                     // returns the value directly. We check via GetVariable first:
                     // if it returns a JS string, return as Datum::String so that
                     // stringp() works. If it returns an object or undefined, return
                     // a FlashObjectRef for setCallback/call usage.
-                    if let Ok(val) = ruffle_get_variable(sn as i32, &path) {
+                    if let Ok(val) = ruffle_get_variable(sn as i32, &rooted) {
                         if val.is_string() {
                             // Simple string variable - return as string
                             let s = val.as_string().unwrap();
@@ -718,18 +748,37 @@ impl SpriteDatumHandlers {
                     return reserve_player_mut(|player| {
                         use crate::director::lingo::datum::FlashObjectRef;
                         Ok(player.alloc_datum(Datum::FlashObjectRef(
-                            FlashObjectRef::from_path_with_sprite(&path, cl, cm, sn as i32),
+                            FlashObjectRef::from_path_with_sprite(&rooted, cl, cm, sn as i32),
                         )))
                     });
                 }
 
-                match ruffle_get_variable(sn as i32, &path) {
+                match ruffle_get_variable(sn as i32, &root_flash_path(&path)) {
                     Ok(val) => {
-                        if let Some(s) = val.as_string() {
-                            return reserve_player_mut(|player| {
-                                Ok(player.alloc_datum(Datum::String(s)))
-                            });
-                        }
+                        // Convert the AS value to a Lingo datum. GetVariable's
+                        // value form (2nd arg non-zero) isn't string-only — an AS
+                        // number or boolean must come back as a comparable value,
+                        // not VOID. Neopets DGS state 81 polls
+                        // `getVariable("preloaderTranslationSuccess", 1) = 1`,
+                        // where the AS var is a Number/Boolean; returning VOID for
+                        // those (`as_string()` is None) made the comparison never
+                        // true and stalled the loader. Bools → Int(0/1), integral
+                        // Numbers → Int, else Float, matching the callFunction
+                        // converter that already let `includeIsLoaded() = 1` work.
+                        let datum = if let Some(s) = val.as_string() {
+                            Datum::String(s)
+                        } else if let Some(b) = val.as_bool() {
+                            Datum::Int(if b { 1 } else { 0 })
+                        } else if let Some(n) = val.as_f64() {
+                            if n.fract() == 0.0 && n.abs() < i32::MAX as f64 {
+                                Datum::Int(n as i32)
+                            } else {
+                                Datum::Float(n)
+                            }
+                        } else {
+                            Datum::Void
+                        };
+                        return reserve_player_mut(|player| Ok(player.alloc_datum(datum)));
                     }
                     Err(e) => warn!("sprite.getVariable error: {:?}", e),
                 }
@@ -743,7 +792,7 @@ impl SpriteDatumHandlers {
                     let value = reserve_player_ref(|player| {
                         player.get_datum(&args[1]).string_value()
                     })?;
-                    if let Err(e) = ruffle_set_variable(sn, &path, &value) {
+                    if let Err(e) = ruffle_set_variable(sn, &root_flash_path(&path), &value) {
                         warn!("sprite.setVariable error: {:?}", e);
                     }
                 }
@@ -752,7 +801,7 @@ impl SpriteDatumHandlers {
             "callfunction" => {
                 if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
                     let path = reserve_player_ref(|player| {
-                        player.get_datum(&args[0]).string_value()
+                        player.get_datum(&args[0]).string_value().map(|p| root_flash_path(&p))
                     })?;
                     let args_xml = if args.len() > 1 {
                         reserve_player_ref(|player| {
@@ -992,6 +1041,55 @@ impl SpriteDatumHandlers {
             "telltarget" | "findlabel" | "flashtostage" | "stagetoflash" => {
                 warn!("Flash sprite method '{}' called but not yet implemented", handler_name);
                 Ok(DatumRef::Void)
+            }
+            "newobject" => {
+                // Flash sprite command: sprite(N).newObject(objectType {, args...})
+                // Per the Director 11.5 Scripting Dictionary this "creates an
+                // ActionScript object of the specified type" in the Flash movie and
+                // returns a *reference* to it, for use with setCallback() / call() /
+                // connect() etc (e.g. `sprite(3).newObject("LocalConnection")`).
+                //
+                // We return a sprite-bound FlashObjectRef with a unique synthetic
+                // path — never VOID — mirroring getVariable()'s object form so the
+                // chained setCallback()/connect() calls resolve. The callback bridge
+                // (dirplayer_ruffleRegisterLingoCallback) and method dispatch
+                // (dirplayer_ruffleCallFunction) key off this path. NOTE: extra
+                // constructor args are not yet forwarded to a real AS constructor —
+                // that needs a Ruffle-side newObject bridge to physically host the
+                // object (e.g. so a LocalConnection can actually receive messages).
+                let object_type = reserve_player_ref(|player| {
+                    if args.is_empty() {
+                        return Err(ScriptError::new(
+                            "newObject requires at least one argument".to_string(),
+                        ));
+                    }
+                    player.get_datum(&args[0]).string_value()
+                })?;
+                reserve_player_mut(|player| {
+                    use crate::director::lingo::datum::FlashObjectRef;
+                    let sprite_num = player.get_datum(datum).to_sprite_ref()?;
+                    let (cl, cm) = player
+                        .movie
+                        .score
+                        .get_sprite(sprite_num)
+                        .and_then(|s| s.member.as_ref())
+                        .map(|m| (m.cast_lib, m.cast_member))
+                        .unwrap_or((0, 0));
+                    let id = super::flash_object::FLASH_OBJECT_COUNTER.with(|c| {
+                        let v = c.get() + 1;
+                        c.set(v);
+                        v
+                    });
+                    // Sanitise the class name into a readable, valid AS path segment.
+                    let safe: String = object_type
+                        .chars()
+                        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+                        .collect();
+                    let path = format!("_root.__dpObj_{}_{}", safe, id);
+                    Ok(player.alloc_datum(Datum::FlashObjectRef(
+                        FlashObjectRef::from_path_with_sprite(&path, cl, cm, sprite_num as i32),
+                    )))
+                })
             }
             "setscriptlist" => {
                 // sprite.setScriptList(list)

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -55,6 +55,31 @@ extern "C" {
     fn ruffle_get_flash_property(sprite_num: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetFlashProperty")]
     fn ruffle_set_flash_property(sprite_num: i32, target: &str, prop_num: i32, value: &str);
+    /// True once the sprite's Ruffle instance has loaded AND finished AS init.
+    /// Used to BLOCK a Flash interop call until the SWF is ready (see call_async).
+    #[wasm_bindgen(js_name = "dirplayer_isFlashInstanceReady", catch)]
+    fn is_flash_instance_ready(sprite_num: i32) -> Result<JsValue, JsValue>;
+}
+
+/// Yield the frame loop until the sprite's Ruffle instance is ready (loaded +
+/// AS-initialized), so a Flash interop call reads/writes a live instance rather
+/// than returning null. Bounded (~10s) so a sprite that never gets a ready
+/// instance falls back to the caller's existing lazy-handle / VOID behaviour.
+async fn wait_for_flash_ready(sprite_num: i16) {
+    for _ in 0..100u32 {
+        let ready = is_flash_instance_ready(sprite_num as i32)
+            .ok()
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+        if ready {
+            return;
+        }
+        let _ = async_std::future::timeout(
+            std::time::Duration::from_millis(100),
+            std::future::pending::<()>(),
+        )
+        .await;
+    }
 }
 
 /// Root a bare Flash variable/function path.
@@ -184,10 +209,30 @@ impl SpriteDatumHandlers {
     pub fn has_async_handler(datum: &DatumRef, handler_name: &str) -> Result<bool, ScriptError> {
         // First check if it's a built-in sync handler (case-insensitive)
         let name_lower = handler_name.to_lowercase();
+
+        // Flash interop: async ONLY on the first access to a sprite whose Ruffle
+        // instance isn't confirmed ready yet — call_async waits for readiness,
+        // then whitelists the sprite (flash_ready_sprites). Every later call
+        // finds it whitelisted and takes the SYNC fast path below, so the
+        // hundreds of per-frame interop calls (Coke Studios) don't pay
+        // async-dispatch overhead. Cleared on member unload/swap so it re-waits.
+        if matches!(
+            name_lower.as_str(),
+            "getvariable" | "setvariable" | "callfunction" | "setcallback"
+        ) {
+            let ready = reserve_player_ref(|player| {
+                match player.get_datum(datum).to_sprite_ref() {
+                    Ok(sn) => player.flash_ready_sprites.contains(&sn),
+                    Err(_) => false,
+                }
+            });
+            return Ok(!ready);
+        }
+
         let is_sync_handler = matches!(name_lower.as_str(),
             "intersects" | "getprop" | "getat" | "setat" | "getaprop" | "setaprop" | "pointtoword" | "pointtoline" |
             "gotoframe" | "callframe" | "stop" | "play" | "rewind" | "hold" |
-            "getvariable" | "setvariable" | "callfunction" | "setcallback" | "newobject" |
+            "newobject" |
             "hittest" | "getflashproperty" | "setflashproperty" | "telltarget" |
             "findlabel" | "flashtostage" | "stagetoflash" | "mapstagetomember" | "getpropref" |
             "addcamera" | "removecamera" | "cameracount"
@@ -1200,6 +1245,47 @@ impl SpriteDatumHandlers {
         handler_name: &str,
         args: &Vec<DatumRef>,
     ) -> Result<DatumRef, ScriptError> {
+        // Flash (SWF) interop: block until the sprite's Ruffle instance has
+        // loaded + finished AS init, THEN run the (sync) op against a live
+        // instance. A one-shot Lingo init that reads Flash objects (Coke
+        // Studios' SF gateway: oLoginServlet / oStatusServlet / ...) runs before
+        // the async createFlashInstance completes, so without this wait every
+        // read comes back null and the gateway never connects. The wait is
+        // per-sprite (see wait_for_flash_ready), so it can't stall unrelated
+        // display-only Flash sprites.
+        let name_lower = handler_name.to_lowercase();
+        if matches!(
+            name_lower.as_str(),
+            "getvariable" | "setvariable" | "callfunction" | "setcallback"
+        ) {
+            // Reached only for a sprite NOT yet whitelisted (has_async_handler
+            // routes whitelisted sprites straight to the sync path). If its
+            // instance is ALREADY ready, don't pay for pre_dispatch/the wait —
+            // just whitelist and fall through to the sync arm. Only a genuinely
+            // not-ready sprite kicks off the dispatch + waits: a script can call
+            // into a Flash sprite before the render loop has dispatched its
+            // Ruffle instance (Coke Studios' one-shot `SESSION_createSession`
+            // runs before sprite#1's SWF is dispatched), and without triggering
+            // the dispatch here the wait would block the frame before render ever
+            // dispatches it (deadlock). Whitelist so all later calls are sync.
+            if let Ok(sn) =
+                reserve_player_ref(|player| player.get_datum(&datum).to_sprite_ref())
+            {
+                let ready = is_flash_instance_ready(sn as i32)
+                    .ok()
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                if !ready {
+                    reserve_player_mut(|player| player.pre_dispatch_flash_members());
+                    wait_for_flash_ready(sn).await;
+                }
+                reserve_player_mut(|player| {
+                    player.flash_ready_sprites.insert(sn);
+                });
+            }
+            return Self::call(&datum, handler_name, args);
+        }
+
         // First, try the sprite's attached script instances
         let instance_refs =
             reserve_player_ref(|player| SpriteDatumUtils::get_script_instance_ids(&datum, player))?;

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -780,13 +780,24 @@ impl SpriteDatumHandlers {
                     // a FlashObjectRef for setCallback/call usage.
                     if let Ok(val) = ruffle_get_variable(sn as i32, &rooted) {
                         if val.is_string() {
-                            // Simple string variable - return as string
                             let s = val.as_string().unwrap();
-                            return reserve_player_mut(|player| {
-                                Ok(player.alloc_datum(Datum::String(s)))
-                            });
+                            // Ruffle's GetVariable ALWAYS returns a string, coercing
+                            // an AS OBJECT to "[object Object]" / "[type Object]" /
+                            // "[object MovieClip]". The object form
+                            // (getVariable(path, 0)) must return a FlashObjectRef for
+                            // those, NOT the coercion text — DGS does
+                            // `objMain = getVariable("objMain", 0)` then
+                            // `objMain.setBaseUrls(...)` (a method call). Only a
+                            // genuine primitive string returns as Datum::String.
+                            let is_object_coercion =
+                                s.starts_with("[object ") || s.starts_with("[type ");
+                            if !is_object_coercion {
+                                return reserve_player_mut(|player| {
+                                    Ok(player.alloc_datum(Datum::String(s)))
+                                });
+                            }
                         }
-                        // Object or other type - fall through to FlashObjectRef
+                        // Object / object-coercion / undefined → FlashObjectRef.
                     }
                     // Return a sprite-bound FlashObjectRef for use with
                     // setCallback / call / play etc. Never VOID for the object form.

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -432,12 +432,25 @@ impl SpriteDatumHandlers {
                             let result = player.last_sprite_prop_ref.take()
                                 .unwrap_or_else(|| player.alloc_datum(prop_datum));
 
-                            // If there's a second argument, it's an index into the property
+                            // If there's a second argument, it's an index into
+                            // the property value. A property list is indexed by
+                            // KEY (symbol/string), not a positional int — e.g.
+                            // Summer Resort's `sprite(i).pData[#item]`, where
+                            // pData is a #-keyed prop list. The old code coerced
+                            // the key via int_value() (a symbol → 0) and only
+                            // handled positional Lists, so it errored "cannot
+                            // index into prop_list with 0". Mirror the PropList
+                            // handler's key lookup here.
                             if args.len() > 1 {
-                                let index = player.get_datum(&args[1]).int_value()?;
                                 let list_datum = player.get_datum(&result).clone();
                                 match list_datum {
+                                    Datum::PropList(pairs, _) => {
+                                        return crate::player::handlers::datum_handlers::prop_list::PropListUtils::get_by_key(
+                                            &pairs, &args[1], &player.allocator,
+                                        );
+                                    }
                                     Datum::List(_, item_refs, _) => {
+                                        let index = player.get_datum(&args[1]).int_value()?;
                                         if index < 1 || index as usize > item_refs.len() {
                                             return Err(ScriptError::new(format!(
                                                 "getPropRef: index {} out of range for list of length {}",
@@ -447,6 +460,7 @@ impl SpriteDatumHandlers {
                                         return Ok(item_refs[(index - 1) as usize].clone());
                                     }
                                     _ => {
+                                        let index = player.get_datum(&args[1]).int_value().unwrap_or(0);
                                         return Err(ScriptError::new(format!(
                                             "getPropRef: cannot index into {} with {}",
                                             player.get_datum(&result).type_str(), index

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -635,6 +635,11 @@ impl SpriteDatumHandlers {
             }
             "play" => {
                 if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
+                    // play() overrides a prior `sprite.frame = N` hold — clear
+                    // the asserted frame so a fresh instance plays, not pins.
+                    reserve_player_mut(|player| {
+                        player.movie.score.get_sprite_mut(sn as i16).flash_asserted_frame = None;
+                    });
                     ruffle_play(sn);
                 }
                 Ok(DatumRef::Void)
@@ -645,22 +650,19 @@ impl SpriteDatumHandlers {
                 }
                 Ok(DatumRef::Void)
             }
-            // Director 11.5 `hold()` — Flash sprite command. In Director the
-            // playhead advances a Flash sprite one SWF frame per Director frame;
-            // `hold` suppresses THAT Director-driven advance for the current
-            // frame while the SWF's own timeline and audio keep running. Movies
-            // call it every `exitFrame` (alongside `go the frame`) to stop the
-            // SWF being double-advanced.
-            //
-            // dirplayer doesn't drive the SWF frame-by-frame — the Ruffle
-            // instance free-runs its own timeline in real time — so there is no
-            // extra advance to suppress. Mapping `hold` to Ruffle `pause()`
-            // wrongly freezes an already-correctly-playing SWF (bogey_nights'
-            // characters stopped animating). The faithful behaviour here is a
-            // no-op: let Ruffle keep playing. Still recognised (not an error) so
-            // `hold(sprite N)` in a hot `exitFrame` loop doesn't abort the
-            // handler.
-            "hold" => Ok(DatumRef::Void),
+            // Director 11.5 `hold()` (spec: "stops a Flash movie sprite that is
+            // playing in the current frame, but any audio continues to play").
+            // We map it to the same root-timeline stop as `stop()` — stopFlash
+            // halts the root MovieClip while leaving the player alive to render
+            // (we don't split audio in the Ruffle bridge, an acceptable
+            // divergence). bogey_nights' bogeyman #hiding relies on hold to
+            // actually halt the idle SWF.
+            "hold" => {
+                if let Some((sn, _cl, _cm)) = Self::resolve_sprite_flash_member(datum)? {
+                    ruffle_stop(sn);
+                }
+                Ok(DatumRef::Void)
+            }
             "getvariable" => {
                 // Resolve the target sprite number FIRST, even if its cast
                 // member isn't resolvable at this instant. Director's

--- a/vm-rust/src/player/handlers/datum_handlers/timeout.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/timeout.rs
@@ -296,6 +296,10 @@ impl TimeoutDatumHandlers {
                 match prop {
                     "name" => Ok(player.alloc_datum(Datum::String(timeout_name.to_owned()))),
                     "target" => Ok(timeout.map_or(DatumRef::Void, |x| x.target_ref.clone())),
+                    "period" => {
+                        let p = timeout.map_or(0, |t| t.period as i32);
+                        Ok(player.alloc_datum(Datum::Int(p)))
+                    }
                     _ => Err(ScriptError::new(format!(
                         "Cannot get timeout property {}",
                         prop
@@ -306,6 +310,13 @@ impl TimeoutDatumHandlers {
                 match prop {
                     "name" => Ok(player.alloc_datum(Datum::String(name.to_owned()))),
                     "target" => Ok(target.clone()),
+                    "period" => {
+                        let p = player
+                            .timeout_manager
+                            .get_timeout(name)
+                            .map_or(0, |t| t.period as i32);
+                        Ok(player.alloc_datum(Datum::Int(p)))
+                    }
                     _ => Err(ScriptError::new(format!(
                         "Cannot get timeout property {}",
                         prop
@@ -333,18 +344,43 @@ impl TimeoutDatumHandlers {
             )),
         };
         
-        let timeout = player.timeout_manager.get_timeout_mut(&timeout_name);
         match prop {
             "target" => {
-                let new_target = value;
+                let new_target = value.clone();
+                let timeout = player.timeout_manager.get_timeout_mut(&timeout_name);
                 if let Some(timeout) = timeout {
-                    timeout.target_ref = new_target.clone();
+                    timeout.target_ref = new_target;
+                    Ok(())
                 } else {
-                    return Err(ScriptError::new(
+                    Err(ScriptError::new(
                         "Cannot set target of unscheduled timeout".to_string(),
-                    ));
+                    ))
                 }
-                Ok(())
+            }
+            // `the period of timeoutObject` is read/write (Director Scripting
+            // Dictionary): it is the number of ms between timeout events, and
+            // setting it changes the interval. We update the period and
+            // reschedule the underlying timer (a period of 0 makes it dormant).
+            // Habbo's DM_CurlDetacher sets `period = 1` to start a dormant
+            // timeout — that drives the cURL-download completion callback. Before
+            // this arm existed, the assignment errored ("Cannot set timeout
+            // property period") and, because it runs inside the cURL Xtra
+            // callback (which fails silently), the download never completed and
+            // ES Origins never showed its login (figuredata/external_texts
+            // never loaded).
+            "period" => {
+                let new_period = player.get_datum(value).int_value()?;
+                let new_period = if new_period < 0 { 0 } else { new_period as u32 };
+                let timeout = player.timeout_manager.get_timeout_mut(&timeout_name);
+                if let Some(timeout) = timeout {
+                    timeout.period = new_period;
+                    timeout.schedule();
+                    Ok(())
+                } else {
+                    Err(ScriptError::new(
+                        "Cannot set period of unscheduled timeout".to_string(),
+                    ))
+                }
             }
             _ => Err(ScriptError::new(format!(
                 "Cannot set timeout property {}",

--- a/vm-rust/src/player/handlers/datum_handlers/transform3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/transform3d.rs
@@ -52,9 +52,15 @@ impl Transform3dDatumHandlers {
                 let sz = (m[8]*m[8] + m[9]*m[9] + m[10]*m[10]).sqrt();
                 Ok(Datum::Vector([sx, sy, sz]))
             }
-            "xAxis" => Ok(Datum::Vector([m[0], m[1], m[2]])),
-            "yAxis" => Ok(Datum::Vector([m[4], m[5], m[6]])),
-            "zAxis" => Ok(Datum::Vector([m[8], m[9], m[10]])),
+            // Director returns the rotation basis as UNIT vectors (scale removed).
+            // A scaled node must still report unit axes — e.g. Rasterwerks' actor-model
+            // group is scaled ~1.06, and the bot's turn convergence does
+            // `targetZaxis.angleBetween(model.transform.zAxis)`; a non-unit zAxis skews
+            // that angle so the body settles facing the wrong way. (The control node is
+            // unit-scaled, which is why movement was correct but the visible model wasn't.)
+            "xAxis" => Ok(Datum::Vector(normalize_vec3([m[0], m[1], m[2]]))),
+            "yAxis" => Ok(Datum::Vector(normalize_vec3([m[4], m[5], m[6]]))),
+            "zAxis" => Ok(Datum::Vector(normalize_vec3([m[8], m[9], m[10]]))),
             "axisAngle" => {
                 // Extract axis-angle from the rotation part of the matrix
                 let (axis, angle) = matrix_to_axis_angle(&m);
@@ -518,6 +524,16 @@ fn translation_matrix(tx: f64, ty: f64, tz: f64) -> [f64; 16] {
         0.0, 0.0, 1.0, 0.0,
         tx,  ty,  tz,  1.0,
     ]
+}
+
+/// Normalize a 3-vector to unit length (returns the input unchanged if ~zero).
+fn normalize_vec3(v: [f64; 3]) -> [f64; 3] {
+    let len = (v[0] * v[0] + v[1] * v[1] + v[2] * v[2]).sqrt();
+    if len > 1e-10 {
+        [v[0] / len, v[1] / len, v[2] / len]
+    } else {
+        v
+    }
 }
 
 /// Euler angles to column-major rotation matrix (R = Rz * Ry * Rx)

--- a/vm-rust/src/player/handlers/datum_handlers/transform3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/transform3d.rs
@@ -402,11 +402,9 @@ impl Transform3dDatumHandlers {
                 _ => return Err(ScriptError::new("Expected Transform3d argument".into())),
             };
             let t = player.get_datum(&args[1]).float_value()? / 100.0; // percent → 0-1
-
-            let mut result = [0.0f64; 16];
-            for i in 0..16 {
-                result[i] = m[i] + (target[i] - m[i]) * t;
-            }
+            // Lerp position/scale, SLERP rotation (Director 11.5 interpolate():
+            // "position and rotation"). Element-wise matrix lerp shears rotation.
+            let result = interpolate_transform(&m, &target, t);
             Ok(player.alloc_datum(Datum::Transform3d(result)))
         })
     }
@@ -423,11 +421,8 @@ impl Transform3dDatumHandlers {
                 _ => return Err(ScriptError::new("Expected Transform3d argument".into())),
             };
             let t = player.get_datum(&args[1]).float_value()? / 100.0;
-
-            let mut result = [0.0f64; 16];
-            for i in 0..16 {
-                result[i] = m[i] + (target[i] - m[i]) * t;
-            }
+            // interpolateTo modifies transform1 in place (Director 11.5).
+            let result = interpolate_transform(&m, &target, t);
             *player.get_datum_mut(datum) = Datum::Transform3d(result);
             Ok(DatumRef::Void)
         })
@@ -537,6 +532,100 @@ fn normalize_vec3(v: [f64; 3]) -> [f64; 3] {
 }
 
 /// Euler angles to column-major rotation matrix (R = Rz * Ry * Rx)
+/// Interpolate two Director (column-major) transforms by `t` (0..1): lerp the
+/// position and per-axis scale, SLERP the rotation. Matches the 11.5 dictionary
+/// for interpolate()/interpolateTo() ("position and rotation"). An element-wise
+/// 16-cell matrix lerp shears the rotation basis — a follow camera would track
+/// position but never actually rotate to face its target.
+fn interpolate_transform(m: &[f64; 16], target: &[f64; 16], t: f64) -> [f64; 16] {
+    let t = t.clamp(0.0, 1.0);
+    let (p1, s1, q1) = decompose_transform(m);
+    let (p2, s2, q2) = decompose_transform(target);
+    let pos = [p1[0] + (p2[0]-p1[0])*t, p1[1] + (p2[1]-p1[1])*t, p1[2] + (p2[2]-p1[2])*t];
+    let scale = [s1[0] + (s2[0]-s1[0])*t, s1[1] + (s2[1]-s1[1])*t, s1[2] + (s2[2]-s1[2])*t];
+    let q = quat_slerp(q1, q2, t);
+    recompose_transform(pos, scale, q)
+}
+
+/// Decompose a column-major transform into (position, per-axis scale, rotation
+/// quaternion [x,y,z,w]). Scale = column lengths; rotation = normalized columns.
+fn decompose_transform(m: &[f64; 16]) -> ([f64; 3], [f64; 3], [f64; 4]) {
+    let pos = [m[12], m[13], m[14]];
+    let s0 = (m[0]*m[0] + m[1]*m[1] + m[2]*m[2]).sqrt();
+    let s1 = (m[4]*m[4] + m[5]*m[5] + m[6]*m[6]).sqrt();
+    let s2 = (m[8]*m[8] + m[9]*m[9] + m[10]*m[10]).sqrt();
+    let (i0, i1, i2) = (s0.max(1e-10), s1.max(1e-10), s2.max(1e-10));
+    // r_{row,col} from normalized columns
+    let (r00, r10, r20) = (m[0]/i0, m[1]/i0, m[2]/i0);
+    let (r01, r11, r21) = (m[4]/i1, m[5]/i1, m[6]/i1);
+    let (r02, r12, r22) = (m[8]/i2, m[9]/i2, m[10]/i2);
+    let q = mat3_to_quat(r00, r10, r20, r01, r11, r21, r02, r12, r22);
+    (pos, [s0, s1, s2], q)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn mat3_to_quat(
+    r00: f64, r10: f64, r20: f64,
+    r01: f64, r11: f64, r21: f64,
+    r02: f64, r12: f64, r22: f64,
+) -> [f64; 4] {
+    let trace = r00 + r11 + r22;
+    if trace > 0.0 {
+        let s = 0.5 / (trace + 1.0).sqrt();
+        normalize_quat([(r21 - r12) * s, (r02 - r20) * s, (r10 - r01) * s, 0.25 / s])
+    } else if r00 > r11 && r00 > r22 {
+        let s = (2.0 * (1.0 + r00 - r11 - r22).sqrt()).max(1e-10);
+        normalize_quat([0.25 * s, (r01 + r10) / s, (r02 + r20) / s, (r21 - r12) / s])
+    } else if r11 > r22 {
+        let s = (2.0 * (1.0 + r11 - r00 - r22).sqrt()).max(1e-10);
+        normalize_quat([(r01 + r10) / s, 0.25 * s, (r12 + r21) / s, (r02 - r20) / s])
+    } else {
+        let s = (2.0 * (1.0 + r22 - r00 - r11).sqrt()).max(1e-10);
+        normalize_quat([(r02 + r20) / s, (r12 + r21) / s, 0.25 * s, (r10 - r01) / s])
+    }
+}
+
+fn recompose_transform(pos: [f64; 3], scale: [f64; 3], q: [f64; 4]) -> [f64; 16] {
+    let (x, y, z, w) = (q[0], q[1], q[2], q[3]);
+    let (r00, r10, r20) = (1.0 - 2.0*(y*y + z*z), 2.0*(x*y + z*w), 2.0*(x*z - y*w));
+    let (r01, r11, r21) = (2.0*(x*y - z*w), 1.0 - 2.0*(x*x + z*z), 2.0*(y*z + x*w));
+    let (r02, r12, r22) = (2.0*(x*z + y*w), 2.0*(y*z - x*w), 1.0 - 2.0*(x*x + y*y));
+    [
+        r00*scale[0], r10*scale[0], r20*scale[0], 0.0,
+        r01*scale[1], r11*scale[1], r21*scale[1], 0.0,
+        r02*scale[2], r12*scale[2], r22*scale[2], 0.0,
+        pos[0], pos[1], pos[2], 1.0,
+    ]
+}
+
+fn quat_slerp(q1: [f64; 4], mut q2: [f64; 4], t: f64) -> [f64; 4] {
+    let mut dot = q1[0]*q2[0] + q1[1]*q2[1] + q1[2]*q2[2] + q1[3]*q2[3];
+    if dot < 0.0 {
+        for i in 0..4 { q2[i] = -q2[i]; }
+        dot = -dot;
+    }
+    if dot > 0.9995 {
+        // nearly parallel → lerp + normalize (avoids sin(0) blow-up)
+        return normalize_quat([
+            q1[0] + (q2[0]-q1[0])*t, q1[1] + (q2[1]-q1[1])*t,
+            q1[2] + (q2[2]-q1[2])*t, q1[3] + (q2[3]-q1[3])*t,
+        ]);
+    }
+    let theta = dot.clamp(-1.0, 1.0).acos();
+    let s = theta.sin();
+    let a = ((1.0 - t) * theta).sin() / s;
+    let b = (t * theta).sin() / s;
+    normalize_quat([
+        q1[0]*a + q2[0]*b, q1[1]*a + q2[1]*b,
+        q1[2]*a + q2[2]*b, q1[3]*a + q2[3]*b,
+    ])
+}
+
+fn normalize_quat(q: [f64; 4]) -> [f64; 4] {
+    let len = (q[0]*q[0] + q[1]*q[1] + q[2]*q[2] + q[3]*q[3]).sqrt();
+    if len > 1e-10 { [q[0]/len, q[1]/len, q[2]/len, q[3]/len] } else { [0.0, 0.0, 0.0, 1.0] }
+}
+
 pub fn euler_to_matrix(rx_deg: f64, ry_deg: f64, rz_deg: f64) -> [f64; 16] {
     // Guard against NaN/infinity — use 0 for any invalid input
     let rx = if rx_deg.is_finite() { rx_deg } else { 0.0 }.to_radians();

--- a/vm-rust/src/player/handlers/datum_handlers/void.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/void.rs
@@ -57,9 +57,17 @@ impl VoidDatumHandlers {
             // built, real Director silently no-ops these and the surrounding
             // voidp(...) guards skip the body — we have to mirror that.
             "getAvatar" | "getItemByPossessionId" | "display" => Ok(DatumRef::Void),
-            _ => Err(ScriptError::new(format!(
-                "No handler {handler_name} for void"
-            ))),
+            // Director silently no-ops ANY handler call on a VOID value and
+            // returns VOID — it never raises. g349's `on particle` does
+            // `g.particles[g.cparticle].spawn(Args)`; between levels
+            // `g.particles` is cleared to VOID, so the subscript is VOID and
+            // `.spawn(Args)` must be a no-op. Returning VOID here (rather than
+            // maintaining a whitelist of handler names) mirrors Director and
+            // subsumes the specific cases above.
+            _ => {
+                log::debug!("Calling handler '{}' on VOID → VOID (Director-lenient no-op)", handler_name);
+                Ok(DatumRef::Void)
+            },
         })
     }
 
@@ -113,19 +121,20 @@ impl VoidDatumHandlers {
                 // Director tolerates .count and .number on void, returning 0
                 Ok(player.alloc_datum(Datum::Int(0)))
             }
-            // CS-specific scene-graph properties read without a voidp() guard
-            // on the parent (e.g. Studio.receiveCdStop chains
-            // `oIsoScene.oAvatars.getAvatar(...)` and
-            // `oIsoScene.oInfoStand.display(...)`). Real Director silently
-            // returns void for these so the surrounding voidp(...) checks
-            // skip the body.
-            "oAvatars" | "oInfoStand" | "oSelectedItem" => {
+            // Director returns VOID for ANY property read on a VOID value —
+            // it never raises. Scripts rely on this: e.g. g349's
+            // "horizontal-only background scroll bhv" reads
+            // `g.map.we_are_playing` every exitFrame, and once the level ends
+            // and `g.map` is cleared to VOID the `> 0` test simply reads VOID
+            // (false) and the sprite hides. The typed special-cases above
+            // (count/x/string/...) stay because their callers expect a number
+            // or string rather than VOID; every other property falls through
+            // to VOID, matching Director instead of maintaining a whitelist of
+            // custom property names (previously oAvatars/oInfoStand/etc.).
+            _ => {
+                log::debug!("Reading property '{}' on VOID → VOID (Director-lenient)", prop);
                 Ok(player.alloc_datum(Datum::Void))
             }
-            _ => Err(ScriptError::new(format!(
-                "Cannot get property '{}' on VOID - a variable or property that should contain an object is uninitialized",
-                prop
-            ))),
         }
     }
 }

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1035,6 +1035,7 @@ impl BuiltInHandlerManager {
             "rect" => TypeHandlers::rect(args),
             "getstreamstatus" => NetHandlers::get_stream_status(args),
             "neterror" => NetHandlers::net_error(args),
+            "netstatus" => NetHandlers::net_status(args),
             "nettextresult" => NetHandlers::net_text_result(args),
             "postnettext" => NetHandlers::post_net_text(args),
             "rgb" => TypeHandlers::rgb(args),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1701,8 +1701,38 @@ impl BuiltInHandlerManager {
                 Ok(DatumRef::Void)
             }
             "preload" => {
-                log::warn!("preload is not implemented");
-                Ok(DatumRef::Void)
+                // All cast data is resident in memory (WASM) — there's nothing to
+                // stream in, so preload completes instantly. Per the 11.5 Scripting
+                // Dictionary, preLoad returns the number of the last frame it loaded:
+                //   0 args -> current frame .. last frame of movie -> last frame
+                //   1 arg  -> current frame .. frameN              -> frameN
+                //   2 args -> frameA .. frameB                     -> frameB
+                // A frame arg may be a number or a marker label.
+                fn resolve_frame(player: &crate::player::DirPlayer, dref: &DatumRef) -> i32 {
+                    let d = player.get_datum(dref);
+                    if let Datum::String(s) = d {
+                        if let Some(fl) = player
+                            .movie
+                            .score
+                            .frame_labels
+                            .iter()
+                            .find(|fl| fl.label.eq_ignore_ascii_case(s.as_str()))
+                        {
+                            return fl.frame_num;
+                        }
+                    }
+                    d.int_value().unwrap_or(0)
+                }
+                reserve_player_mut(|player| {
+                    let last = if args.len() >= 2 {
+                        resolve_frame(player, &args[1])
+                    } else if args.len() == 1 {
+                        resolve_frame(player, &args[0])
+                    } else {
+                        player.movie.score.frame_count.unwrap_or(1) as i32
+                    };
+                    Ok(player.alloc_datum(Datum::Int(last)))
+                })
             }
             "charpostoloc" => {
                 reserve_player_mut(|player| {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -366,7 +366,22 @@ impl BuiltInHandlerManager {
             
             // Validate the new_value type BEFORE taking mutable borrow
             let new_value_datum = player.get_datum(&new_value).clone();
-            
+
+            // Director 11.5 Scripting Dictionary (setAt): when the position is
+            // past the end of a LINEAR list, Director grows the list, filling
+            // the intervening "blank" entries with 0. Pre-allocate that fill
+            // here — before the &mut borrow below, since alloc needs its own
+            // borrow — but only when growth is actually required. (Property
+            // lists intentionally error instead; see the PropList arm.)
+            let list_grow_fill = match player.get_datum(list_ref) {
+                Datum::List(_, list, ..)
+                    if (is_zero_based || position >= 1) && index >= list.len() =>
+                {
+                    Some(player.alloc_datum(Datum::Int(0)))
+                }
+                _ => None,
+            };
+
             // Now take the mutable borrow
             let list_datum = player.get_datum_mut(list_ref);
             match list_datum {
@@ -399,20 +414,23 @@ impl BuiltInHandlerManager {
                     Ok(())
                 }
                 Datum::List(_, list, ..) => {
-                    if index < list.len() {
+                    if !is_zero_based && position < 1 {
+                        // Director tolerates setAt at position <= 0 on a linear
+                        // list as a no-op (mirrors ListDatumHandlers::set_at);
+                        // guarding here also avoids the usize underflow of
+                        // `index` below turning a grow into a huge allocation.
+                        Ok(())
+                    } else if index < list.len() {
                         list[index] = new_value;
-                        
-                        debug!(
-                            "setAt complete: list is now {}", 
-                            format_concrete_datum(
-                                &Datum::List(DatumType::List, list.clone(), false),
-                                player
-                            )
-                        );
-                        
                         Ok(())
                     } else {
-                        Err(ScriptError::new(format!("Index {} out of bounds", position)))
+                        // Grow to `position`, padding the blank entries with 0.
+                        let fill = list_grow_fill.clone().unwrap_or(DatumRef::Void);
+                        while list.len() < index {
+                            list.push_back(fill.clone());
+                        }
+                        list.push_back(new_value);
+                        Ok(())
                     }
                 }
                 Datum::PropList(prop_list, ..) => {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1137,9 +1137,13 @@ impl BuiltInHandlerManager {
                 })
             }
             "rightmousedown" => {
-                // We don't track right mouse state separately yet — return FALSE
+                // Right button IS tracked (right_mouse_down/right_mouse_up JS exports set
+                // movie.right_mouse_down; the `the rightMouseDown` property reads it too).
+                // The function form was stubbed to FALSE, so polling movies (Rasterwerks
+                // C_Input.ReadMouse → KEY_ALTFIRE) never saw right-click → the sniper scope
+                // never engaged. Mirror the `mousedown` function above.
                 reserve_player_mut(|player| {
-                    Ok(player.alloc_datum(datum_bool(false)))
+                    Ok(player.alloc_datum(datum_bool(player.movie.right_mouse_down)))
                 })
             }
             "getrendererservices" => {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -870,6 +870,10 @@ impl BuiltInHandlerManager {
             "do" => true,
             "updateStage" => true,
             "go" => true,
+            // `play movie X` / `play frame X of movie Y` compile to play(frame, movie)
+            // and must load a movie like `go` (async). The 1-arg Flash form is handled
+            // synchronously inside the async arm.
+            "play" => true,
             "nothing" => true,
             // Old-style Lingo lets `importFileInto member, url, props` be
             // called as a global verb; route it to the same async impl as
@@ -894,6 +898,50 @@ impl BuiltInHandlerManager {
             "do" => Self::do_command(args).await,
             "updateStage" => MovieHandlers::update_stage(args).await,
             "go" => MovieHandlers::go(args).await,
+            // The global `play` command. `play movie X` / `play frame X of movie Y`
+            // compile to play(frame, movie) — the SAME arg shape as `go`, so route the
+            // 2-arg form to the movie-load path. `play movie the movieName` (the current
+            // movie) reloads it = restart (frog01's game-over "hit enter to restart").
+            // The 1-arg form is the Ruffle/Flash sprite play (sprite.play() global form).
+            "play" => {
+                if args.len() >= 2 {
+                    // `play movie X`. If X is the CURRENT movie → in-place restart
+                    // (the net loader often can't re-fetch the movie by name once
+                    // it's loaded; frog01's "hit enter to restart" does exactly this).
+                    // Otherwise load X like `go frame N of movie X`.
+                    let restart = reserve_player_mut(|player| {
+                        let name = player.get_datum(&args[1]).string_value().unwrap_or_default();
+                        fn base(s: &str) -> String {
+                            s.rsplit(|c| c == '/' || c == '\\').next().unwrap_or(s)
+                                .split('.').next().unwrap_or(s).to_ascii_lowercase()
+                        }
+                        let cur = player.movie.file_name.clone();
+                        let has_bytes = player.movie_reload_data.is_some();
+                        // Restart when the target IS the current movie. `the movieName` /
+                        // file_name are frequently EMPTY here (the loader didn't set a
+                        // usable filename), so treat an empty name or empty current file as
+                        // "the current movie" and restart from the retained bytes. Only a
+                        // clearly-different *named* movie (both names present, not matching)
+                        // falls through to `go`.
+                        let m = has_bytes
+                            && (name.is_empty() || cur.is_empty() || base(&name) == base(&cur));
+                        if m { player.pending_restart = true; }
+                        m
+                    });
+                    if restart {
+                        Ok(DatumRef::Void)
+                    } else {
+                        MovieHandlers::go(args).await
+                    }
+                } else {
+                    if !args.is_empty() {
+                        if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                            ruffle_play(sn);
+                        }
+                    }
+                    Ok(DatumRef::Void)
+                }
+            }
             "nothing" => MovieHandlers::nothing_async(args).await,
             "importFileInto" => Self::import_file_into(args).await,
             _ => {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1584,6 +1584,15 @@ impl BuiltInHandlerManager {
                     _ => Err(ScriptError::new("Cannot findPos on non-list".to_string())),
                 }
             }),
+            "findposnear" => reserve_player_mut(|player| {
+                let list = &args[0];
+                let args = &args[1..].to_vec();
+                match player.get_datum(list) {
+                    Datum::List(..) => ListDatumHandlers::find_pos_near(list, &args),
+                    Datum::PropList(..) => PropListDatumHandlers::find_pos_near(list, &args),
+                    _ => Err(ScriptError::new("Cannot findPosNear on non-list".to_string())),
+                }
+            }),
             "setprop" => {
                 let datum = &args[0];
                 let datum_type = reserve_player_ref(|player| player.get_datum(datum).type_enum());

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -781,7 +781,7 @@ impl BuiltInHandlerManager {
             player.net_manager.preload_net_thing(file_or_url.clone())
         });
         {
-            let player = unsafe { crate::player::PLAYER_OPT.as_mut().unwrap() };
+            let player = unsafe { crate::player::player_mut() };
             if !player.net_manager.is_task_done(Some(task_id)) {
                 player.net_manager.await_task(task_id).await;
             }
@@ -2218,6 +2218,18 @@ impl BuiltInHandlerManager {
                         Ok(player.alloc_datum(Datum::Point([x as f64, y as f64], 0)))
                     }
                 })
+            }
+            "locvtolinepos" | "linepostolocv" | "loctocharpos" | "charpostoloc"
+                if !args.is_empty() =>
+            {
+                // Global form `locVToLinePos(member, loc)` etc. Director exposes
+                // these text/field position helpers both as member methods and as
+                // globals whose first arg is the member. Delegate to the member's
+                // own handler (implemented in cast_member/text.rs & field.rs).
+                let rest = args[1..].to_vec();
+                crate::player::handlers::datum_handlers::cast_member_ref::CastMemberRefHandlers::call(
+                    &args[0], name, &rest,
+                )
             }
             _ => {
                 // Check if first arg is an xtra instance - if so, forward to the xtra instance handler

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -24,7 +24,7 @@ use crate::{
     director::lingo::datum::{Datum, DatumType, datum_bool},
     js_api::JsApi,
     player::{
-        DatumRef, DirPlayer, ScriptError, ScriptErrorCode, bitmap::bitmap::{Bitmap, PaletteRef, get_system_default_palette}, datum_formatting::{format_concrete_datum, format_datum}, geometry::IntRect, handlers::datum_handlers::xml::XmlHelper, keyboard_map, player_alloc_datum, player_call_script_handler, reserve_player_mut, reserve_player_ref, score::get_concrete_sprite_rect, script_ref::ScriptInstanceRef, trace_output, xtra::manager::call_xtra_instance_handler
+        DatumRef, DirPlayer, ScriptError, ScriptErrorCode, bitmap::bitmap::{Bitmap, PaletteRef, get_system_default_palette}, datum_formatting::{format_concrete_datum, format_datum}, geometry::IntRect, handlers::datum_handlers::xml::XmlHelper, keyboard_map, player_alloc_datum, player_call_script_handler, reserve_player_mut, reserve_player_ref, score::{get_concrete_sprite_rect, get_sprite_rect_in_context}, script_ref::ScriptInstanceRef, trace_output, xtra::manager::call_xtra_instance_handler
     },
 };
 
@@ -73,8 +73,10 @@ extern "C" {
     #[wasm_bindgen(js_name = "dirplayer_ruffleCallFrame")]
     fn ruffle_call_frame(sprite_num: i32, frame: i32);
 
+    /// Classify what's under a sprite-local point: 0 = #background,
+    /// 1 = #normal, 2 = #button, 3 = #editText (Director Flash hitTest values).
     #[wasm_bindgen(js_name = "dirplayer_ruffleHitTest")]
-    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> bool;
+    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> i32;
 
     #[wasm_bindgen(js_name = "dirplayer_ruffleGetFlashProperty", catch)]
     fn ruffle_get_flash_property(sprite_num: i32, target: &str, prop_num: i32) -> Result<JsValue, JsValue>;
@@ -1304,6 +1306,8 @@ impl BuiltInHandlerManager {
             "hittest" => {
                 if args.len() >= 3 {
                     let member_ref = Self::resolve_flash_member(&args[0])?;
+                    // Director stage coords; rebase to sprite-local for the
+                    // classifier by subtracting the sprite's top-left.
                     let x = reserve_player_ref(|player| {
                         player.get_datum(&args[1]).int_value()
                     })?;
@@ -1311,9 +1315,20 @@ impl BuiltInHandlerManager {
                         player.get_datum(&args[2]).int_value()
                     })?;
                     if let Some((sn, _cl, _cm)) = member_ref {
-                        let result = ruffle_hit_test(sn, x as f64, y as f64);
+                        let rect = reserve_player_ref(|player| {
+                            get_sprite_rect_in_context(player, sn as i16)
+                        });
+                        let lx = (x - rect.0 as i32) as f64;
+                        let ly = (y - rect.1 as i32) as f64;
+                        // 0 = #background, 1 = #normal, 2 = #button, 3 = #editText.
+                        let symbol = match ruffle_hit_test(sn, lx, ly) {
+                            2 => "button",
+                            3 => "editText",
+                            1 => "normal",
+                            _ => "background",
+                        };
                         return reserve_player_mut(|player| {
-                            Ok(player.alloc_datum(Datum::Int(if result { 1 } else { 0 })))
+                            Ok(player.alloc_datum(Datum::Symbol(symbol.to_string())))
                         });
                     }
                 }

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -544,11 +544,34 @@ impl BuiltInHandlerManager {
 
     fn random(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
+            // The Director 11.5 Scripting Dictionary documents only the
+            // single-arg form random(n) → a random integer in 1..n. Many
+            // shipped Shockwave games also rely on an undocumented two-arg
+            // form random(min, max) → a random integer in [min, max] inclusive
+            // (bogey_nights uses e.g. `random(-6, -3)` for a splash's launch
+            // velocity and `random(40, 120)` for spawn ranges — with no custom
+            // `on random` handler). The spec is silent on the two-arg form
+            // rather than forbidding it, so we support both. Inferred from the
+            // calling movie, not the 11.5 dictionary.
+            if args.len() >= 2 {
+                let a = player.get_datum(&args[0]).int_value()?;
+                let b = player.get_datum(&args[1]).int_value()?;
+                let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+                let span = hi - lo + 1; // inclusive range size, always >= 1
+                // next_random_int(n) returns 1..n from the seeded sequence;
+                // rebase it into [lo, hi] so deterministic replay still holds.
+                let value = match player.movie.next_random_int(span) {
+                    Some(v) => lo + (v - 1),
+                    None => player.rng.random_range(lo..=hi),
+                };
+                return Ok(player.alloc_datum(Datum::Int(value)));
+            }
+
             let max = player.get_datum(&args[0]).int_value()?;
             if max <= 0 {
                 return Ok(player.alloc_datum(Datum::Int(0)));
             }
-            
+
             // Director's random(n) returns a value from 1 to n (inclusive)
             let random_int = match player.movie.next_random_int(max) {
                 Some(value) => value,
@@ -556,7 +579,7 @@ impl BuiltInHandlerManager {
                     player.rng.random_range(1..=max)
                 }
             };
-            
+
             Ok(player.alloc_datum(Datum::Int(random_int)))
         })
     }
@@ -1089,6 +1112,15 @@ impl BuiltInHandlerManager {
                 }
                 Ok(DatumRef::Void)
             }
+            // Director 11.5 `hold()` — global form `hold(sprite N)`. In Director
+            // this suppresses the playhead's per-frame advance of a Flash sprite
+            // while the SWF's own timeline/audio keep running (movies call it
+            // every `exitFrame`). dirplayer doesn't drive the SWF frame-by-frame
+            // — Ruffle free-runs it in real time — so there is nothing to
+            // suppress; pausing would wrongly freeze an already-correct SWF.
+            // Faithful behaviour is a no-op. See the sprite-method `hold` arm in
+            // datum_handlers/sprite.rs for the full rationale.
+            "hold" => Ok(DatumRef::Void),
             "pause"  => Ok(DatumRef::Void),
             "cursor" => TypeHandlers::cursor(args),
             "externalparamcount" => MovieHandlers::external_param_count(args),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1649,6 +1649,21 @@ impl BuiltInHandlerManager {
             "color" => TypeHandlers::color(args),
             "date" => TypeHandlers::date(args),
             "keypressed" => Self::key_pressed(args),
+            // Legacy function-call forms of the modifier-key state properties (Director
+            // 11.5 Scripting Dictionary: Key properties `the shiftDown` / `controlDown` /
+            // `optionDown` / `commandDown`, read-only). Movies call e.g. `shiftDown()`.
+            "shiftdown" => reserve_player_mut(|player| {
+                Ok(player.alloc_datum(datum_bool(player.keyboard_manager.is_shift_down())))
+            }),
+            "controldown" => reserve_player_mut(|player| {
+                Ok(player.alloc_datum(datum_bool(player.keyboard_manager.is_control_down())))
+            }),
+            "optiondown" | "altdown" => reserve_player_mut(|player| {
+                Ok(player.alloc_datum(datum_bool(player.keyboard_manager.is_alt_down())))
+            }),
+            "commanddown" => reserve_player_mut(|player| {
+                Ok(player.alloc_datum(datum_bool(player.keyboard_manager.is_command_down())))
+            }),
             "showglobals" => Self::show_globals(),
             "tellstreamstatus" => Self::tell_stream_status(args),
             "frame" => {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -561,6 +561,19 @@ impl BuiltInHandlerManager {
         })
     }
 
+    /// `randomVector()` (Director 11.5 dictionary): top-level function returning a
+    /// unit vector — a uniformly random point on the surface of the unit sphere,
+    /// guaranteed length 1. No parameters. Uses the cylinder/Archimedes method
+    /// (z uniform in [-1,1], azimuth uniform in [0, 2pi)) which is exactly uniform.
+    fn random_vector(_args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            let z: f64 = player.rng.random_range(-1.0..1.0);
+            let phi: f64 = player.rng.random_range(0.0..std::f64::consts::TAU);
+            let r = (1.0 - z * z).max(0.0).sqrt();
+            Ok(player.alloc_datum(Datum::Vector([r * phi.cos(), r * phi.sin(), z])))
+        })
+    }
+
     fn bit_and(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let a = player.get_datum(&args[0]).int_value()?;
@@ -999,6 +1012,7 @@ impl BuiltInHandlerManager {
             "put" => Self::put(args),
             "inspect" => Self::inspect(args),
             "random" => Self::random(args),
+            "randomvector" => Self::random_vector(args),
             "bitand" => Self::bit_and(args),
             "bitor" => Self::bit_or(args),
             "bitnot" => Self::bit_not(args),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -351,6 +351,23 @@ impl BuiltInHandlerManager {
     fn set_at(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let list_ref = &args[0];
+            // `setAt` on a PROPERTY list accepts a property KEY (string/symbol),
+            // not only an integer position — Director's Hey-Arnold gObstacles does
+            // both: `setAt(gPersonList, dTargetPerson, "walking")` (int position)
+            // and `setAt(gPersonList, pShape, "free")` (pShape = "gerald", a key).
+            // Route a non-numeric key to the property setter; int_value() would
+            // coerce "gerald" to 0 → "Index 0 out of bounds".
+            let key_is_name = matches!(
+                player.get_datum(&args[1]),
+                Datum::String(_) | Datum::Symbol(_)
+            );
+            let is_prop_list = matches!(player.get_datum(list_ref), Datum::PropList(..));
+            if is_prop_list && key_is_name {
+                crate::player::handlers::datum_handlers::prop_list::PropListUtils::set_at(
+                    player, list_ref, &args[1], &args[2], "",
+                )?;
+                return Ok(());
+            }
             let position = player.get_datum(&args[1]).int_value()?;
             let new_value = args[2].clone();
             let is_zero_based = matches!(player.get_datum(list_ref), Datum::List(crate::director::lingo::datum::DatumType::XmlChildNodes, ..));
@@ -1037,6 +1054,7 @@ impl BuiltInHandlerManager {
             "findempty" => CastHandlers::find_empty(args),
             "preloadnetthing" => NetHandlers::preload_net_thing(args),
             "netdone" => NetHandlers::net_done(args),
+            "netabort" => NetHandlers::net_abort(args),
             "movetofront" | "preloadmember" | "preloadbuffer" | "unloadmember" | "beep"
             // Cast/movie preload + unload commands: dirplayer loads everything
             // synchronously up front, so there is nothing to (un)cache. Accept

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -892,7 +892,16 @@ impl BuiltInHandlerManager {
                     b.info.bit_depth = 32;
                     b.info.pitch = w.saturating_mul(4);
                     b.info.trim_white_space = trim_white_space;
+                    // Director centers a bitmap member's regPoint on its image
+                    // when content is (re)imported — the same rule the
+                    // `member.image = ...` setter applies. Without this, a
+                    // `new(#bitmap)` member filled via importFileInto keeps its
+                    // (0,0) regPoint, so its sprite renders offset by half the
+                    // image. (Tetris imports bgpicture.jpg into member 18 and its
+                    // full-stage sprite drew shifted down-right by ~180x200.)
+                    b.reg_point = ((w as i32 / 2) as i16, (h as i32 / 2) as i16);
                 }
+                member.reg_point = (w as i32 / 2, h as i32 / 2);
             }
             player.bitmap_manager.replace_bitmap(existing_bitmap_ref, bitmap);
             JsApi::dispatch_cast_member_changed(member_ref.clone());

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1207,6 +1207,7 @@ impl BuiltInHandlerManager {
             "abort" => Err(ScriptError::new_code(ScriptErrorCode::Abort, "abort".to_string())),
             "mousedown" => {
                 reserve_player_mut(|player| {
+                    player.input_polled = true;
                     Ok(player.alloc_datum(datum_bool(player.movie.mouse_down)))
                 })
             }
@@ -2317,6 +2318,9 @@ impl BuiltInHandlerManager {
 
     pub fn key_pressed(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
+            // Mark this iteration as input-polling so the bytecode busy-wait
+            // yield only kicks in for `repeat while keyPressed(...)` spins.
+            player.input_polled = true;
             let arg_datum = player.get_datum(&args[0]);
 
             // An INTEGER argument is a direct key code (this is how games store

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -974,6 +974,21 @@ impl BuiltInHandlerManager {
                 } else {
                     if !args.is_empty() {
                         if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                            // play(sprite) overrides a prior `sprite.frame = N`
+                            // hold — clear the asserted frame so a freshly
+                            // (re)created instance PLAYS from the current frame
+                            // instead of pinning+stopping at the held one. This
+                            // mirrors the `sprite(x).play()` method arm
+                            // (datum_handlers/sprite.rs). bogey_nights' #pickit
+                            // does `frame = 1; member = "straw"; play(sprite)`,
+                            // and the member swap recreates the instance on the
+                            // next frame — without clearing here, straw loads
+                            // pinned+stopped at frame 1 (assertedFrame=1) and
+                            // never animates or advances (the grab machine then
+                            // reads a frozen frame and stalls into #retreat).
+                            reserve_player_mut(|player| {
+                                player.movie.score.get_sprite_mut(sn as i16).flash_asserted_frame = None;
+                            });
                             ruffle_play(sn);
                         }
                     }
@@ -1099,6 +1114,14 @@ impl BuiltInHandlerManager {
             "play" => {
                 if args.len() >= 1 {
                     if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                        // play() is resume-semantic: it OVERRIDES a prior
+                        // `sprite.frame = N` hold, so clear the sprite's asserted
+                        // frame — otherwise a fresh instance would be pinned
+                        // (stopped) at N instead of playing (StoryScramble's
+                        // grow-bubble does `frame = N; play()` and must animate).
+                        reserve_player_mut(|player| {
+                            player.movie.score.get_sprite_mut(sn as i16).flash_asserted_frame = None;
+                        });
                         ruffle_play(sn);
                     }
                 }
@@ -1112,15 +1135,18 @@ impl BuiltInHandlerManager {
                 }
                 Ok(DatumRef::Void)
             }
-            // Director 11.5 `hold()` — global form `hold(sprite N)`. In Director
-            // this suppresses the playhead's per-frame advance of a Flash sprite
-            // while the SWF's own timeline/audio keep running (movies call it
-            // every `exitFrame`). dirplayer doesn't drive the SWF frame-by-frame
-            // — Ruffle free-runs it in real time — so there is nothing to
-            // suppress; pausing would wrongly freeze an already-correct SWF.
-            // Faithful behaviour is a no-op. See the sprite-method `hold` arm in
-            // datum_handlers/sprite.rs for the full rationale.
-            "hold" => Ok(DatumRef::Void),
+            // Director 11.5 `hold()` — global form `hold(sprite N)`. Maps to the
+            // same root-timeline stop as `stop()` (spec: stops the Flash sprite,
+            // audio would continue — we don't split audio). See the sprite-method
+            // `hold` arm in datum_handlers/sprite.rs.
+            "hold" => {
+                if args.len() >= 1 {
+                    if let Some(sn) = Self::resolve_flash_sprite_strict(&args[0])? {
+                        ruffle_stop(sn);
+                    }
+                }
+                Ok(DatumRef::Void)
+            }
             "pause"  => Ok(DatumRef::Void),
             "cursor" => TypeHandlers::cursor(args),
             "externalparamcount" => MovieHandlers::external_param_count(args),

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1340,6 +1340,27 @@ impl BuiltInHandlerManager {
                                 .map(|m| (m.cast_lib as i32, m.cast_member as i32))
                                 .unwrap_or((0, 0)))
                         })?;
+                        // Member-swap guard: when the score just swapped this
+                        // sprite to a NEW Flash member, the PREVIOUS member's
+                        // Ruffle instance can still be resident until the new one
+                        // loads. Reading the old member's variables is wrong —
+                        // BioBoxing's menu frame swaps sprite 1 loading.swf ->
+                        // start.swf, and reading loading.swf's stale `/:cont="1"`
+                        // (instead of start.swf's "00") skips the menu. If the
+                        // sprite's CURRENT (cl,cm) isn't in `flash_sprite_loaded`,
+                        // treat the VALUE read as not-ready (VOID) so the frame's
+                        // `if cont = 1 ... else go(the frame)` loop holds until the
+                        // new member loads. (Object form below still returns a
+                        // sprite-bound handle.) Safe for Storyscramble in-place
+                        // same-number reloads: its `invalidate_flash_for_cast_lib`
+                        // already pulls the entry from this set.
+                        let member_ready = (cl == 0 && cm == 0)
+                            || reserve_player_ref(|player| {
+                                Ok(player.flash_sprite_loaded.contains(&(sn, cl, cm)))
+                            })?;
+                        if !return_as_object && !member_ready {
+                            return Ok(DatumRef::Void);
+                        }
                         match ruffle_get_variable(sn as i32, &path) {
                             Ok(val) => {
                                 if let Some(s) = val.as_string() {

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1211,14 +1211,50 @@ impl BuiltInHandlerManager {
                 })
             }
             "getvariable" => {
-                // Flash (SWF) member interop — getVariable(sprite, path)
+                // Flash (SWF) member interop — getVariable(sprite, path [, asObjectFlag]).
+                //
+                // The optional 3rd arg == 0 is Director's "return the value as a
+                // Flash object handle" flag (e.g. getVariable(sprite N, "_level0", 0)
+                // grabs the SWF's _level0 timeline object). Otherwise a scalar
+                // string is returned.
+                //
+                // Resolve the sprite NUMBER directly (not via resolve_flash_member,
+                // which returns None when sprite.member isn't committed to the
+                // channel yet — a beginSprite can run before the Flash member is
+                // assigned). For the object form we then ALWAYS return a
+                // sprite-bound FlashObjectRef, never VOID: a VOID handle stored in
+                // a global (gDemoFlash) crashes the later gDemoFlash.play(). The
+                // binding also makes that deferred call dispatch to the right
+                // sprite even though the member wasn't resolvable at capture time.
                 if args.len() >= 2 {
-                    let member_ref = Self::resolve_flash_member(&args[0])?;
+                    let sn_opt: Option<i16> = reserve_player_ref(|player| {
+                        Ok(match player.get_datum(&args[0]) {
+                            Datum::SpriteRef(n) => Some(*n),
+                            Datum::Int(n) => Some(*n as i16),
+                            _ => None,
+                        })
+                    })?;
                     let path = reserve_player_ref(|player| {
                         player.get_datum(&args[1]).string_value()
                     })?;
-                    if let Some((sn, _cl, _cm)) = member_ref {
-                        match ruffle_get_variable(sn, &path) {
+                    let return_as_object: bool = if args.len() >= 3 {
+                        reserve_player_ref(|player| {
+                            Ok(player.get_datum(&args[2]).int_value().unwrap_or(1) == 0)
+                        })?
+                    } else {
+                        false
+                    };
+                    if let Some(sn) = sn_opt {
+                        let (cl, cm): (i32, i32) = reserve_player_ref(|player| {
+                            Ok(player
+                                .movie
+                                .score
+                                .get_sprite(sn)
+                                .and_then(|s| s.member.as_ref())
+                                .map(|m| (m.cast_lib as i32, m.cast_member as i32))
+                                .unwrap_or((0, 0)))
+                        })?;
+                        match ruffle_get_variable(sn as i32, &path) {
                             Ok(val) => {
                                 if let Some(s) = val.as_string() {
                                     return reserve_player_mut(|player| {
@@ -1227,6 +1263,14 @@ impl BuiltInHandlerManager {
                                 }
                             }
                             Err(e) => warn!("getVariable error: {:?}", e),
+                        }
+                        if return_as_object {
+                            return reserve_player_mut(|player| {
+                                use crate::director::lingo::datum::FlashObjectRef;
+                                Ok(player.alloc_datum(Datum::FlashObjectRef(
+                                    FlashObjectRef::from_path_with_sprite(&path, cl, cm, sn as i32),
+                                )))
+                            });
                         }
                     }
                 }

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -505,25 +505,30 @@ impl MovieHandlers {
             let is_puppet = player.get_datum(&args[1]).int_value()? == 1;
 
             if !is_puppet {
-                // Director: unpuppeting resets the sprite's properties to those
-                // in the Score for the current frame. If the channel has no score
-                // data at this frame, the sprite reverts to empty (no member).
+                // Director defers reverting an unpuppeted sprite to the Score:
+                // the sprite keeps its current member/position/appearance until
+                // the NEXT frame update (begin_sprites / per-frame delta) reloads
+                // the channel from the score. Clearing the visual state here is
+                // wrong — it destroys a sprite the script is still reading in the
+                // same handler.
+                //
+                // BrickOut's newLevel does, per brick channel:
+                //     makeStage()                  -- set the memberNum (scene)
+                //     puppetSprite(i, 0)           -- unpuppet
+                //     puppetSprite(i, 1)           -- re-puppet
+                //     add(vListRect, the rect of sprite i)
+                // With the old clear, puppetSprite(i,0) wiped the member/loc the
+                // score+makeStage had established, so `the rect` read (0,0,0,0)
+                // and brick collision never fired. Preserving the visual state
+                // (and letting the score re-drive it on the next frame if it is
+                // NOT re-puppeted) matches Director's deferred reversion.
+                //
+                // Only the puppet flag and behavior lifecycle are cleared:
+                // `entered = false` lets the next begin_sprites re-enter the span
+                // and reload from the score (the deferred revert) when the sprite
+                // stays unpuppeted; if it is re-puppeted first, it keeps its data.
                 let sprite = player.movie.score.get_sprite_mut(sprite_number as i16);
                 sprite.puppet = false;
-                sprite.member = None;
-                sprite.visible = true;
-                sprite.blend = 100;
-                sprite.ink = 0;
-                sprite.loc_h = 0;
-                sprite.loc_v = 0;
-                sprite.width = 0;
-                sprite.height = 0;
-                sprite.has_fore_color = false;
-                sprite.has_back_color = false;
-                sprite.has_visible_mod = false;
-                sprite.has_blend_mod = false;
-                sprite.has_size_changed = false;
-                sprite.moveable = false;
                 sprite.entered = false;
                 sprite.exited = false;
                 sprite.script_instance_list.clear();
@@ -1103,8 +1108,21 @@ impl MovieHandlers {
             let (channel_num, member_ref) = if args.len() == 1 {
                 (1, args[0].clone())
             } else {
-                let channel = player.get_datum(&args[0]).int_value()?;
-                (channel, args[1].clone())
+                // Director's puppetSound disambiguates its two arguments by type
+                // rather than by strict position: the sound cast member may be
+                // named by a string, and the channel is always an integer. The
+                // documented order is `puppetSound whichChannel, whichCastMember`,
+                // but many movies (e.g. BrickOut) write the member-first idiom
+                // `puppetSound "Intro", 2`. When the first argument is a string
+                // it is the member name and the second is the channel; otherwise
+                // fall back to the documented channel-first order.
+                if matches!(player.get_datum(&args[0]), Datum::String(_)) {
+                    let channel = player.get_datum(&args[1]).int_value()?;
+                    (channel, args[0].clone())
+                } else {
+                    let channel = player.get_datum(&args[0]).int_value()?;
+                    (channel, args[1].clone())
+                }
             };
 
             // `puppetSound channel, 0` (and the single-arg `puppetSound 0`)

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -106,7 +106,37 @@ impl MovieHandlers {
                     Ok(player.alloc_datum(Datum::CastMember(INVALID_CAST_MEMBER_REF)))
                 }
             } else {
-                Ok(player.alloc_datum(Datum::CastMember(INVALID_CAST_MEMBER_REF)))
+                // `member(N)` with no cast lib and no existing member: Director
+                // returns a valid BY-NUMBER reference to member N of the default
+                // cast even when that slot is empty — `member(19)` IS member 19,
+                // allocated or not (11.5 Scripting Dictionary: a numbered
+                // reference addresses a slot; it does not require the slot to be
+                // filled). Without this the ref was INVALID (-1,-1), so
+                // `new(#bitmap, member(19))` couldn't target slot 19 (it fell
+                // back to the first free slot) and `member(19).image = ...`
+                // errored. Tetris reserves empty slots 10-14 / 19-21 and fills
+                // them at runtime with exactly that pattern. A failed name
+                // lookup or a non-positive number stays invalid.
+                let numeric = match &member_name_or_num {
+                    Datum::Int(n) => Some(*n),
+                    Datum::Float(f) => Some(*f as i32),
+                    _ => None,
+                };
+                match numeric {
+                    Some(n) if n > 0 => {
+                        // High 16 bits may encode the cast lib (slot-number
+                        // form); a bare member number has cast_lib 0 → default
+                        // to the first cast (mirrors member_ref_from_slot_number).
+                        let cast_lib = (n >> 16) as i32;
+                        let cast_member = (n & 0xFFFF) as i32;
+                        let cast_lib = if cast_lib == 0 { 1 } else { cast_lib };
+                        Ok(player.alloc_datum(Datum::CastMember(CastMemberRef {
+                            cast_lib,
+                            cast_member,
+                        })))
+                    }
+                    _ => Ok(player.alloc_datum(Datum::CastMember(INVALID_CAST_MEMBER_REF))),
+                }
             }
         })
     }

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -173,28 +173,58 @@ impl MovieHandlers {
             let dest = match datum_type {
                 DatumType::Int => Some(datum.int_value()? as u32),
 
-                DatumType::String => {
-                    let label = datum.string_value()?;
-                    player.movie.score.frame_labels
-                        .iter()
-                        .find(|fl| fl.label.eq_ignore_ascii_case(&label))
-                        .map(|fl| fl.frame_num as u32)
-                }
-
-                DatumType::Symbol => {
-                    let symbol = datum.string_value()?;
-                    match symbol.as_str() {
-                        "next" => {
-                            let next_frame = player.movie.current_frame + 1;
-                            debug!("🎬 go(#next): {} -> {}", player.movie.current_frame, next_frame);
-                            Some(next_frame)
-                        },
-                        "previous" => Some(if player.movie.current_frame > 1 { player.movie.current_frame - 1 } else { 1 }),
-                        "loop" => Some(player.movie.current_frame),
-                        _ => player.movie.score.frame_labels
+                // A frame label / marker keyword can arrive as either a string
+                // (`do("go next")`, `go "label"`) or a symbol (decompiled
+                // `go(#next)`), so handle both the same way.
+                DatumType::String | DatumType::Symbol => {
+                    let s = datum.string_value()?;
+                    let key = s.to_ascii_lowercase();
+                    // Director marker-navigation keywords: `next` == marker(1),
+                    // `previous` == marker(-1), `loop` == marker(0) — i.e. the
+                    // next/previous/current MARKER, not the next/previous frame
+                    // (Director 11.5 Scripting Dictionary: `next` keyword ≡
+                    // `the marker(+1)`). mixmaster's buttons do `do("go next")`.
+                    if key == "next" || key == "previous" || key == "loop" {
+                        let mut frames: Vec<u32> = player
+                            .movie
+                            .score
+                            .frame_labels
                             .iter()
-                            .find(|fl| fl.label.eq_ignore_ascii_case(&symbol))
-                            .map(|fl| fl.frame_num as u32),
+                            .map(|fl| fl.frame_num as u32)
+                            .collect();
+                        frames.sort_unstable();
+                        frames.dedup();
+                        let current = player.movie.current_frame;
+                        let offset: i32 = match key.as_str() {
+                            "next" => 1,
+                            "previous" => -1,
+                            _ => 0, // loop
+                        };
+                        // marker(offset): index of marker(0) (largest marker <=
+                        // current, i.e. current-if-marked else previous) is
+                        // pos-1, where pos = count of markers <= current.
+                        let dest_frame = if frames.is_empty() {
+                            None
+                        } else {
+                            let pos = frames.partition_point(|&f| f <= current) as i32;
+                            let target = (pos - 1) + offset;
+                            if target >= 0 {
+                                frames.get(target as usize).copied()
+                            } else {
+                                None
+                            }
+                        };
+                        // No such marker (e.g. `go next` past the last marker) →
+                        // stay on the current frame rather than erroring.
+                        Some(dest_frame.unwrap_or(current))
+                    } else {
+                        player
+                            .movie
+                            .score
+                            .frame_labels
+                            .iter()
+                            .find(|fl| fl.label.eq_ignore_ascii_case(&s))
+                            .map(|fl| fl.frame_num as u32)
                     }
                 }
 
@@ -479,7 +509,10 @@ impl MovieHandlers {
                         player.is_in_frame_update = false;
                     });
                 } else {
-                    warn!("Failed to run frame update in go function, already updating");
+                    // Benign re-entrancy guard (a `go` fired while a frame update
+                    // was already in progress); debug! to keep it out of the
+                    // browser console.
+                    debug!("Failed to run frame update in go function, already updating");
                 }
             }
         }

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -565,6 +565,14 @@ impl MovieHandlers {
                 sprite.entered = false;
                 sprite.exited = false;
                 sprite.script_instance_list.clear();
+                // Mark for revert on the NEXT frame tick. If the sprite is not
+                // re-puppeted / re-membered before then it reverts to the Score
+                // (a reset to empty for a pure-puppet channel with no span). This
+                // matches Director's deferred revert AND keeps BrickOut working
+                // (it re-puppets in the same handler, clearing the flag), while
+                // fixing Coke Studios' WallItems which unpuppet furniture WITHOUT
+                // setting visible=0 and relied on the old immediate wipe to clear.
+                sprite.pending_unpuppet_revert = true;
                 player.movie.score.invalidate_render_channel_cache();
                 player.refresh_stage_behavior_channel_cache_entry(sprite_number as i16);
                 player.invalidate_active_stage_filmloop_cache();
@@ -573,6 +581,8 @@ impl MovieHandlers {
 
             let sprite = player.movie.score.get_sprite_mut(sprite_number as i16);
             sprite.puppet = is_puppet;
+            // Re-puppeted before the deferred revert ran → keep its data.
+            sprite.pending_unpuppet_revert = false;
             player.movie.score.invalidate_render_channel_cache();
             player.refresh_stage_behavior_channel_cache_entry(sprite_number as i16);
             player.invalidate_active_stage_filmloop_cache();

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -969,6 +969,7 @@ impl MovieHandlers {
         crate::player::events::dispatch_w3d_timer_events().await;
         crate::player::events::tick_w3d_animations().await;
         crate::player::events::tick_w3d_particles().await;
+        crate::player::events::tick_w3d_collisions().await;
         crate::player::events::dispatch_physx_collision_callbacks().await;
 
         reserve_player_mut(|player| {

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -1097,6 +1097,39 @@ impl MovieHandlers {
                 || player.movie.mouse_down)
         })?;
 
+        // While a keyDown busy-wait loop is running (command_handler_yielding),
+        // the main frame loop is paused to keep its frame scripts from
+        // interleaving with the handler's bytecodes and corrupting the shared
+        // scope stack. But that also freezes any frame-driven animation (fish's
+        // `on prepareFrame` swimming fish) for as long as the key is held. Run
+        // the frame update HERE instead — on this task, nested in the keyDown
+        // handler, so it's sequential (no concurrent scope-stack corruption) —
+        // throttled to the movie tempo so a tight `repeat while keyPressed`
+        // loop calling updateStage() rapidly doesn't fast-forward the movie.
+        // execute_frame_update()'s is_in_frame_update guard blocks the recursive
+        // updateStage() that fires from inside prepareFrame.
+        let run_frame_anim = reserve_player_mut(|player| {
+            if !player.command_handler_yielding || player.is_in_frame_update {
+                return false;
+            }
+            let now = js_sys::Date::now();
+            let tempo = player.current_frame_tempo.max(1);
+            let interval = 1000.0 / tempo as f64;
+            if now - player.last_kb_loop_frame_ms >= interval {
+                player.last_kb_loop_frame_ms = now;
+                true
+            } else {
+                false
+            }
+        });
+        if run_frame_anim {
+            if let Err(err) = Self::execute_frame_update().await {
+                if err.code != ScriptErrorCode::Abort {
+                    reserve_player_mut(|player| player.on_script_error(&err));
+                }
+            }
+        }
+
         // Director's updateStage() forces an immediate stage redraw even from
         // inside enterFrame/prepareFrame loops. Yielding to the browser event loop
         // is only needed for busy-wait input handlers.

--- a/vm-rust/src/player/handlers/net.rs
+++ b/vm-rust/src/player/handlers/net.rs
@@ -51,21 +51,68 @@ impl NetHandlers {
 
     pub fn get_stream_status(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
-            // Support: no args (last task), int task ID, or URL string
-            let task_id = if args.is_empty() {
-                player.net_manager.get_last_task_id()
-                    .ok_or_else(|| ScriptError::new("No network tasks exist".to_string()))?
+            // Support: no args (last task), int task ID, or URL string.
+            // Resolve to Option<task_id> first so the datum borrow is released
+            // before we (mutably) alloc the result — and so an unknown URL can
+            // return a status instead of raising (Director's getStreamStatus
+            // never throws on a bad URL).
+            let mut req_url: Option<String> = None;
+            let resolved: Option<u32> = if args.is_empty() {
+                Some(
+                    player
+                        .net_manager
+                        .get_last_task_id()
+                        .ok_or_else(|| ScriptError::new("No network tasks exist".to_string()))?,
+                )
             } else {
                 let arg = player.get_datum(&args[0]);
                 match arg {
-                    Datum::Int(id) => *id as u32,
+                    Datum::Int(id) => Some(*id as u32),
                     Datum::String(url) => {
+                        req_url = Some(url.clone());
                         player.net_manager.find_task_by_url(url)
-                            .ok_or_else(|| ScriptError::new(format!("Network task not found for URL: {}", url)))?
-                    },
-                    _ => return Err(ScriptError::new(
-                        "getStreamStatus requires an integer task ID or URL string".to_string()
-                    ))
+                    }
+                    _ => {
+                        return Err(ScriptError::new(
+                            "getStreamStatus requires an integer task ID or URL string".to_string(),
+                        ))
+                    }
+                }
+            };
+            let task_id = match resolved {
+                Some(id) => id,
+                None => {
+                    // Unknown URL. A `#movie`'s linked file is loaded into a
+                    // nested DirPlayer (its net task consumed), so a status poll
+                    // of its URL has no task here — report Complete so load-status
+                    // pollers proceed rather than the debugger pausing on an error.
+                    let url = req_url.unwrap_or_default();
+                    let result_map = Datum::PropList(
+                        VecDeque::from(vec![
+                            (
+                                player.alloc_datum(Datum::String("URL".to_owned())),
+                                player.alloc_datum(Datum::String(url)),
+                            ),
+                            (
+                                player.alloc_datum(Datum::String("state".to_owned())),
+                                player.alloc_datum(Datum::String("Complete".to_owned())),
+                            ),
+                            (
+                                player.alloc_datum(Datum::String("bytesSoFar".to_owned())),
+                                player.alloc_datum(Datum::Int(0)),
+                            ),
+                            (
+                                player.alloc_datum(Datum::String("bytesTotal".to_owned())),
+                                player.alloc_datum(Datum::Int(0)),
+                            ),
+                            (
+                                player.alloc_datum(Datum::String("error".to_owned())),
+                                player.alloc_datum(Datum::String("OK".to_owned())),
+                            ),
+                        ]),
+                        false,
+                    );
+                    return Ok(player.alloc_datum(result_map));
                 }
             };
 
@@ -86,7 +133,16 @@ impl NetHandlers {
                 }
                 None => {
                     if task_state.bytes_loaded > 0 {
-                        ("InProgress", "", task_state.bytes_loaded as i32, task_state.bytes_total as i32)
+                        // If the server (or a CORS proxy) didn't advertise a
+                        // total, `bytes_total` is 0. Report the bytes loaded so
+                        // far as the total so callers that divide by it don't hit
+                        // a divide-by-zero and pin progress at 0% forever — DGS's
+                        // showGameLoadStats computes
+                        // `percentloaded = bytesloaded / bytestotal * 100`.
+                        // Accurate mid-load % still needs Content-Length (which
+                        // the proxy now preserves); this is the graceful floor.
+                        let total = task_state.bytes_total.max(task_state.bytes_loaded);
+                        ("InProgress", "", task_state.bytes_loaded as i32, total as i32)
                     } else {
                         ("Connecting", "", 0i32, 0i32)
                     }

--- a/vm-rust/src/player/handlers/net.rs
+++ b/vm-rust/src/player/handlers/net.rs
@@ -114,6 +114,24 @@ impl NetHandlers {
         })
     }
 
+    /// `netStatus msgString` — Director 11.5 Scripting Dictionary: a Command
+    /// that displays `msgString` in the status area of the browser window, and
+    /// "doesn't work in projectors". Modern browsers ignore `window.status`, so
+    /// there is no real status area to write to; we honor the documented VOID
+    /// return and treat it as a no-op (logged at debug for diagnostics — movies
+    /// like SpongeBob "JellyFishin'" call it once per download-progress tick to
+    /// surface "Download N% Complete").
+    pub fn net_status(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            if let Some(msg_ref) = args.get(0) {
+                if let Ok(msg) = player.get_datum(msg_ref).string_value() {
+                    log::debug!("netStatus: {}", msg);
+                }
+            }
+            Ok(DatumRef::Void)
+        })
+    }
+
     pub fn net_error(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let task_id = args

--- a/vm-rust/src/player/handlers/net.rs
+++ b/vm-rust/src/player/handlers/net.rs
@@ -1,13 +1,48 @@
 use std::collections::VecDeque;
 use crate::{
     director::lingo::datum::{datum_bool, Datum},
-    player::{reserve_player_mut, DatumRef, ScriptError},
+    player::{net_task::NetTaskState, reserve_player_mut, DatumRef, ScriptError},
 };
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 
 pub struct NetHandlers {}
 
 impl NetHandlers {
+    /// `netAbort(netID)` / `netAbort(URL)` — cancel a network operation without
+    /// waiting for a result (Director 11.5: a Command, returns nothing). We can't
+    /// interrupt an in-flight fetch, but we mark the task terminated with error
+    /// 4242 ("Download stopped by netAbort") so `netDone(id)` returns TRUE and
+    /// `netError(id)` reports it — the movie stops polling. An unknown id/URL is a
+    /// no-op. Returns VOID.
+    pub fn net_abort(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            let (id_opt, url_opt) = if let Some(dr) = args.first() {
+                let d = player.get_datum(dr);
+                (d.int_value().ok().map(|v| v as u32), d.string_value().ok())
+            } else {
+                (None, None)
+            };
+            let task_id = id_opt.or_else(|| {
+                url_opt.and_then(|u| player.net_manager.find_task_by_url(&u))
+            });
+            if let Some(id) = task_id {
+                if let Some(mut shared) = player.net_manager.shared_state.try_lock() {
+                    // "If the data transmission is complete, this command has no
+                    // effect." — only terminate a task that is still in progress.
+                    let in_progress =
+                        shared.task_states.get(&id).map_or(false, |s| s.result.is_none());
+                    if in_progress {
+                        shared.update_task_state(
+                            id,
+                            NetTaskState { result: Some(Err(4242)), bytes_loaded: 0, bytes_total: 0 },
+                        );
+                    }
+                }
+            }
+            Ok(DatumRef::Void)
+        })
+    }
+
     pub fn net_done(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let task_id = if let Some(task_id_ref) = &args.get(0) {

--- a/vm-rust/src/player/handlers/net.rs
+++ b/vm-rust/src/player/handlers/net.rs
@@ -16,8 +16,16 @@ impl NetHandlers {
             } else {
                 None
             };
-            let task_state = player.net_manager.get_task_state(task_id);
-            let is_done = task_state.is_some_and(|state| state.is_done());
+            // Director 11.5: netDone returns TRUE (the default) when the
+            // operation is finished OR was terminated by a browser error, and
+            // FALSE only while genuinely in progress. An unknown / never-started
+            // id (e.g. mixmaster's Billboard polls netDone(-1) when there is no
+            // billboard URL) is therefore "done", not "in progress" — returning
+            // FALSE there made the movie spin on the download state.
+            let is_done = match player.net_manager.get_task_state(task_id) {
+                Some(state) => state.is_done(),
+                None => true,
+            };
             Ok(player.alloc_datum(datum_bool(is_done)))
         })
     }
@@ -137,14 +145,25 @@ impl NetHandlers {
             let task_id = args
                 .get(0)
                 .and_then(|datum_ref| player.get_datum(datum_ref).int_value().ok()).map(|id| id as u32);
-            let task_state = player.net_manager.get_task_state(task_id).ok_or_else(|| ScriptError::new("Network task not found".to_string()))?;
-            let is_ok = task_state.is_done() && task_state.result.as_ref().unwrap().is_ok();
-            let error = if is_ok {
-                Datum::String("OK".to_owned())
-            } else if let Some(Err(error)) = task_state.result.as_ref() {
-                Datum::Int(*error)
-            } else {
-                Datum::Int(0)
+            // Director 11.5: netError returns an empty string when no background
+            // loading operation has started for this id (or it is still in
+            // progress), "OK" on success, else an error code. An unknown id must
+            // NOT raise — mixmaster's Billboard calls netError(-1) with no
+            // billboard URL, and raising aborts the exitFrame handler, leaving
+            // the stage's black bgColor stuck (blank screen).
+            let error = match player.net_manager.get_task_state(task_id) {
+                None => Datum::String("".to_owned()),
+                Some(task_state) => {
+                    let is_ok = task_state.is_done()
+                        && task_state.result.as_ref().is_some_and(|r| r.is_ok());
+                    if is_ok {
+                        Datum::String("OK".to_owned())
+                    } else if let Some(Err(error)) = task_state.result.as_ref() {
+                        Datum::Int(*error)
+                    } else {
+                        Datum::Int(0)
+                    }
+                }
             };
             Ok(player.alloc_datum(error))
         })
@@ -155,17 +174,22 @@ impl NetHandlers {
             let task_id = args
                 .get(0)
                 .and_then(|datum_ref| player.get_datum(datum_ref).int_value().ok()).map(|id| id as u32);
-            let task_state = player.net_manager.get_task_state(task_id).ok_or_else(|| ScriptError::new("Network task not found".to_string()))?;
-            let is_ok = task_state.is_done() && task_state.result.as_ref().unwrap().is_ok();
-            let text = if is_ok {
-                let bytes = task_state.result.as_ref().unwrap().as_ref().unwrap();
-                // UTF-8 strict first (modern editors), Win-1252 fallback
-                // (legacy Director-authored external_texts_*.txt etc.).
-                // Strips a UTF-8 BOM if present. See io::encoding for why
-                // strict-then-fallback is unambiguous in practice.
-                Datum::String(crate::io::encoding::decode_text_auto(bytes))
-            } else {
-                Datum::String("".to_owned())
+            // netTextResult returns the downloaded text, or an empty string if
+            // the operation failed, is in progress, or the id is unknown (Director
+            // does not raise on a bad id).
+            let text = match player.net_manager.get_task_state(task_id) {
+                Some(task_state)
+                    if task_state.is_done()
+                        && task_state.result.as_ref().is_some_and(|r| r.is_ok()) =>
+                {
+                    let bytes = task_state.result.as_ref().unwrap().as_ref().unwrap();
+                    // UTF-8 strict first (modern editors), Win-1252 fallback
+                    // (legacy Director-authored external_texts_*.txt etc.).
+                    // Strips a UTF-8 BOM if present. See io::encoding for why
+                    // strict-then-fallback is unambiguous in practice.
+                    Datum::String(crate::io::encoding::decode_text_auto(bytes))
+                }
+                _ => Datum::String("".to_owned()),
             };
             Ok(player.alloc_datum(text))
         })

--- a/vm-rust/src/player/handlers/string.rs
+++ b/vm-rust/src/player/handlers/string.rs
@@ -52,6 +52,12 @@ impl StringHandlers {
                     let s = obj.string_value()?;
                     Ok(player.alloc_datum(Datum::Int(s.chars().count() as i32)))
                 }
+                // Director coerces VOID to EMPTY in string contexts, so
+                // `length(VOID)` is `length("")` = 0. This underpins the very
+                // common "is this set?" idiom `if length(me.prop) > 0` on an
+                // uninitialised property (which reads VOID) — e.g. Neopets DGS
+                // `setFlashLoaderVars`: `if length(me.gameVersion) > 0`.
+                Datum::Void => Ok(player.alloc_datum(Datum::Int(0))),
                 _ => Err(ScriptError::new(
                     "Cannot get length of non-string".to_string(),
                 )),

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -444,6 +444,19 @@ impl TypeHandlers {
                     normalise_lingo_expr_for_value,
                 };
                 let cleaned = normalise_lingo_expr_for_value(&s);
+                // Director's `value()` evaluates the FIRST complete expression
+                // and ignores any trailing tokens. When the input is a list /
+                // property list, trim to the matching close bracket so trailing
+                // garbage doesn't fail the whole parse. Summer Resort's room
+                // members are Paige #text stored in over-allocated text blocks:
+                // the buffer holds the real room list followed by stale bytes
+                // left from a prior edit (Paige tracks the logical length but
+                // XMED serializes the whole buffer). Parsing the whole thing
+                // returned VOID, which blanked the room (and broke map
+                // navigation, since the `= #empty` boundary check then let the
+                // player scroll into an unparsed/black room). Trimming to the
+                // first balanced list matches Director and recovers the room.
+                let cleaned = truncate_to_first_balanced_list(&cleaned);
                 // TEMP diagnostic: log EVERY value() call that looks like a
                 // Lingo prop-list/list so we can confirm whether the Coke
                 // Studios ElementManager retry (concatenating the two halves
@@ -2094,6 +2107,42 @@ impl TypeHandlers {
             Ok(player.alloc_datum(Datum::Int(if is_busy { 1 } else { 0 })))
         })
     }
+}
+
+/// Director's `value()` evaluates only the FIRST complete expression in the
+/// string. When that expression is a list or property list, trailing tokens
+/// after the matching close bracket are ignored. If `s` (ignoring leading
+/// whitespace) starts with `[`, return the slice up to and including the
+/// bracket that balances it; otherwise return `s` unchanged.
+///
+/// Bracket scanning is string-aware: `[`/`]` inside a Lingo string literal
+/// (`"..."`) don't count. Lingo string literals cannot contain a literal
+/// double quote (the `QUOTE` constant is used instead), so a simple in-string
+/// toggle is sufficient. If the brackets never balance, `s` is returned as-is
+/// so the normal parser still reports the error.
+fn truncate_to_first_balanced_list(s: &str) -> String {
+    let trimmed_start = s.len() - s.trim_start().len();
+    let bytes = s.as_bytes();
+    if bytes.get(trimmed_start) != Some(&b'[') {
+        return s.to_string();
+    }
+    let mut depth: i32 = 0;
+    let mut in_string = false;
+    for (i, &b) in bytes.iter().enumerate().skip(trimmed_start) {
+        match b {
+            b'"' => in_string = !in_string,
+            b'[' if !in_string => depth += 1,
+            b']' if !in_string => {
+                depth -= 1;
+                if depth == 0 {
+                    // Include this closing bracket; drop everything after.
+                    return s[..=i].to_string();
+                }
+            }
+            _ => {}
+        }
+    }
+    s.to_string()
 }
 
 /// Returns true if the given input/cleaned strings look like a Lingo

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -254,6 +254,12 @@ impl TypeUtils {
                     player.alloc_datum(Datum::Void)
                 }
             }
+            // Subscripting a VOID value yields VOID in Director — it never
+            // raises. g349's `on particle` does `g.particles[g.cparticle]`;
+            // before `g.particles` is populated (or after teardown) it is VOID,
+            // so `VOID[n]` reads VOID and the subsequent `.spawn(Args)` is a
+            // silent no-op on VOID rather than an error.
+            Datum::Void => player.alloc_datum(Datum::Void),
             _ => {
                 web_sys::console::log_1(
                     &format!(

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -1744,17 +1744,27 @@ impl TypeHandlers {
 
     pub fn atan(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
-            let value = player.get_datum(&args[0]);
-            
-            let num = if let Ok(f) = value.float_value() {
-                f
-            } else if let Ok(i) = value.int_value() {
-                i as f64
-            } else {
-                return Err(ScriptError::new("atan requires a number".to_string()));
+            let num = |dr: &DatumRef| -> Result<f64, ScriptError> {
+                let value = player.get_datum(dr);
+                if let Ok(f) = value.float_value() {
+                    Ok(f)
+                } else if let Ok(i) = value.int_value() {
+                    Ok(i as f64)
+                } else {
+                    Err(ScriptError::new("atan requires a number".to_string()))
+                }
             };
-            
-            let result = num.atan();
+            let a0 = num(&args[0])?;
+            // Two-arg `atan(y, x)` is arctangent-of-two-values (atan2). Director's
+            // built-in atan is single-arg, but the 3D Groove Xtra exports a 2-arg
+            // `atan` (RE: `atan(a1,a2) = atan2(a2,a1)`) that movies call to aim one
+            // object at another (e.g. BioBoxing's `atan(dx, dy)` enemy heading).
+            // Built-ins resolve before xtra commands, so handle the 2-arg form here.
+            let result = if args.len() >= 2 {
+                a0.atan2(num(&args[1])?)
+            } else {
+                a0.atan()
+            };
             Ok(player.alloc_datum(Datum::Float(result)))
         })
     }

--- a/vm-rust/src/player/js_lingo_loader.rs
+++ b/vm-rust/src/player/js_lingo_loader.rs
@@ -127,6 +127,16 @@ fn register_runtime(member_ref: &CastMemberRef, ir: JsScriptIR) {
     });
 }
 
+/// Drop every registered JS-Lingo runtime. Called on movie reset so the
+/// previous movie's runtimes (and everything their global scope holds) don't
+/// leak across a movie switch — this map is a `thread_local`, so unlike the
+/// player's own caches it is NOT freed when the `DirPlayer` is dropped.
+/// Runtimes are re-registered lazily by `diagnose_js_script` as the new
+/// movie's scripts load.
+pub fn clear_all_runtimes() {
+    JS_RUNTIMES.with(|m| m.borrow_mut().clear());
+}
+
 /// Hook called from `player_call_script_handler_raw_args` before the
 /// existing Lingo handler lookup. `receiver` is the Script instance that
 /// owns the handler (Director's `me`): when set, it's prepended to the

--- a/vm-rust/src/player/keyboard.rs
+++ b/vm-rust/src/player/keyboard.rs
@@ -94,11 +94,31 @@ impl KeyboardManager {
         key.code
     }
 
+    /// Translate a stored browser key name (e.g. `e.key` = "ArrowLeft") to the
+    /// single character Director's `the key` / `the keyPressed` report. Director
+    /// returns its arrow-key char constants — numToChar(28..31) — so movies that
+    /// test `charToNum(the keyPressed) = 28` (left), 29 (right), 30 (up),
+    /// 31 (down) work. bogey_nights' dog-movement `case` falls to exactly these
+    /// tests for single-arrow (non-diagonal) presses. Returns None for keys with
+    /// no Director char equivalent (function keys, "Shift", etc.).
+    fn director_char_for(key: &str) -> Option<char> {
+        match key {
+            "ArrowLeft" => Some('\u{1C}'),  // 28
+            "ArrowRight" => Some('\u{1D}'), // 29
+            "ArrowUp" => Some('\u{1E}'),    // 30
+            "ArrowDown" => Some('\u{1F}'),  // 31
+            _ => None,
+        }
+    }
+
     pub fn key(&self) -> String {
         if self.down_keys.is_empty() {
             return "".to_string();
         }
         let key = &self.down_keys.last().unwrap().key;
+        if let Some(ch) = Self::director_char_for(key) {
+            return ch.to_string();
+        }
         if key.len() == 1 && key.as_bytes()[0] < 0x80 {
             key.clone()
         } else {
@@ -110,6 +130,10 @@ impl KeyboardManager {
         if self.down_keys.is_empty() {
             return "".to_string();
         }
-        self.down_keys.last().unwrap().key.clone()
+        let key = &self.down_keys.last().unwrap().key;
+        if let Some(ch) = Self::director_char_for(key) {
+            return ch.to_string();
+        }
+        key.clone()
     }
 }

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -661,7 +661,7 @@ impl DirPlayer {
                     // (StoryScramble posters) never reflow. Only for on-stage
                     // sprites (positive channel); 3D-texture instances excluded
                     // in the JS twin.
-                    ruffle_set_size(
+                    let _ = ruffle_set_size(
                         channel_num as i32,
                         channel.sprite.width.max(1) as i32,
                         channel.sprite.height.max(1) as i32,
@@ -736,10 +736,12 @@ impl DirPlayer {
             })
             .collect();
         for (cn, total) in loop_check {
-            if !ruffle_is_playing(cn as i32) {
+            // Bridge not installed (test harness / pre-init) → treat as "not
+            // playing" and skip; the `catch` keeps the frame loop alive.
+            if !ruffle_is_playing(cn as i32).unwrap_or(false) {
                 continue;
             }
-            let cur = ruffle_get_current_frame(cn as i32);
+            let cur = ruffle_get_current_frame(cn as i32).unwrap_or(0);
             if cur < 1 {
                 continue;
             }
@@ -751,7 +753,7 @@ impl DirPlayer {
                 .unwrap_or(0);
             let wrapped = prev >= 1 && cur < prev;
             if cur >= total || wrapped {
-                ruffle_goto_frame_and_stop(cn as i32, &total.to_string());
+                let _ = ruffle_goto_frame_and_stop(cn as i32, &total.to_string());
             }
             self.movie.score.get_sprite_mut(cn).flash_prev_frame = cur;
         }
@@ -1258,6 +1260,16 @@ impl DirPlayer {
 
     pub fn reset(&mut self) {
         self.stop();
+
+        // Silence any sound still playing from the movie we're leaving and tear
+        // down its Flash/Ruffle instances (their capture RAF loops + SWF audio),
+        // so switching movies doesn't leave old sounds looping or leak players.
+        self.sound_manager.stop_all();
+        self.flash_frame_buffers.clear();
+        JsApi::dispatch_flash_reset_all();
+        // JS-Lingo runtimes live in a thread_local map, not on the player, so
+        // they survive both this reset and a full player drop — clear them here.
+        crate::player::js_lingo_loader::clear_all_runtimes();
 
         // Cancel any outstanding on-demand xtra loads so leftover oneshot
         // receivers don't leak across movies. Each waiter sees `false`
@@ -3948,16 +3960,22 @@ extern "C" {
 
     /// Resize a live Ruffle instance so it re-renders the vector sharp at the
     /// sprite's current on-stage size (splashes grow, arm swaps dims).
-    #[wasm_bindgen(js_name = "dirplayer_ruffleSetSize")]
-    fn ruffle_set_size(sprite_num: i32, w: i32, h: i32);
+    ///
+    /// `catch`: these four are called from the per-frame loop, so a page that
+    /// hasn't installed the Flash bridge (`initFlashBridge`) — e.g. the e2e test
+    /// harness, or the dev app before startup wiring runs — would otherwise throw
+    /// a `ReferenceError` (`dirplayer_ruffleSetSize is not defined`) that aborts
+    /// the whole frame loop. With `catch` the missing global degrades to a no-op.
+    #[wasm_bindgen(js_name = "dirplayer_ruffleSetSize", catch)]
+    fn ruffle_set_size(sprite_num: i32, w: i32, h: i32) -> Result<(), wasm_bindgen::JsValue>;
 
     // Used to halt a `loop = false` Flash sprite at end-of-timeline.
-    #[wasm_bindgen(js_name = "dirplayer_ruffleIsPlaying")]
-    fn ruffle_is_playing(sprite_num: i32) -> bool;
-    #[wasm_bindgen(js_name = "dirplayer_ruffleGetCurrentFrame")]
-    fn ruffle_get_current_frame(sprite_num: i32) -> i32;
-    #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrameAndStop")]
-    fn ruffle_goto_frame_and_stop(sprite_num: i32, frame_or_label: &str);
+    #[wasm_bindgen(js_name = "dirplayer_ruffleIsPlaying", catch)]
+    fn ruffle_is_playing(sprite_num: i32) -> Result<bool, wasm_bindgen::JsValue>;
+    #[wasm_bindgen(js_name = "dirplayer_ruffleGetCurrentFrame", catch)]
+    fn ruffle_get_current_frame(sprite_num: i32) -> Result<i32, wasm_bindgen::JsValue>;
+    #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrameAndStop", catch)]
+    fn ruffle_goto_frame_and_stop(sprite_num: i32, frame_or_label: &str) -> Result<(), wasm_bindgen::JsValue>;
 }
 /// Execute one complete frame cycle: run frame scripts, then advance to the next frame.
 /// Returns (is_playing, is_script_paused) so callers can check if the movie is still running.

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -3899,6 +3899,14 @@ pub async fn run_single_frame() -> (bool, bool) {
         if has_frame_changed_in_go && go_direction == 1 { // backwards
             dispatch_event_to_all_behaviors(&"exitFrame".to_string(), &vec![]).await;
         } else {
+            // Forward advance/go: the arriving (or looping-in-place) frame's sprite
+            // BEHAVIORS were never sent exitFrame here — only the frame+movie scripts ran —
+            // so a sprite's FIRST exitFrame on the frame it lands on was lost (Director fires
+            // beginSprite -> enterFrame -> exitFrame in one frame visit; e.g. a RaycastCar's
+            // updateWheelModels ran a frame late, leaving its wheels in the hover-ray path).
+            // Dispatch the behaviors' exitFrame first (matching the backwards-go branch and
+            // the stayed-on-frame else branch below), then the frame+movie script exitFrames.
+            dispatch_event_to_all_behaviors(&"exitFrame".to_string(), &vec![]).await;
             if let Err(err) = player_invoke_frame_and_movie_scripts(&"exitFrame".to_string(), &vec![]).await {
                 if err.code != ScriptErrorCode::Abort {
                     reserve_player_mut(|player| player.on_script_error(&err));

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -705,6 +705,56 @@ impl DirPlayer {
             }
         }
 
+        // LOOP=false stop-at-end pass. A Flash member with `loop` disabled plays
+        // once and halts at its last frame (Director: `the playing of sprite`
+        // then becomes FALSE — eds_kart_attack's "Wait for Flash" behavior loops
+        // the Director frame until sprite(1).playing = 0). Ruffle, however, loops
+        // the root timeline forever when the SWF has no internal stop(). So for
+        // loop-disabled Flash sprites, watch the root playhead and, once it
+        // reaches the last frame (or wraps past it), gotoAndStop the final frame.
+        let loop_check: Vec<(i16, i32)> = self
+            .movie
+            .score
+            .channels
+            .iter()
+            .filter_map(|channel| {
+                let cn = channel.number as i16;
+                let member_ref = channel.sprite.member.as_ref()?;
+                let member = self.movie.cast_manager.find_member_by_ref(member_ref)?;
+                if let CastMemberType::Flash(f) = &member.member_type {
+                    let loops = f.flash_info.as_ref().map_or(true, |i| i.loop_enabled);
+                    if !loops {
+                        let total = crate::player::cast_member::CastMember::parse_swf_frame_count(&f.data)
+                            .map(|n| n as i32)
+                            .unwrap_or(0);
+                        if total > 1 {
+                            return Some((cn, total));
+                        }
+                    }
+                }
+                None
+            })
+            .collect();
+        for (cn, total) in loop_check {
+            if !ruffle_is_playing(cn as i32) {
+                continue;
+            }
+            let cur = ruffle_get_current_frame(cn as i32);
+            if cur < 1 {
+                continue;
+            }
+            let prev = self
+                .movie
+                .score
+                .get_sprite(cn)
+                .map(|s| s.flash_prev_frame)
+                .unwrap_or(0);
+            let wrapped = prev >= 1 && cur < prev;
+            if cur >= total || wrapped {
+                ruffle_goto_frame_and_stop(cn as i32, &total.to_string());
+            }
+            self.movie.score.get_sprite_mut(cn).flash_prev_frame = cur;
+        }
     }
 
     /// True if the given score channel currently holds a Flash (SWF) cast
@@ -3889,6 +3939,14 @@ extern "C" {
     /// sprite's current on-stage size (splashes grow, arm swaps dims).
     #[wasm_bindgen(js_name = "dirplayer_ruffleSetSize")]
     fn ruffle_set_size(sprite_num: i32, w: i32, h: i32);
+
+    // Used to halt a `loop = false` Flash sprite at end-of-timeline.
+    #[wasm_bindgen(js_name = "dirplayer_ruffleIsPlaying")]
+    fn ruffle_is_playing(sprite_num: i32) -> bool;
+    #[wasm_bindgen(js_name = "dirplayer_ruffleGetCurrentFrame")]
+    fn ruffle_get_current_frame(sprite_num: i32) -> i32;
+    #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrameAndStop")]
+    fn ruffle_goto_frame_and_stop(sprite_num: i32, frame_or_label: &str);
 }
 /// Execute one complete frame cycle: run frame scripts, then advance to the next frame.
 /// Returns (is_playing, is_script_paused) so callers can check if the movie is still running.

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -1231,8 +1231,26 @@ impl DirPlayer {
                 .map(|sprite| sprite.script_instance_list.clone())
                 .unwrap_or_default();
             let synced_ids = self.get_sprite_script_instance_ids(sprite_id, &existing_ids);
-            let sprite = self.movie.score.get_sprite_mut(sprite_id);
-            sprite.script_instance_list = synced_ids;
+            {
+                let sprite = self.movie.score.get_sprite_mut(sprite_id);
+                sprite.script_instance_list = synced_ids.clone();
+            }
+            // Stamp `spriteNum` on every instance so `the currentSpriteNum`
+            // resolves for behaviors attached at RUNTIME via
+            // `add(the scriptInstanceList of sprite X, new(script(...)))`. That
+            // add-to-cache path bypasses the scriptInstanceList *setter* (which
+            // stamps spriteNum) and the score begin-sprite path, so without this
+            // the instance's spriteNum stayed Void and `the currentSpriteNum`
+            // returned 0. Summer Resort's inventory icons attach
+            // inventory.select.item this way and read `the currentSpriteNum` in
+            // their mouseUp to identify the clicked item — a 0 there made
+            // `getPos(page, "")` return 0 and crashed showDescription.
+            let sprite_num_ref = self.alloc_datum(Datum::Int(sprite_id as i32));
+            for inst in &synced_ids {
+                let _ = crate::player::script::script_set_prop(
+                    self, inst, "spriteNum", &sprite_num_ref, false,
+                );
+            }
         }
     }
 

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -3234,6 +3234,27 @@ pub async fn player_call_global_handler(
     handler_name: &str,
     args: &Vec<DatumRef>,
 ) -> Result<DatumRef, ScriptError> {
+    // Director 6 `birth(script, args)` constructor: when the first arg is a
+    // ScriptRef this is the pre-`new` idiom — allocate a FRESH instance and run
+    // its `on birth me, args`. This MUST run before the generic first-arg
+    // handler lookup below, which would otherwise find the script's `on birth`
+    // and invoke it statically (no instance), so every same-script `birth`
+    // shared one property set. (100s-Marios births 200 marios via
+    // `birth(script "MarioScript", 3+i)`; the shared `sn`/`timr`/`pipe` made all
+    // 50 same-script marios drive one sprite and emerge at once.)
+    if handler_name == "birth" && !args.is_empty() {
+        let first_is_script = reserve_player_ref(|player| {
+            Ok(matches!(player.get_datum(&args[0]), Datum::ScriptRef(_)))
+        })?;
+        if first_is_script {
+            return crate::player::handlers::datum_handlers::script::ScriptDatumHandlers::birth(
+                &args[0],
+                &args[1..].to_vec(),
+            )
+            .await;
+        }
+    }
+
     let receiver_handler = unsafe {
         // let player_opt = PLAYER_LOCK.try_read().unwrap();
         let player = crate::player::player_mut();

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -1900,6 +1900,47 @@ impl DirPlayer {
                 Ok(self.alloc_datum(Datum::DateRef(date_id)))
             },
             "stage" => Ok(self.alloc_datum(Datum::Stage)),
+            "globals" => {
+                // Director 11.5 Scripting Dictionary — `the globals`:
+                // a special property list of every current global variable
+                // whose value is not VOID, each keyed by its name (symbol)
+                // paired with the value. Supports count/getPropAt/getProp/
+                // getAProp via the normal PropList handlers. The list always
+                // contains #version (Director's running version), so it is
+                // never empty even before any global is declared.
+                //
+                // dirplayer stores the Lingo language constants (PI, EMPTY,
+                // QUOTE, TAB, TRUE, FALSE, …) as globals internally for
+                // convenience, but Director does NOT expose those as global
+                // variables, so they're excluded here to match the spec.
+                // actorList is a genuine global and is kept.
+                const CONST_GLOBALS: &[&str] = &[
+                    "PI", "VOID", "EMPTY", "RETURN", "ENTER", "QUOTE", "TAB",
+                    "BACKSPACE", "TRUE", "FALSE",
+                ];
+                let entries: Vec<(String, DatumRef)> = self
+                    .globals
+                    .iter()
+                    .filter(|(name, r)| {
+                        if CONST_GLOBALS.iter().any(|c| c.eq_ignore_ascii_case(name)) {
+                            return false;
+                        }
+                        // Skip globals whose value is VOID (spec).
+                        !matches!(self.get_datum(r), Datum::Void)
+                    })
+                    .map(|(name, r)| (name.clone(), r.clone()))
+                    .collect();
+                let mut props: VecDeque<(DatumRef, DatumRef)> = entries
+                    .into_iter()
+                    .map(|(name, value_ref)| {
+                        (self.alloc_datum(Datum::Symbol(name)), value_ref)
+                    })
+                    .collect();
+                let version_key = self.alloc_datum(Datum::Symbol("version".to_string()));
+                let version_val = self.alloc_datum(Datum::String("11.0".to_string()));
+                props.push_back((version_key, version_val));
+                Ok(self.alloc_datum(Datum::PropList(props, false)))
+            },
             "time" => Ok(self.alloc_datum(Datum::String(
                 chrono::Local::now().format("%H:%M %p").to_string(),
             ))),

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -639,6 +639,33 @@ impl DirPlayer {
                 }
             }
         }
+
+        // Reconcile: tear down any Ruffle instance whose channel no longer
+        // holds that exact Flash member. Instances are otherwise only destroyed
+        // on an external-cast swap (invalidate_flash_for_cast_lib), so a channel
+        // that showed a Flash member once would keep its WebGL-backed Ruffle
+        // player forever. bogey_nights churns Flash sprites hard — every splash
+        // that reaches #superstar swaps its bitmap member for the boogyflash /
+        // spitflash SWF, and `killer` empties the channel a moment later. Across
+        // hundreds of channels this leaks Ruffle instances until the browser
+        // hits its WebGL context cap ("Too many active WebGL contexts"). Freeing
+        // the instance as soon as its Flash member leaves keeps only the
+        // genuinely-active Flash sprites alive.
+        let loaded: Vec<(i16, i32, i32)> = self.flash_sprite_loaded.iter().cloned().collect();
+        for (ch, cl, cm) in loaded {
+            let still_present = self
+                .movie
+                .score
+                .get_sprite(ch)
+                .and_then(|s| s.member.as_ref())
+                .map(|m| m.cast_lib == cl && m.cast_member == cm)
+                .unwrap_or(false);
+            if !still_present {
+                JsApi::dispatch_flash_member_unloaded(ch as i32);
+                self.flash_sprite_loaded.remove(&(ch, cl, cm));
+                self.flash_frame_buffers.remove(&ch);
+            }
+        }
     }
 
     /// Tear down any Flash (Ruffle) instances whose source member lives in the

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -351,6 +351,18 @@ pub struct DirPlayer {
     /// ordinary interactions (navigator windows vanishing/rebuilding). Keeps the
     /// hundreds of per-frame interop calls sync with no async-dispatch overhead.
     pub flash_ready_sprites: HashSet<i16>,
+    /// Flash `LocalConnection` receiver registry (Neopets DGS score/protocol).
+    /// A Director-created LocalConnection is `newObject("LocalConnection")` →
+    /// synthetic `_root.__dpObj_LocalConnection_N` ref, `connect(name)` claims a
+    /// name, and `setCallback(lc, method, #handler, target)` wires a method. The
+    /// SWF's AS `LocalConnection.send(name, method, args)` is forwarded by the
+    /// Ruffle fork to `local_connection_send`, which routes name→lc_path→handler.
+    /// `flash_lc_connections`: connection name → lc synthetic path.
+    pub flash_lc_connections: std::collections::HashMap<String, String>,
+    /// `(lc_path, method)` → `(lingo handler, target instance)` — the target keeps
+    /// `me` correct in `on <handler> me, aInfo, aMessage`.
+    pub flash_lc_callbacks:
+        std::collections::HashMap<(String, String), (String, ScriptInstanceRef)>,
     /// Set true whenever a script reads live input state — `keyPressed(...)`,
     /// `the mouseDown`, `the stillDown`. The bytecode loop's busy-wait yield
     /// counts a loop iteration toward yielding ONLY when this was set that
@@ -548,6 +560,8 @@ impl DirPlayer {
             flash_frame_buffers: HashMap::new(),
             flash_sprite_loaded: HashSet::new(),
             flash_ready_sprites: HashSet::new(),
+            flash_lc_connections: std::collections::HashMap::new(),
+            flash_lc_callbacks: std::collections::HashMap::new(),
             input_polled: false,
             flash_texture_targets: HashMap::new(),
             w3d_frame_buffers: HashMap::new(),

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -387,6 +387,20 @@ pub struct DirPlayer {
     pub in_step_frame: bool,
     pub in_event_dispatch: bool,
     pub command_handler_yielding: bool, // Pauses frame loop when a command handler (keyDown) needs updateStage to yield
+    /// Frame/movie-script handlers currently executing via player_invoke_static_event,
+    /// as (script member, handler name). Guards against a static-event handler
+    /// being re-invoked while it's already on the call stack for the SAME event —
+    /// Director's message system won't re-dispatch a message to a handler already
+    /// processing it. Fish's movie `on keyDown` does `sendSprite(4, #keyDown)`,
+    /// which (when sprite 4 has no keyDown behavior) propagates back up to the
+    /// movie script per the sendSprite hierarchy; without this guard it recurses
+    /// into the same `on keyDown` forever (stack overflow).
+    pub active_static_event_handlers: Vec<(CastMemberRef, String)>,
+    /// Timestamp (Date.now ms) of the last frame update driven from updateStage()
+    /// while `command_handler_yielding`. The frame loop is paused during a keyDown
+    /// busy-wait loop, so updateStage() runs the frame's animation itself,
+    /// throttled by tempo — see MovieHandlers::update_stage.
+    pub last_kb_loop_frame_ms: f64,
     pub in_mouse_command: bool, // Pauses frame loop during mouse handlers; updateStage renders without yielding
     pub nothing_call_count: u32,    // Consecutive nothing() calls, reset after yield
     pub last_nothing_yield_ms: f64, // Timestamp of last nothing() yield for time-throttled rendering
@@ -573,6 +587,8 @@ impl DirPlayer {
             in_step_frame: false,
             in_event_dispatch: false,
             command_handler_yielding: false,
+            active_static_event_handlers: Vec::new(),
+            last_kb_loop_frame_ms: 0.0,
             in_mouse_command: false,
             nothing_call_count: 0,
             last_nothing_yield_ms: 0.0,

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -88,7 +88,6 @@ use script::script_get_prop_opt;
 use script_ref::ScriptInstanceRef;
 use sprite::Sprite;
 use xtra::curl::{CurlXtraManager, CURL_XTRA_MANAGER_OPT};
-use xtra::groove::{GrooveXtraManager, GROOVE_XTRA_MANAGER_OPT};
 use xtra::fileio::{FileIoXtraManager, FILEIO_XTRA_MANAGER_OPT};
 use xtra::multiuser::{MultiuserXtraManager, MULTIUSER_XTRA_MANAGER_OPT};
 use xtra::xmlparser::{XmlParserXtraManager, XMLPARSER_XTRA_MANAGER_OPT};
@@ -1562,6 +1561,9 @@ impl DirPlayer {
         // found" ScriptError instead of hanging forever.
         debug!("Cancelling pending external-xtra loads");
         crate::player::xtra::external::cancel_all_pending_loads();
+        // Drop any external-Xtra 3D scenes from the previous movie; their GL
+        // resources are freed the next time the renderer sees them gone.
+        crate::player::xtra::scene3d::clear_all();
 
         // Clear all references before resetting the allocator
         // This ensures all DatumRef and ScriptInstanceRef objects are dropped properly
@@ -5710,7 +5712,6 @@ pub fn init_player() {
         MULTIUSER_XTRA_MANAGER_OPT = Some(MultiuserXtraManager::new());
         XMLPARSER_XTRA_MANAGER_OPT = Some(XmlParserXtraManager::new());
         CURL_XTRA_MANAGER_OPT = Some(CurlXtraManager::new());
-        GROOVE_XTRA_MANAGER_OPT = Some(GrooveXtraManager::new());
     }
 
     unsafe {

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -337,6 +337,27 @@ pub struct DirPlayer {
     /// duplicate `createFlashInstance` calls every frame before the
     /// instance's first pixels arrive.
     pub flash_sprite_loaded: HashSet<(i16, i32, i32)>,
+    /// Sprites whose Ruffle instance has been confirmed loaded + AS-initialized
+    /// at least once. Flash interop (getVariable/setVariable/callFunction/
+    /// setCallback) takes the SYNC fast path for these; only the FIRST access to
+    /// a sprite ever goes through the async wait (which then adds it here).
+    /// STICKY on purpose — never cleared: once a sprite has had a ready instance
+    /// we always take the sync path, which safely returns null/void if the
+    /// instance is transiently not ready (a member swap / reload), exactly as
+    /// interop behaved before the ready-wait existed. The async path exists only
+    /// to make the one-shot startup call (Coke Studios' SESSION_createSession,
+    /// which runs before its SWF is dispatched) get a live instance; clearing
+    /// this would re-arm the async path mid-game and reload the instance on
+    /// ordinary interactions (navigator windows vanishing/rebuilding). Keeps the
+    /// hundreds of per-frame interop calls sync with no async-dispatch overhead.
+    pub flash_ready_sprites: HashSet<i16>,
+    /// Set true whenever a script reads live input state — `keyPressed(...)`,
+    /// `the mouseDown`, `the stillDown`. The bytecode loop's busy-wait yield
+    /// counts a loop iteration toward yielding ONLY when this was set that
+    /// iteration, so it cooperatively yields for input-wait spins (Neopets'
+    /// `repeat while keyPressed(" ") end`) but NEVER for compute/AMF loops (Coke
+    /// Studios' object-graph conversion), where a yield only adds latency.
+    pub input_polled: bool,
     /// Off-screen Flash members rendered into W3D textures (frog01's environment:
     /// `newTexture(#fromCastMember, flashMember)`). Keyed by a synthetic NEGATIVE
     /// sprite number (so it never collides with on-stage positive channels);
@@ -526,6 +547,8 @@ impl DirPlayer {
             in_frame_script: false,
             flash_frame_buffers: HashMap::new(),
             flash_sprite_loaded: HashSet::new(),
+            flash_ready_sprites: HashSet::new(),
+            input_polled: false,
             flash_texture_targets: HashMap::new(),
             w3d_frame_buffers: HashMap::new(),
             in_enter_frame: false,
@@ -2370,7 +2393,7 @@ impl DirPlayer {
                 let val = compute_mouse_line(self);
                 Ok(self.alloc_datum(Datum::Int(val)))
             },
-            "stillDown" => Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))),
+            "stillDown" => { self.input_polled = true; Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))) },
             "rollover" => {
                 let sprite = get_sprite_at(self, self.mouse_loc.0, self.mouse_loc.1, false);
                 Ok(self.alloc_datum(Datum::Int(sprite.unwrap_or(0) as i32)))
@@ -2680,9 +2703,9 @@ impl DirPlayer {
                 let val = compute_mouse_line(self);
                 Ok(self.alloc_datum(Datum::Int(val)))
             }
-            "mouseDown" => Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))),
-            "mouseUp" => Ok(self.alloc_datum(datum_bool(!self.movie.mouse_down))),
-            "stillDown" => Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))),
+            "mouseDown" => { self.input_polled = true; Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))) }
+            "mouseUp" => { self.input_polled = true; Ok(self.alloc_datum(datum_bool(!self.movie.mouse_down))) }
+            "stillDown" => { self.input_polled = true; Ok(self.alloc_datum(datum_bool(self.movie.mouse_down))) }
             "rightMouseDown" => Ok(self.alloc_datum(datum_bool(self.movie.right_mouse_down))),
             "rightMouseUp" => Ok(self.alloc_datum(datum_bool(!self.movie.right_mouse_down))),
             _ => Err(ScriptError::new(format!("Unknown _mouse prop {}", prop))),
@@ -3877,25 +3900,20 @@ pub async fn player_call_script_handler_raw_args(
                 });
                 return Err(err);
             }
-            HandlerExecutionResult::Jump => {}
-        }
-
-        // Busy-wait cooperative yield (see `last_yield_ms` above). A backward
-        // jump means we looped; if we've run >16ms without unwinding, yield a
-        // real 1ms macrotask so the JS event loop can deliver queued key/mouse
-        // events (letting `keyPressed`/`the mouseDown` actually change).
-        if !should_return {
-            let new_index = reserve_player_ref(|player| {
-                player.scopes.get(scope_ref).map(|s| s.bytecode_index)
-            });
-            if let Some(new_index) = new_index {
-                if new_index < bytecode_index {
-                    backjumps += 1;
-                    // Only re-check the clock every 4096 backward jumps. A tight
-                    // busy-wait reaches this in well under a frame; a compute loop
-                    // (drawmap ~hundreds of iterations total) never does, so it
-                    // never yields. When a tight loop HAS run ≥16ms, yield a real
-                    // macrotask so queued key/mouse events are delivered.
+            HandlerExecutionResult::Jump => {
+                // Busy-wait cooperative yield, scoped to INPUT-polling loops.
+                // Added for Neopets' `repeat while keyPressed(" ") end` — an empty
+                // tight loop that must yield so the JS event loop can deliver the
+                // key-up, else it spins forever. Only count this jump toward the
+                // yield when the iteration actually read live input (keyPressed /
+                // the mouseDown / the stillDown set `input_polled`); a heavy
+                // compute/AMF loop (Coke Studios' object-graph conversion) never
+                // sets it, so it never yields — a yield there only adds latency
+                // and was the source of the navigator stalls. Reading+clearing a
+                // bool is far cheaper than the old per-instruction scope lookup.
+                let polled = reserve_player_mut(|player| std::mem::take(&mut player.input_polled));
+                if polled {
+                    backjumps = backjumps.wrapping_add(1);
                     if backjumps >= 4096 {
                         backjumps = 0;
                         let now = chrono::Local::now().timestamp_millis();

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -88,6 +88,7 @@ use script::script_get_prop_opt;
 use script_ref::ScriptInstanceRef;
 use sprite::Sprite;
 use xtra::curl::{CurlXtraManager, CURL_XTRA_MANAGER_OPT};
+use xtra::groove::{GrooveXtraManager, GROOVE_XTRA_MANAGER_OPT};
 use xtra::fileio::{FileIoXtraManager, FILEIO_XTRA_MANAGER_OPT};
 use xtra::multiuser::{MultiuserXtraManager, MULTIUSER_XTRA_MANAGER_OPT};
 use xtra::xmlparser::{XmlParserXtraManager, XMLPARSER_XTRA_MANAGER_OPT};
@@ -708,10 +709,15 @@ impl DirPlayer {
                     // (StoryScramble posters) never reflow. Only for on-stage
                     // sprites (positive channel); 3D-texture instances excluded
                     // in the JS twin.
+                    // Match the Ruffle render resolution to the RESOLVED sprite
+                    // rect (member natural size when un-stretched), not the raw
+                    // score cell — otherwise a 626x100 member in a 100x320 cell
+                    // captures at the wrong aspect and resamples to a thin strip.
+                    let rect = crate::player::score::get_concrete_sprite_rect(self, &channel.sprite);
                     let _ = ruffle_set_size(
                         js_flash_key(channel_num),
-                        channel.sprite.width.max(1) as i32,
-                        channel.sprite.height.max(1) as i32,
+                        rect.width().max(1),
+                        rect.height().max(1),
                     );
                     continue;
                 }
@@ -719,8 +725,11 @@ impl DirPlayer {
                     if let CastMemberType::Flash(flash_member) = &member.member_type {
                         if crate::rendering::has_swf_signature(&flash_member.data) {
                             let data = flash_member.data.clone();
-                            let w = channel.sprite.width.max(1) as u32;
-                            let h = channel.sprite.height.max(1) as u32;
+                            // Capture at the resolved sprite rect (member natural
+                            // size when un-stretched), not the raw score cell.
+                            let rect = crate::player::score::get_concrete_sprite_rect(self, &channel.sprite);
+                            let w = rect.width().max(1) as u32;
+                            let h = rect.height().max(1) as u32;
                             let paused_at_start = flash_member
                                 .flash_info
                                 .as_ref()
@@ -5701,6 +5710,7 @@ pub fn init_player() {
         MULTIUSER_XTRA_MANAGER_OPT = Some(MultiuserXtraManager::new());
         XMLPARSER_XTRA_MANAGER_OPT = Some(XmlParserXtraManager::new());
         CURL_XTRA_MANAGER_OPT = Some(CurlXtraManager::new());
+        GROOVE_XTRA_MANAGER_OPT = Some(GrooveXtraManager::new());
     }
 
     unsafe {

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -2576,6 +2576,17 @@ impl DirPlayer {
                 self.float_precision = value.int_value()? as u8;
                 Ok(())
             },
+            "timer" => {
+                // `set the timer = N` resets Director's timer to N ticks (1/60 s);
+                // `set the timer = 0` is equivalent to `startTimer`. `the timer`
+                // reads elapsed ticks since `start_time`, so back-date start_time
+                // by N ticks so it reads N going forward. eds_kart_attack's Kart
+                // behavior does `set the timer = 0` in `on wobble`.
+                let ticks = value.int_value()?;
+                let ms = (ticks as i64) * 1000 / 60;
+                self.start_time = chrono::Local::now() - chrono::Duration::milliseconds(ms);
+                Ok(())
+            },
             "centerStage" => {
                 self.center_stage = value.int_value()? != 0;
                 crate::player::stage::apply_stage_draw_rect(self);

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -4532,6 +4532,19 @@ pub async fn run_single_frame() -> (bool, bool) {
         return (false, is_script_paused);
     }
 
+    // Deferred puppetSprite(N,FALSE) revert: a sprite unpuppeted on a prior tick
+    // and not re-puppeted / re-membered since reverts to the Score now (Director
+    // defers the revert to the next frame update). Runs every tick so it fires
+    // even for single-frame movies — Coke Studios' WallItems unpuppet furniture
+    // WITHOUT setting visible=0 and relied on the old immediate wipe to clear it.
+    reserve_player_mut(|player| {
+        let frame = player.movie.current_frame;
+        if player.movie.score.process_pending_unpuppet_reverts(frame) {
+            player.movie.score.invalidate_render_channel_cache();
+            player.stage_dirty = true;
+        }
+    });
+
     // Dispatch streamStatus for any net tasks that completed since last check
     stream_status::dispatch_pending_stream_status().await;
 

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -623,6 +623,38 @@ impl DirPlayer {
         }
     }
 
+    /// Tear down any Flash (Ruffle) instances whose source member lives in the
+    /// given cast lib, so the renderer re-creates them from the member's CURRENT
+    /// bytes.
+    ///
+    /// Director keeps a member ref stable across an external-cast swap, but the
+    /// bytes behind it change: Storyscramble's `castLib("story").fileName =
+    /// nextStory.castFile` reloads cast lib 2 in place, so member 2:1 (the story
+    /// SWF the tiles render) is replaced while the sprites still point at 2:1.
+    /// The lazy-load gate (`flash_sprite_loaded`) and the captured-frame buffer
+    /// would otherwise keep the STALE Ruffle player on screen forever. Clearing
+    /// both — and destroying the JS-side player (which also stops its capture
+    /// RAF) — makes the next render see `flash_bitmap_ref.is_none()` and
+    /// re-dispatch `createFlashInstance` with the new story's SWF.
+    pub fn invalidate_flash_for_cast_lib(&mut self, cast_lib: i32) {
+        let sprites: Vec<i16> = self
+            .flash_sprite_loaded
+            .iter()
+            .filter(|(_, cl, _)| *cl == cast_lib)
+            .map(|(sn, _, _)| *sn)
+            .collect();
+        if sprites.is_empty() {
+            return;
+        }
+        self.flash_sprite_loaded.retain(|(_, cl, _)| *cl != cast_lib);
+        for sn in sprites {
+            // Destroy the JS-side Ruffle instance first (cancels its capture
+            // RAF so it can't re-insert a frame buffer after we drop it).
+            JsApi::dispatch_flash_member_unloaded(sn as i32);
+            self.flash_frame_buffers.remove(&sn);
+        }
+    }
+
     pub async fn load_movie_from_file(&mut self, path: &str) -> Result<(), String> {
         let task_id = self.net_manager.preload_net_thing(path.to_owned());
         self.net_manager.await_task(task_id).await;

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -325,6 +325,13 @@ pub struct DirPlayer {
     /// duplicate `createFlashInstance` calls every frame before the
     /// instance's first pixels arrive.
     pub flash_sprite_loaded: HashSet<(i16, i32, i32)>,
+    /// Off-screen Flash members rendered into W3D textures (frog01's environment:
+    /// `newTexture(#fromCastMember, flashMember)`). Keyed by a synthetic NEGATIVE
+    /// sprite number (so it never collides with on-stage positive channels);
+    /// maps to the target W3D cast member + texture name. `update_flash_frame`
+    /// routes captured frames for these synthetic numbers into the named texture
+    /// instead of `flash_frame_buffers`. See `flash_texture_synthetic_id`.
+    pub flash_texture_targets: HashMap<i16, (cast_lib::CastMemberRef, String)>,
     /// Cached rendered 3D scene bitmaps (populated during sprite rendering, read by world.image)
     pub w3d_frame_buffers: HashMap<(i32, i32), bitmap::manager::BitmapRef>,
     pub in_enter_frame: bool,
@@ -532,6 +539,7 @@ impl DirPlayer {
             in_frame_script: false,
             flash_frame_buffers: HashMap::new(),
             flash_sprite_loaded: HashSet::new(),
+            flash_texture_targets: HashMap::new(),
             w3d_frame_buffers: HashMap::new(),
             in_enter_frame: false,
             in_prepare_frame: false,
@@ -3489,6 +3497,10 @@ async fn run_movie_init_sequence() {
     // animation_playing — emit/age/move particles using the emitter params + model
     // position set by Lingo (see tick_w3d_particles).
     crate::player::events::tick_w3d_particles().await;
+
+    // Native #collision modifier detection: sweep enabled collision models,
+    // fire each model's setCollisionCallback handler for overlapping pairs.
+    crate::player::events::tick_w3d_collisions().await;
 
     // After prepareFrame behaviors have run (which is where simulate()
     // typically lives), drain any pending PhysX collision reports and

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -208,6 +208,12 @@ pub const MAX_STACK_SIZE: usize = 50;
 pub struct DirPlayer {
     pub net_manager: NetManager,
     pub movie: Movie,
+    /// Host-side composited stage image of each active nested `#movie` sub-player,
+    /// keyed by the Linked Movie member. Each host frame the sub-player's stage is
+    /// rendered (headless, CPU) and copied here into the HOST's bitmap_manager so
+    /// the WebGL2 `Movie` sprite arm can blit it at the sprite rect. One BitmapRef
+    /// per member, overwritten in place.
+    pub nested_movie_images: HashMap<CastMemberRef, BitmapRef>,
     pub is_playing: bool,
     pub is_script_paused: bool,
     pub next_frame: Option<u32>,
@@ -310,6 +316,12 @@ pub struct DirPlayer {
     pub is_in_frame_update: bool,
     pub is_dispatching_events: bool, // Prevents re-entrant event dispatch
     pub is_in_send_all_sprites: bool, // Prevents re-entrant sendAllSprites calls
+    /// `tell <target> … end tell` stack. Each entry is the target a `tellcall`
+    /// should dispatch to: `Some(nested_player_id)` when the target is a `#movie`
+    /// sprite (the loader→game command bridge — DGS `on keyIsDown` does
+    /// `tell sprite(spShk) \n sendAllSprites(#keyWasPressed, k) \n end tell`),
+    /// or `None` for an unsupported/self target (tellcall runs on this player).
+    pub tell_target_stack: Vec<Option<usize>>,
     pub system_start_time: chrono::DateTime<chrono::Local>, // For ticks & milliSeconds (system uptime)
     pub handler_stack_depth: usize,
     pub in_frame_script: bool,
@@ -436,42 +448,8 @@ impl DirPlayer {
         let now = chrono::Local::now();
 
         let mut result = DirPlayer {
-            movie: Movie {
-                rect: IntRect::from(0, 0, 0, 0),
-                cast_manager: CastManager::empty(),
-                score: Score::empty(),
-                current_frame: 1,
-                puppet_tempo: 0,
-                random_seed: None,
-                exit_lock: false,
-                dir_version: 0,
-                item_delimiter: ',',
-                alert_hook: None,
-                base_path: "".to_string(),
-                file_name: "".to_string(),
-                stage_color: (255, 255, 255),
-                stage_color_ref: ColorRef::PaletteIndex(255),
-                frame_rate: 30,
-                file: None,
-                update_lock: false,
-                mouse_down_script: None,
-                mouse_up_script: None,
-                key_down_script: None,
-                key_up_script: None,
-                timeout_script: None,
-                allow_custom_caching: false,
-                trace_script: false,
-                trace_log_file: String::new(),
-                debug_playback_enabled: false,
-                edit_shortcuts_enabled: true,
-                mouse_down: false,
-                right_mouse_down: false,
-                click_loc: (0,0),
-                frame_script_instance: None,
-                frame_script_member: None,
-                frame_script_span_start: None,
-                sound_device: String::new(),
-            },
+            movie: Movie::empty(),
+            nested_movie_images: HashMap::new(),
             net_manager: NetManager {
                 base_path: None,
                 override_base_path: None,
@@ -542,6 +520,7 @@ impl DirPlayer {
             is_in_frame_update: false,
             is_dispatching_events: false,
             is_in_send_all_sprites: false,
+            tell_target_stack: Vec::new(),
             system_start_time: now - chrono::Duration::days(8), // Simulated system start
             handler_stack_depth: 0,
             in_frame_script: false,
@@ -601,6 +580,18 @@ impl DirPlayer {
     /// before Lingo scripts try to access them. Per-sprite: each sprite that
     /// references a Flash member gets its own dedicated Ruffle instance.
     pub fn pre_dispatch_flash_members(&mut self) {
+        // When running a nested `#movie` sub-player, dispatch its Flash sprites
+        // to Ruffle under a synthetic per-player key so they don't collide with
+        // the host's channel keys and their captured frames route back into THIS
+        // sub's `flash_frame_buffers` (see NESTED_FLASH_BASE / update_flash_frame).
+        let active = unsafe { ACTIVE_PLAYER_ID };
+        let js_flash_key = |ch: i16| -> i32 {
+            if active == 0 {
+                ch as i32
+            } else {
+                nested_flash_key(active, ch)
+            }
+        };
         // UNLOAD pass FIRST: tear down any Ruffle instance whose channel no
         // longer holds that exact Flash member — BEFORE the load pass below, so
         // a member swap is deterministically unload(old) → load(new). If the
@@ -639,7 +630,7 @@ impl DirPlayer {
             // channel no longer shows ANY live Flash member; otherwise just drop
             // the stale bookkeeping entry and leave the new instance alone.
             if !self.channel_holds_live_flash(ch) {
-                JsApi::dispatch_flash_member_unloaded(ch as i32);
+                JsApi::dispatch_flash_member_unloaded(js_flash_key(ch));
                 self.flash_frame_buffers.remove(&ch);
             }
             self.flash_sprite_loaded.remove(&(ch, cl, cm));
@@ -662,7 +653,7 @@ impl DirPlayer {
                     // sprites (positive channel); 3D-texture instances excluded
                     // in the JS twin.
                     let _ = ruffle_set_size(
-                        channel_num as i32,
+                        js_flash_key(channel_num),
                         channel.sprite.width.max(1) as i32,
                         channel.sprite.height.max(1) as i32,
                     );
@@ -689,7 +680,7 @@ impl DirPlayer {
                                 w, h, data.len(), paused_at_start, asserted_frame,
                             );
                             JsApi::dispatch_flash_member_loaded(
-                                channel_num as i32,
+                                js_flash_key(channel_num),
                                 member_ref.cast_lib,
                                 member_ref.cast_member,
                                 &data,
@@ -840,6 +831,229 @@ impl DirPlayer {
         Ok(())
     }
 
+    /// Instantiate a full nested `DirPlayer` for a Linked `#movie` member whose
+    /// linked bytes are loaded, register it in `NESTED_PLAYERS`, and start it
+    /// (load + play + its own command loop) on its own active-player id. The sub
+    /// runs the entire engine against itself — its own scripts/score/cast — via
+    /// the active-player indirection; the loader keeps running independently.
+    /// Synchronous: the async load+play happens in a spawned task bound to the
+    /// sub's id (a manual `ACTIVE_PLAYER_ID` set can't span an await here, since
+    /// the enclosing task's `WithActivePlayer` wrapper would restore it).
+    pub fn spawn_nested_player(&self, member_ref: CastMemberRef) {
+        if nested_player_id(&member_ref).is_some() {
+            return;
+        }
+        let (bytes, base_url, file_name) = match self
+            .movie
+            .cast_manager
+            .find_member_by_ref(&member_ref)
+            .and_then(|m| {
+                if let CastMemberType::Movie(mv) = &m.member_type {
+                    mv.bytes.as_ref().map(|b| {
+                        let fname = mv
+                            .file_name
+                            .rsplit(|c| c == '/' || c == '\\')
+                            .next()
+                            .filter(|s| !s.is_empty())
+                            .unwrap_or("nested.dcr")
+                            .to_string();
+                        (b.clone(), mv.base_url.clone(), fname)
+                    })
+                } else {
+                    None
+                }
+            }) {
+            Some(t) => t,
+            None => return,
+        };
+        let dir = match crate::director::file::read_director_file_bytes(&bytes, &file_name, &base_url)
+        {
+            Ok(d) => d,
+            Err(e) => {
+                warn!("[nested-player] parse '{}' failed: {}", file_name, e);
+                return;
+            }
+        };
+        let (tx, rx) = async_std::channel::unbounded();
+        // The sub gets its OWN event channel (parallel to its command channel) so
+        // its events are processed by its own event loop with ACTIVE_PLAYER_ID =
+        // its id — otherwise a sub's script-instance ids resolve against the host
+        // allocator and panic (see NESTED_EVENT_TX).
+        let (event_tx, event_rx) = async_std::channel::unbounded();
+        let id = unsafe {
+            NESTED_PLAYERS.push(Some(DirPlayer::new(tx)));
+            NESTED_PLAYER_KEYS.push(Some(member_ref.clone()));
+            NESTED_EVENT_TX.push(Some(event_tx));
+            NESTED_PLAYERS.len()
+        };
+        // The sub never receives the frontend's `SetSystemFontPath` command, so
+        // its font_manager has no system font — text whose font isn't a cast
+        // member (Verdana etc.) falls back to `get_system_font()` and, finding
+        // none, fails to render ("No font found for 'Verdana'"). Inherit the
+        // host's system font (a shared `Rc<BitmapFont>`, cheap to clone).
+        let host_system_font = self.font_manager.system_font.clone();
+        let prev = unsafe { ACTIVE_PLAYER_ID };
+        // Bind the load/play task (and everything it spawns, incl. the sub's
+        // frame loop via play()) to the sub's id; spawn_player_local captures
+        // the id set right here.
+        unsafe {
+            ACTIVE_PLAYER_ID = id;
+        }
+        crate::player::spawn_player_local(async move {
+            reserve_player_mut_async(|p| Box::pin(p.load_movie_from_dir(dir))).await;
+            if host_system_font.is_some() {
+                reserve_player_mut(|p| {
+                    if p.font_manager.system_font.is_none() {
+                        p.font_manager.system_font = host_system_font.clone();
+                    }
+                });
+            }
+            reserve_player_mut(|p| p.play());
+            crate::player::spawn_player_local(crate::player::commands::run_command_loop(rx));
+            // Bound to the sub's id (spawn_player_local captured it above), so
+            // reserve_player_* inside the loop resolves to THIS sub.
+            crate::player::spawn_player_local(crate::player::events::run_event_loop(event_rx));
+            let (rw, rh, ver) = reserve_player_ref(|p| {
+                (p.movie.rect.width(), p.movie.rect.height(), p.movie.dir_version)
+            });
+            debug!(
+                "[nested-player] id={} started '{}' dir_version={} rect={}x{}",
+                id, file_name, ver, rw, rh
+            );
+        });
+        unsafe {
+            ACTIVE_PLAYER_ID = prev;
+        }
+    }
+
+    /// Scan the host movie's on-stage sprites for Linked Movie (`#movie`)
+    /// members whose linked bytes are loaded, and start a nested `DirPlayer` for
+    /// any not yet running. Called each frame so assigning a #movie member to a
+    /// sprite (DGS `sprite(spShk).member = member(gMember)`) activates playback.
+    pub fn activate_nested_players(&self) {
+        let to_build: Vec<CastMemberRef> = self
+            .movie
+            .score
+            .channels
+            .iter()
+            .filter_map(|channel| channel.sprite.member.clone())
+            .filter(|m| nested_player_id(m).is_none())
+            .filter(|m| {
+                matches!(
+                    self.movie.cast_manager.find_member_by_ref(m).map(|mem| &mem.member_type),
+                    Some(CastMemberType::Movie(mv)) if mv.bytes.is_some()
+                )
+            })
+            .collect();
+        for member_ref in to_build {
+            self.spawn_nested_player(member_ref);
+        }
+    }
+
+    /// Render each on-stage nested `#movie` sub-player's stage (headless, CPU)
+    /// and copy it into THIS (host) player's `bitmap_manager`, keyed by member,
+    /// so the WebGL2 `Movie` sprite arm can blit it. Called on the host each
+    /// frame. The sub-player renders from its own score/cast/bitmap_manager under
+    /// its active-player id; the resulting stage bitmap is a plain owned `Bitmap`
+    /// which is then stored in the host's manager (a separate manager, so the
+    /// pixels are copied across — no id collision).
+    pub fn render_nested_player_stages(&mut self) {
+        use std::collections::HashSet;
+        let refs: Vec<CastMemberRef> = self
+            .movie
+            .score
+            .channels
+            .iter()
+            .filter_map(|ch| ch.sprite.member.clone())
+            .filter(|m| nested_player_id(m).is_some())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
+        for member_ref in refs {
+            let id = match nested_player_id(&member_ref) {
+                Some(i) => i,
+                None => continue,
+            };
+            // Render the sub-player headlessly. Set ACTIVE_PLAYER_ID = id so any
+            // internal reserve_player_* inside the renderer resolves to the sub;
+            // no await here, so the manual set is safe. `self` (host) and the sub
+            // are distinct DirPlayers, so the &mut aliasing is only the usual
+            // raw-pointer re-entrancy the engine already relies on.
+            let prev = unsafe { ACTIVE_PLAYER_ID };
+            let rendered = unsafe {
+                ACTIVE_PLAYER_ID = id;
+                let out = match NESTED_PLAYERS.get_mut(id - 1).and_then(|o| o.as_mut()) {
+                    Some(sub) if {
+                        // Guard against a transient bad/huge sub stage rect (seen
+                        // when the window is unfocused and the sub is mid-reset):
+                        // a large width*height*32 in Bitmap::new aborts with an
+                        // allocation error. Movie stages are never > 4096.
+                        let (rw, rh) = (sub.movie.rect.width(), sub.movie.rect.height());
+                        let ok = rw >= 1 && rh >= 1 && rw <= 4096 && rh <= 4096;
+                        if !ok {
+                            warn!("[nested] skip render: bad sub rect {}x{}", rw, rh);
+                        }
+                        ok
+                    } => {
+                        let w = (sub.movie.rect.width().max(1)) as u16;
+                        let h = (sub.movie.rect.height().max(1)) as u16;
+                        // Render the sub-movie through the full WebGL2 pipeline
+                        // (off-screen FBO → readback) so it matches the host's
+                        // fidelity — the CPU rasterizer's text/ink quality is
+                        // visibly worse. Fall back to CPU if the live renderer
+                        // isn't WebGL2 (e.g. Canvas2D backend or none yet).
+                        let webgl_bmp = crate::rendering::with_renderer_mut(|r| match r {
+                            Some(crate::rendering_gpu::DynamicRenderer::WebGL2(webgl)) => {
+                                Some(webgl.render_player_to_bitmap(sub, id, w as u32, h as u32))
+                            }
+                            _ => None,
+                        });
+                        let bmp = webgl_bmp.unwrap_or_else(|| {
+                            let mut bmp = crate::player::bitmap::bitmap::Bitmap::new(
+                                w,
+                                h,
+                                32,
+                                32,
+                                0,
+                                crate::player::bitmap::bitmap::PaletteRef::BuiltIn(
+                                    crate::player::bitmap::bitmap::get_system_default_palette(),
+                                ),
+                            );
+                            crate::rendering::render_stage_to_bitmap(sub, &mut bmp, None);
+                            bmp
+                        });
+                        Some(bmp)
+                    }
+                    _ => None,
+                };
+                ACTIVE_PLAYER_ID = prev;
+                out
+            };
+            // Store into the host's bitmap_manager (ACTIVE is back to host).
+            if let Some(bmp) = rendered {
+                let (w, h) = (bmp.width, bmp.height);
+                let reuse = self.nested_movie_images.get(&member_ref).copied().filter(|r| {
+                    matches!(self.bitmap_manager.get_bitmap(*r), Some(b) if b.width == w && b.height == h)
+                });
+                match reuse {
+                    Some(r) => {
+                        // `replace_bitmap` bumps the bitmap version so the WebGL
+                        // texture cache re-uploads this frame's content. A plain
+                        // `*slot = bmp` reset version to 0, so the composite went
+                        // STALE after the first frame (only refreshing when the
+                        // texture was LRU-evicted) — that was the hover-highlight
+                        // "flickers to the state where it should be showing".
+                        self.bitmap_manager.replace_bitmap(r, bmp);
+                    }
+                    None => {
+                        let r = self.bitmap_manager.add_bitmap(bmp);
+                        self.nested_movie_images.insert(member_ref.clone(), r);
+                    }
+                }
+            }
+        }
+    }
+
     pub(crate) async fn load_movie_from_dir(&mut self, dir: DirectorFile) {
         // Pick the platform-correct default system palette before loading. Mac
         // movies (Director 4 titles like thead) default to System-Mac, Windows
@@ -918,13 +1132,18 @@ impl DirPlayer {
             .cast_manager
             .load_fonts_into_manager(&mut self.font_manager);
 
-        with_renderer_mut(|renderer_opt| {
-            if let Some(renderer) = renderer_opt {
-                use crate::rendering_gpu::Renderer;
-                let (stage_w, stage_h) = crate::player::stage::stage_canvas_dims(self);
-                renderer.set_size(stage_w, stage_h);
-            }
-        });
+        // A nested `#movie` sub-player is headless — it must never resize the
+        // shared WebGL2 renderer (that canvas belongs to the host stage). Only
+        // the host player (active id 0) owns the on-screen renderer size.
+        if unsafe { ACTIVE_PLAYER_ID } == 0 {
+            with_renderer_mut(|renderer_opt| {
+                if let Some(renderer) = renderer_opt {
+                    use crate::rendering_gpu::Renderer;
+                    let (stage_w, stage_h) = crate::player::stage::stage_canvas_dims(self);
+                    renderer.set_size(stage_w, stage_h);
+                }
+            });
+        }
 
         let (stage_w, stage_h) = crate::player::stage::stage_canvas_dims(self);
         crate::js_api::JsApi::dispatch_stage_size_changed(stage_w, stage_h, self.center_stage);
@@ -948,7 +1167,7 @@ impl DirPlayer {
         use crate::js_api::safe_string;
         debug!("Loading Movie: {} (version: {})", safe_string(&self.movie.file_name), self.movie.dir_version);
 
-        async_std::task::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             run_movie_init_sequence().await;
             run_frame_loop().await;
         });
@@ -1070,7 +1289,7 @@ impl DirPlayer {
         let breakpoint = self.current_breakpoint.take();
 
         if let Some(breakpoint) = breakpoint {
-            spawn_local(breakpoint.completer.complete(()));
+            crate::player::spawn_player_local(breakpoint.completer.complete(()));
         }
     }
 
@@ -1081,7 +1300,7 @@ impl DirPlayer {
         let breakpoint = self.current_breakpoint.take();
 
         if let Some(breakpoint) = breakpoint {
-            spawn_local(breakpoint.completer.complete(()));
+            crate::player::spawn_player_local(breakpoint.completer.complete(()));
         }
     }
 
@@ -1092,7 +1311,7 @@ impl DirPlayer {
         let breakpoint = self.current_breakpoint.take();
 
         if let Some(breakpoint) = breakpoint {
-            spawn_local(breakpoint.completer.complete(()));
+            crate::player::spawn_player_local(breakpoint.completer.complete(()));
         }
     }
 
@@ -1103,7 +1322,7 @@ impl DirPlayer {
         let breakpoint = self.current_breakpoint.take();
 
         if let Some(breakpoint) = breakpoint {
-            spawn_local(breakpoint.completer.complete(()));
+            crate::player::spawn_player_local(breakpoint.completer.complete(()));
         }
     }
 
@@ -1114,7 +1333,7 @@ impl DirPlayer {
         let breakpoint = self.current_breakpoint.take();
 
         if let Some(breakpoint) = breakpoint {
-            spawn_local(breakpoint.completer.complete(()));
+            crate::player::spawn_player_local(breakpoint.completer.complete(()));
         }
     }
 
@@ -1125,7 +1344,7 @@ impl DirPlayer {
         let breakpoint = self.current_breakpoint.take();
 
         if let Some(breakpoint) = breakpoint {
-            spawn_local(breakpoint.completer.complete(()));
+            crate::player::spawn_player_local(breakpoint.completer.complete(()));
         }
     }
 
@@ -2623,6 +2842,36 @@ impl DirPlayer {
         })
     }
 
+    /// Human-readable dump of the current handler call stack (`script::handler`
+    /// per scope, outer→inner). Used to surface a nested `#movie` sub-player's
+    /// stack in the console — the Dev UI panels are bound to the main player, so
+    /// a sub-player's error is otherwise uninspectable there.
+    pub fn call_stack_string(&self) -> String {
+        let mut trace = String::new();
+        for i in 0..self.scope_count {
+            if let Some(scope) = self.scopes.get(i as usize) {
+                let handler_info = if let Some(script) =
+                    self.movie.cast_manager.get_script_by_ref(&scope.script_ref)
+                {
+                    let handler_name = script
+                        .handlers
+                        .iter()
+                        .find(|(_, h)| h.name_id == scope.handler_name_id)
+                        .map(|(name, _)| name.as_str().to_owned())
+                        .unwrap_or_else(|| format!("#{}", scope.handler_name_id));
+                    format!("{}::{}", script.name, handler_name)
+                } else {
+                    format!("?::#{}", scope.handler_name_id)
+                };
+                trace.push_str(&format!(
+                    "  {}: {} (pc={})\n",
+                    i, handler_info, scope.bytecode_index
+                ));
+            }
+        }
+        trace
+    }
+
     fn on_script_error(&mut self, err: &ScriptError) {
         // abort is flow control (exits handler chain), not a real error
         if err.code == ScriptErrorCode::Abort {
@@ -2892,7 +3141,7 @@ impl DirPlayer {
 pub fn player_alloc_datum(datum: Datum) -> DatumRef {
     // let mut player_opt = PLAYER_LOCK.try_write().unwrap();
     unsafe {
-        let player = PLAYER_OPT.as_mut().unwrap();
+        let player = crate::player::player_mut();
         player.alloc_datum(datum)
     }
 }
@@ -2950,7 +3199,7 @@ pub async fn player_call_global_handler(
 ) -> Result<DatumRef, ScriptError> {
     let receiver_handler = unsafe {
         // let player_opt = PLAYER_LOCK.try_read().unwrap();
-        let player = PLAYER_OPT.as_mut().unwrap();
+        let player = crate::player::player_mut();
 
         let mut receiver_handler = None;
 
@@ -3047,13 +3296,97 @@ pub fn player_global_handler_exists(player: &DirPlayer, handler_name: &str) -> b
         })
 }
 
+/// Which player `reserve_player_*` / `player_*` currently resolve to.
+/// `0` = the main/host player (`PLAYER_OPT`); `N>0` = `NESTED_PLAYERS[N-1]`, a
+/// Linked `#movie` sub-player. A task sets this to run the engine against a
+/// specific player; because all ~1300 `reserve_player_*` call sites funnel
+/// through the accessors below, switching this one value redirects the whole
+/// engine — which is how a nested movie runs its own frame/scripts in the same
+/// wasm instance (no second wasm, no cross-realm bridge). Task-scoping this so
+/// each async task restores its own id on poll is a later step; today it stays
+/// `0`, making these accessors identical to the previous `PLAYER_OPT`-only form.
+pub static mut ACTIVE_PLAYER_ID: usize = 0;
+/// Registry of Linked `#movie` sub-players, indexed by `ACTIVE_PLAYER_ID - 1`.
+pub static mut NESTED_PLAYERS: Vec<Option<DirPlayer>> = Vec::new();
+/// Parallel to `NESTED_PLAYERS`: which `#movie` member owns each sub-player,
+/// so `activate` can skip already-built members and callers can map member→id.
+pub static mut NESTED_PLAYER_KEYS: Vec<Option<CastMemberRef>> = Vec::new();
+/// Parallel to `NESTED_PLAYERS`: each sub-player's OWN event channel sender.
+/// Events (mouseEnter/mouseWithin/mouseLeave, targeted callbacks) must be
+/// processed by the sub's own event loop with `ACTIVE_PLAYER_ID` = its id, so
+/// script-instance refs resolve against the sub's allocator. Routing them to the
+/// host's `PLAYER_EVENT_TX` (as the old single-global path did) processed a sub's
+/// instance ids against the HOST allocator → `get_script_instance` unwrap panic.
+pub static mut NESTED_EVENT_TX: Vec<Option<Sender<PlayerVMEvent>>> = Vec::new();
+
+/// The event-channel sender for the currently active player (host id 0 →
+/// `PLAYER_EVENT_TX`, else the sub's `NESTED_EVENT_TX` slot). Used by the
+/// `player_dispatch_*` event helpers so a sub's events reach the sub's loop.
+pub fn active_event_tx() -> Option<Sender<PlayerVMEvent>> {
+    unsafe {
+        if ACTIVE_PLAYER_ID == 0 {
+            PLAYER_EVENT_TX.clone()
+        } else {
+            NESTED_EVENT_TX
+                .get(ACTIVE_PLAYER_ID - 1)
+                .and_then(|o| o.clone())
+        }
+    }
+}
+
+/// A nested `#movie` sub-player's Flash sprites dispatch to Ruffle under a
+/// synthetic positive sprite key `BASE + player_id*STRIDE + local_channel` so
+/// they neither collide with the host's channel keys nor look like the negative
+/// off-screen-3D-texture keys (which are capture-count-limited). `update_flash_frame`
+/// decodes it back to (player_id, channel) and routes the captured frame into the
+/// SUB's `flash_frame_buffers`. STRIDE bounds a sub's channel count; BASE keeps
+/// the synthetic keys clear of real channels.
+pub const NESTED_FLASH_BASE: i32 = 100_000;
+pub const NESTED_FLASH_STRIDE: i32 = 1_000;
+
+/// Encode a nested sub-player's Flash dispatch key (see `NESTED_FLASH_BASE`).
+pub fn nested_flash_key(player_id: usize, channel: i16) -> i32 {
+    NESTED_FLASH_BASE + (player_id as i32) * NESTED_FLASH_STRIDE + channel as i32
+}
+
+/// Decode a synthetic nested Flash key back to `(player_id, channel)`, or `None`
+/// if it's an ordinary host channel key.
+pub fn decode_nested_flash_key(key: i32) -> Option<(usize, i16)> {
+    if key < NESTED_FLASH_BASE {
+        return None;
+    }
+    let rel = key - NESTED_FLASH_BASE;
+    Some(((rel / NESTED_FLASH_STRIDE) as usize, (rel % NESTED_FLASH_STRIDE) as i16))
+}
+
+/// Active-player id (`>0`) of the sub-player built for `member_ref`, if any.
+pub fn nested_player_id(member_ref: &CastMemberRef) -> Option<usize> {
+    unsafe {
+        NESTED_PLAYER_KEYS
+            .iter()
+            .position(|k| k.as_ref() == Some(member_ref))
+            .map(|i| i + 1)
+    }
+}
+
 #[inline(always)]
+unsafe fn active_player_ptr() -> *mut DirPlayer {
+    if ACTIVE_PLAYER_ID == 0 {
+        PLAYER_OPT.as_mut().unwrap_unchecked() as *mut DirPlayer
+    } else {
+        NESTED_PLAYERS
+            .get_unchecked_mut(ACTIVE_PLAYER_ID - 1)
+            .as_mut()
+            .unwrap_unchecked() as *mut DirPlayer
+    }
+}
+
 pub fn reserve_player_ref<T, F>(callback: F) -> T
 where
     F: FnOnce(&DirPlayer) -> T,
 {
     unsafe {
-        let player = PLAYER_OPT.as_ref().unwrap_unchecked();
+        let player = &*active_player_ptr();
         callback(player)
     }
 }
@@ -3064,7 +3397,7 @@ where
     F: FnOnce(&mut DirPlayer) -> T,
 {
     unsafe {
-        let player = PLAYER_OPT.as_mut().unwrap_unchecked();
+        let player = &mut *active_player_ptr();
         callback(player)
     }
 }
@@ -3073,14 +3406,97 @@ where
 /// Caller must ensure no mutable references exist.
 #[inline(always)]
 pub unsafe fn player_ref() -> &'static DirPlayer {
-    PLAYER_OPT.as_ref().unwrap_unchecked()
+    &*active_player_ptr()
 }
 
 /// Direct mutable reference access without closure overhead.
 /// Caller must ensure no other references exist.
 #[inline(always)]
 pub unsafe fn player_mut() -> &'static mut DirPlayer {
-    PLAYER_OPT.as_mut().unwrap_unchecked()
+    &mut *active_player_ptr()
+}
+
+/// Future wrapper that sets `ACTIVE_PLAYER_ID` to a captured id for the duration
+/// of every poll, then restores it. This is what makes multi-player safe under
+/// the shared async executor: a task spawned for player X always runs against X
+/// even when it's polled while another player's frame is on the stack.
+struct WithActivePlayer<F> {
+    id: usize,
+    inner: F,
+}
+impl<F: std::future::Future> std::future::Future for WithActivePlayer<F> {
+    type Output = F::Output;
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        // SAFETY: standard pin-projection of the single `inner` field; `id` is Copy.
+        let this = unsafe { self.get_unchecked_mut() };
+        let inner = unsafe { std::pin::Pin::new_unchecked(&mut this.inner) };
+        unsafe {
+            let prev = ACTIVE_PLAYER_ID;
+            ACTIVE_PLAYER_ID = this.id;
+            let r = inner.poll(cx);
+            ACTIVE_PLAYER_ID = prev;
+            r
+        }
+    }
+}
+
+/// Await `fut` with `ACTIVE_PLAYER_ID` pinned to `id` across every poll, so async
+/// awaits inside it keep resolving the engine against `id` even after yielding
+/// (a plain `ACTIVE_PLAYER_ID = id` before an `.await` is undone by the enclosing
+/// task's own `WithActivePlayer` on the next poll). Used by `tellcall` to run a
+/// command inside a nested `#movie` sub-player.
+pub fn with_active_player<F: std::future::Future>(
+    id: usize,
+    fut: F,
+) -> impl std::future::Future<Output = F::Output> {
+    WithActivePlayer { id, inner: fut }
+}
+
+/// Deep-copy a datum's VALUE from one player's allocator into another's (for
+/// `tellcall` arg/result marshaling across the `#movie` boundary). Simple,
+/// self-contained datums (Int/Float/String/Symbol/bool/etc.) copy by value;
+/// List/PropList recurse. Player-specific refs (script instances, member refs)
+/// are copied verbatim — meaningful only for the value types that cross a tell,
+/// which in practice are the simple ones (`sendAllSprites(#sym, k)`).
+pub fn marshal_datum(from: &DirPlayer, to: &mut DirPlayer, r: &crate::player::DatumRef) -> crate::player::DatumRef {
+    use crate::director::lingo::datum::{Datum, DatumType};
+    let value = from.get_datum(r).clone();
+    match value {
+        Datum::List(t, items, sorted) => {
+            let new_items: std::collections::VecDeque<_> =
+                items.iter().map(|i| marshal_datum(from, to, i)).collect();
+            to.alloc_datum(Datum::List(t, new_items, sorted))
+        }
+        Datum::PropList(pairs, sorted) => {
+            let new_pairs = pairs
+                .iter()
+                .map(|(k, v)| (marshal_datum(from, to, k), marshal_datum(from, to, v)))
+                .collect();
+            to.alloc_datum(Datum::PropList(new_pairs, sorted))
+        }
+        other => {
+            let _ = DatumType::Void;
+            to.alloc_datum(other)
+        }
+    }
+}
+
+/// Spawn a local task bound to the *currently active* player, so its async work
+/// always resolves the engine against the player it was spawned for — even when
+/// interleaved with another player's frame. Replaces raw `spawn_local` across
+/// the engine; the captured id is `0` (main player) everywhere today.
+pub fn spawn_player_local<F>(fut: F)
+where
+    F: std::future::Future<Output = ()> + 'static,
+{
+    // `use ... as raw` (no trailing `(`) so the bulk `crate::player::spawn_player_local(`
+    // → `spawn_player_local(` rewrite doesn't turn this into infinite recursion.
+    use async_std::task::spawn_local as raw;
+    let id = unsafe { ACTIVE_PLAYER_ID };
+    raw(WithActivePlayer { id, inner: fut });
 }
 
 fn reserve_player_mut_async<F, R>(callback: F) -> impl Future<Output = R>
@@ -3089,7 +3505,7 @@ where
 {
     async move {
         unsafe {
-            let player = PLAYER_OPT.as_mut().unwrap();
+            let player = crate::player::player_mut();
             callback(player).await
         }
     }
@@ -3207,13 +3623,36 @@ pub async fn player_call_script_handler_raw_args(
             }
         }?;
 
+        let _ = script_type;
+        let is_instance_receiver = receiver.is_some();
         let receiver_arg = if let Some(script_instance_ref) = receiver.as_ref() {
             Some(Datum::ScriptInstanceRef(script_instance_ref.clone()))
-        } else if script_type != ScriptType::Movie {
-            // TODO: check if this is right
-            Some(Datum::ScriptRef(handler_ref.0.clone()))
         } else {
-            None
+            // No explicit instance receiver: `me` is the script itself (a
+            // ScriptRef). Director binds `me` to the script for
+            // `script("x").handler()` calls — for MOVIE scripts too, whose
+            // sibling-handler calls rely on it (Neopets DGS `secure` movie
+            // script does `me.sub(...)` inside `decrypt_pc927634892`, which
+            // errored with `me`=VOID).
+            Some(Datum::ScriptRef(handler_ref.0.clone()))
+        };
+
+        // Whether the handler declares `me` as its first parameter. The receiver
+        // is only PREPENDED as arg0 (filling that param) when it does. Instance
+        // receivers (behaviors/parents) always declare `me`, so they always
+        // prepend. Movie scripts are the subtle case: `script("x").handler()`
+        // calls whose handler declares `me` (DGS `decrypt_pc927634892`) prepend,
+        // but a plain global/event handler like `on streamStatus url, state,
+        // bytesSoFar, bytesTotal` must NOT — prepending shifted every param by
+        // one (bogey_nights got `bytesSoFar` = the "Complete" state string).
+        let first_param_is_me = unsafe {
+            let handler_def = &*handler_ptr;
+            let names = &*names_ptr;
+            handler_def
+                .argument_name_ids
+                .first()
+                .and_then(|id| names.get(*id as usize))
+                .map_or(false, |n| n.eq_ignore_ascii_case("me"))
         };
 
         let scope_ref = player.push_scope();
@@ -3225,7 +3664,7 @@ pub async fn player_call_script_handler_raw_args(
         };
 
         if let Some(receiver_arg) = receiver_arg {
-            if !use_raw_arg_list {
+            if !use_raw_arg_list && (is_instance_receiver || first_param_is_me) {
                 let arg_ref = player.alloc_datum(receiver_arg);
                 let scope = player.scopes.get_mut(scope_ref).unwrap();
                 scope.args.push(arg_ref);
@@ -3271,6 +3710,21 @@ pub async fn player_call_script_handler_raw_args(
     let scope_generation = reserve_player_ref(|player| {
         player.scopes.get(scope_ref).unwrap().generation
     });
+    // Cooperative-yield budget for synchronous busy-wait loops. A Lingo
+    // `repeat while keyPressed(" ")` (waiting for key release) or
+    // `repeat while the mouseDown` runs entirely in bytecode with no `.await`
+    // that ever returns Pending, so the WASM never unwinds to the JS event loop
+    // — the key-up/mouse-up event can't be processed and the loop spins forever.
+    // On each BACKWARD jump (a loop iteration) we check elapsed time and, past a
+    // frame's worth, yield a real macrotask so queued input events fire, then
+    // resume. Time-budgeted so ordinary fast compute loops are unaffected.
+    let mut last_yield_ms = chrono::Local::now().timestamp_millis();
+    // Count backward jumps to distinguish a TIGHT busy-wait (thousands of
+    // iterations/ms — `repeat while keyPressed`) from a heavy COMPUTE loop (a
+    // few iterations, each doing real work — the game's `drawmap`/water
+    // `copyPixels` tiling). Only the former should yield; yielding inside compute
+    // loops fired ~15×/frame at ~4ms each and tanked the sub to ~3fps.
+    let mut backjumps: u32 = 0;
 
     loop {
         // Check if scope was reused (generation changed = scope was popped and re-pushed)
@@ -3424,6 +3878,38 @@ pub async fn player_call_script_handler_raw_args(
                 return Err(err);
             }
             HandlerExecutionResult::Jump => {}
+        }
+
+        // Busy-wait cooperative yield (see `last_yield_ms` above). A backward
+        // jump means we looped; if we've run >16ms without unwinding, yield a
+        // real 1ms macrotask so the JS event loop can deliver queued key/mouse
+        // events (letting `keyPressed`/`the mouseDown` actually change).
+        if !should_return {
+            let new_index = reserve_player_ref(|player| {
+                player.scopes.get(scope_ref).map(|s| s.bytecode_index)
+            });
+            if let Some(new_index) = new_index {
+                if new_index < bytecode_index {
+                    backjumps += 1;
+                    // Only re-check the clock every 4096 backward jumps. A tight
+                    // busy-wait reaches this in well under a frame; a compute loop
+                    // (drawmap ~hundreds of iterations total) never does, so it
+                    // never yields. When a tight loop HAS run ≥16ms, yield a real
+                    // macrotask so queued key/mouse events are delivered.
+                    if backjumps >= 4096 {
+                        backjumps = 0;
+                        let now = chrono::Local::now().timestamp_millis();
+                        if now - last_yield_ms >= 16 {
+                            last_yield_ms = now;
+                            let _ = timeout(
+                                Duration::from_millis(1),
+                                future::pending::<()>(),
+                            )
+                            .await;
+                        }
+                    }
+                }
+            }
         }
 
         // end_profiling(profile_token);
@@ -4070,7 +4556,7 @@ pub async fn run_single_frame() -> (bool, bool) {
     }
     if new_frame > 1 && prev_frame <= 1 {
         unsafe {
-            let player = PLAYER_OPT.as_mut().unwrap();
+            let player = crate::player::player_mut();
             player
                 .movie
                 .cast_manager
@@ -4244,6 +4730,22 @@ pub async fn run_single_frame() -> (bool, bool) {
     });
 
     player_wait_available().await;
+
+    // Activate any Linked Movie (`#movie`) sprites that just gained their linked
+    // bytes: start a nested DirPlayer running each one on its own active-player
+    // id. Only the main loop reaches here (this whole frame loop runs at id 0);
+    // sub-players get their own frame loops via spawn_nested_player -> play().
+    if unsafe { ACTIVE_PLAYER_ID } == 0 {
+        reserve_player_ref(|player| player.activate_nested_players());
+        // Composite each on-stage sub-player's stage into the host so the WebGL2
+        // `Movie` sprite arm can draw it. Only when sub-players exist.
+        if unsafe { !NESTED_PLAYERS.is_empty() } {
+            reserve_player_mut(|player| {
+                player.render_nested_player_stages();
+                player.stage_dirty = true;
+            });
+        }
+    }
 
     let changed_filmloops = reserve_player_mut_async(|player| {
         Box::pin(async move {
@@ -4759,7 +5261,17 @@ pub fn compute_char_at(player: &mut DirPlayer, sprite_num: i16, mx: i32, my: i32
 /// zero-gain node and is gone by the time the frame loop resumes.
 fn tick_sound_manager(delta: f64) {
     unsafe {
-        if let Some(player) = PLAYER_OPT.as_mut() {
+        // Route to the ACTIVE player's sound manager, not always the host. A
+        // nested `#movie` sub-player's frame loop runs under its own active id;
+        // ticking PLAYER_OPT (the host) here left the sub's sounds un-updated
+        // (fades/loops/cue-points/stop never progressed) — the same
+        // de-globalization gap as DatumRef::drop.
+        let player_opt = if ACTIVE_PLAYER_ID == 0 {
+            PLAYER_OPT.as_mut()
+        } else {
+            NESTED_PLAYERS.get_mut(ACTIVE_PLAYER_ID - 1).and_then(|o| o.as_mut())
+        };
+        if let Some(player) = player_opt {
             // Aliasing the player via a raw pointer because
             // SoundManager::update needs `&mut DirPlayer` for
             // bookkeeping but lives inside the same player.
@@ -4773,7 +5285,7 @@ fn tick_sound_manager(delta: f64) {
 
 pub async fn run_frame_loop() {
     unsafe {
-        let player = PLAYER_OPT.as_ref().unwrap();
+        let player = crate::player::player_ref();
         if !player.is_playing {
             return;
         }
@@ -4925,10 +5437,52 @@ pub async fn run_frame_loop() {
         // Get the target frame delay based on cached tempo for current frame
         let target_delay_ms = reserve_player_ref(|player| {
             let tempo = player.current_frame_tempo;
-            if tempo == 0 {
+            let base = if tempo == 0 {
                 1000.0 / 30.0  // Default to 30fps if tempo is 0
             } else {
                 1000.0 / tempo as f64
+            };
+            // While an async net fetch is in flight, use a longer per-frame
+            // yield (>= ~12 ms) so the browser's fetch/stream gets enough
+            // event-loop time to complete. A tight high-tempo loop
+            // (DGS puppetTempo(999) ≈ 1 ms/frame) that calls into Flash every
+            // frame (showGameLoadStats) otherwise starves the fetch, so
+            // gameLoaded()/netDone never turns true and the loader hangs on its
+            // loading frame — only a debugger pause (which yields the event
+            // loop) unstuck it. The slowdown lasts only while a task loads.
+            // Also cover Ruffle-side browser fetches (LoadVars/URLLoader/XML)
+            // that dirplayer's net_manager never sees: flashPlayerManager's
+            // fetch monkey-patch publishes the count of outstanding requests as
+            // `window.__dirplayerPendingNetCount`. The DGS loader spins at load
+            // state 81 waiting on the preloader's translation POST (Ruffle-side,
+            // 1-3 s) to set `preloaderTranslationSuccess`; without this the tight
+            // loop starves that fetch's completion callback and the login links
+            // (asfunction hyperlinks in the translated IDS strings) never load.
+            let read_window_count = |key: &str| -> f64 {
+                web_sys::window()
+                    .and_then(|w| {
+                        js_sys::Reflect::get(&w, &wasm_bindgen::JsValue::from_str(key)).ok()
+                    })
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0)
+            };
+            let browser_fetch_pending = read_window_count("__dirplayerPendingNetCount") > 0.0;
+            // Offscreen Ruffle instances self-tick via requestAnimationFrame; a
+            // tight high-tempo Director loop (DGS puppetTempo(999) guest-gate
+            // poll at load-state 350) hogs the main thread and starves those
+            // ticks, so a preloader text field whose htmlText was just updated
+            // (the login links) never re-renders — the movie only worked with a
+            // debugger pause, which yields the loop. Floor the per-frame yield
+            // to ~one RAF interval while any Flash sprite is on stage AND the
+            // movie is spinning faster than 60fps (base < 16ms), so normal-tempo
+            // Flash playback is unaffected but a busy-poll can't starve Ruffle.
+            let flash_active = read_window_count("__dirplayerActiveFlashCount") > 0.0;
+            if player.net_manager.has_in_progress_tasks() || browser_fetch_pending {
+                base.max(25.0)
+            } else if flash_active {
+                base.max(16.0)
+            } else {
+                base
             }
         });
 
@@ -5010,7 +5564,7 @@ pub async fn player_trigger_error_pause(
 }
 
 pub async fn player_is_playing() -> bool {
-    unsafe { PLAYER_OPT.as_ref().unwrap().is_playing }
+    unsafe { crate::player::player_ref().is_playing }
 }
 
 pub(crate) static mut PLAYER_TX: Option<Sender<PlayerVMExecutionItem>> = None;
@@ -5046,12 +5600,12 @@ pub fn init_player() {
     // let mut player = //PLAYER_LOCK.try_write().unwrap();
     // *player = Some(DirPlayer::new(tx, allocator_rx, allocator_tx));
 
-    async_std::task::spawn_local(async move {
+    crate::player::spawn_player_local(async move {
         // player_load_system_font().await;
-        async_std::task::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             run_command_loop(rx).await;
         });
-        async_std::task::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             run_event_loop(event_rx).await;
         });
     });

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -454,6 +454,7 @@ impl DirPlayer {
                 click_loc: (0,0),
                 frame_script_instance: None,
                 frame_script_member: None,
+                frame_script_span_start: None,
                 sound_device: String::new(),
             },
             net_manager: NetManager {
@@ -2023,16 +2024,20 @@ impl DirPlayer {
                 Ok(self.alloc_datum(Datum::Point([self.movie.click_loc.0 as f64, self.movie.click_loc.1 as f64], 0)))
             },
             "markerList" => {
+                // Director's `the markerList` is a property list keyed by FRAME
+                // NUMBER with the label as the value: `[23: "ts_i04", 232: "Skelly", …]`
+                // (not `["Skelly": 232]`). Keep that order so movie code that reads
+                // `the markerList` (frame → label) works.
                 let labels: Vec<_> = self.movie.score.frame_labels
                     .iter()
-                    .map(|fl| (fl.label.clone(), fl.frame_num))
+                    .map(|fl| (fl.frame_num, fl.label.clone()))
                     .collect();
                 let props: VecDeque<(DatumRef, DatumRef)> = labels
                     .into_iter()
-                    .map(|(label, frame_num)| {
-                        let label = self.alloc_datum(Datum::String(label));
+                    .map(|(frame_num, label)| {
                         let frame_num = self.alloc_datum(Datum::Int(frame_num));
-                        (label, frame_num)
+                        let label = self.alloc_datum(Datum::String(label));
+                        (frame_num, label)
                     })
                     .collect();
                 Ok(self.alloc_datum(Datum::PropList(props, false)))

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -362,6 +362,14 @@ pub struct DirPlayer {
     /// Pending gotoNetMovie operation: (task_id, frame_destination).
     /// Overwritten by subsequent gotoNetMovie/go-to-movie calls (cancels previous).
     pub pending_goto_net_movie: Option<(u32, MovieFrameTarget)>,
+    /// Set by `play movie <the current movie>` (restart). The frame loop, between
+    /// frames, re-parses the retained movie bytes and runs the full load+init
+    /// (rebuilds the cast → fresh W3D scenes), preserving globals + external params
+    /// like Director's `play movie`. (The net loader can't always re-fetch by name
+    /// once loaded, so we keep the original bytes.)
+    pub pending_restart: bool,
+    /// Raw bytes + file_name + base_url of the loaded movie, retained for restart.
+    pub movie_reload_data: Option<(Vec<u8>, String, String)>,
     /// True while a net movie transition is in progress.
     /// Prevents the event loop from dispatching external events during the transition.
     pub is_in_transition: bool,
@@ -564,6 +572,8 @@ impl DirPlayer {
             eval_scope_index: None,
             delay_until: None,
             pending_goto_net_movie: None,
+            pending_restart: false,
+            movie_reload_data: None,
             is_in_transition: false,
             actor_list_generation: 0,
             behavior_channel_cache_generation: 0,
@@ -679,12 +689,17 @@ impl DirPlayer {
             .and_then(|segments| segments.last())
             .unwrap_or("untitled.dcr");
 
+        let base_url = get_base_url(&task.resolved_url).to_string();
+        let file_name_owned = file_name.to_string();
         let movie_file = read_director_file_bytes(
             &data_bytes,
             &file_name,
-            &get_base_url(&task.resolved_url).to_string(),
+            &base_url,
         )
         .map_err(|e| format!("Failed to parse movie file '{}': {}", path, e))?;
+        // Retain the raw bytes so a `play movie <current>` restart can re-parse and
+        // rebuild the cast (the net loader often can't re-fetch by name once loaded).
+        self.movie_reload_data = Some((data_bytes, file_name_owned, base_url));
         self.load_movie_from_dir(movie_file).await;
         Ok(())
     }
@@ -1138,6 +1153,7 @@ impl DirPlayer {
         self.current_breakpoint = None;
         self.scope_count = 0;
         self.pending_goto_net_movie = None;
+        self.pending_restart = false;
 
         debug!("Resetting allocator");
         // Now it's safe to reset the allocator
@@ -3647,6 +3663,78 @@ async fn transition_to_net_movie(task_id: u32, target: MovieFrameTarget) {
     });
 }
 
+/// Restart the current movie in place (`play movie <the current movie>`). Re-parses
+/// the retained movie bytes and runs the same load+init flow as a movie transition —
+/// rebuilding the cast (fresh W3D scenes, no stale clones) while PRESERVING globals
+/// and external params (which belong to the projector/embedding, not the movie file),
+/// matching Director's `play movie`. Used because the net loader often can't re-fetch
+/// the movie by name once it's been loaded.
+async fn restart_current_movie() {
+    let reload = reserve_player_ref(|player| player.movie_reload_data.clone());
+    let (bytes, file_name, base_url) = match reload {
+        Some(x) => x,
+        None => {
+            // No retained bytes — best-effort soft reset so we don't hang.
+            reserve_player_mut(|player| {
+                player.pending_restart = false;
+                player.reset();
+                player.play();
+            });
+            return;
+        }
+    };
+
+    let dir_file = match read_director_file_bytes(&bytes, &file_name, &base_url) {
+        Ok(f) => f,
+        Err(e) => {
+            log::warn!("restart: failed to re-parse movie bytes: {}", e);
+            reserve_player_mut(|player| player.pending_restart = false);
+            return;
+        }
+    };
+
+    // Shut the current movie down (block the event loop during the transition).
+    reserve_player_mut(|player| {
+        player.pending_restart = false;
+        player.is_playing = false;
+        player.is_in_transition = true;
+    });
+    stop_movie_sequence().await;
+
+    // Rebuild from frame 1, preserving globals + the allocator (like a transition).
+    reserve_player_mut(|player| {
+        player.movie.score.reset();
+        player.clear_script_instance_list_caches();
+        player.movie.frame_script_instance = None;
+        player.movie.frame_script_member = None;
+        player.movie.current_frame = 1;
+        player.last_initialized_frame = None;
+        for scope in player.scopes.iter_mut() {
+            scope.reset();
+        }
+        player.scope_count = 0;
+        player.is_playing = false;
+    });
+
+    reserve_player_mut_async(|player| {
+        Box::pin(async move {
+            player.load_movie_from_dir(dir_file).await;
+        })
+    }).await;
+
+    reserve_player_mut(|player| {
+        player.movie.current_frame = 1;
+        player.pending_restart = false;
+        player.is_playing = true;
+    });
+
+    run_movie_init_sequence().await;
+
+    reserve_player_mut(|player| {
+        player.is_in_transition = false;
+    });
+}
+
 // JS bridge name uses the `dirplayer_` prefix so this fork's globals don't
 // collide with stock Ruffle / other libraries on the same page.
 #[wasm_bindgen]
@@ -4454,6 +4542,18 @@ pub async fn run_frame_loop() {
         // Exit if the player was reset (e.g. between tests)
         if unsafe { PLAYER_GENERATION } != generation {
             return;
+        }
+        // Restart (`play movie <the current movie>`). Done HERE — between frames,
+        // no active bytecode — so it's safe to rebuild the cast. Re-parses the
+        // retained movie bytes and runs the full load+init (fresh W3D scenes etc.),
+        // preserving globals + external params like Director's `play movie`.
+        let do_restart = reserve_player_ref(|player| player.pending_restart);
+        if do_restart {
+            restart_current_movie().await;
+            (is_playing, _) = reserve_player_ref(|player| {
+                (player.is_playing, player.is_script_paused)
+            });
+            continue;
         }
         // Check for pending gotoNetMovie completion
         let goto_transition = reserve_player_ref(|player| {

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -601,11 +601,71 @@ impl DirPlayer {
     /// before Lingo scripts try to access them. Per-sprite: each sprite that
     /// references a Flash member gets its own dedicated Ruffle instance.
     pub fn pre_dispatch_flash_members(&mut self) {
+        // UNLOAD pass FIRST: tear down any Ruffle instance whose channel no
+        // longer holds that exact Flash member — BEFORE the load pass below, so
+        // a member swap is deterministically unload(old) → load(new). If the
+        // load ran first, `createFlashInstance(new)` sets the new instance at
+        // the sprite's key, and the subsequent unload(old) — same key —
+        // destroys the freshly-created instance, so the swapped-in member
+        // (bogey_nights' bogeyman straw/longarm) never renders (frame stays 0,
+        // "stale straw"). Also frees instances when a channel empties
+        // (splash `killer`) so we don't leak players.
+        let loaded: Vec<(i16, i32, i32)> = self.flash_sprite_loaded.iter().cloned().collect();
+        for (ch, cl, cm) in loaded {
+            let cur = self
+                .movie
+                .score
+                .get_sprite(ch)
+                .and_then(|s| s.member.as_ref())
+                .map(|m| (m.cast_lib, m.cast_member));
+            let still_present = cur == Some((cl, cm));
+            if still_present {
+                continue;
+            }
+            // The channel no longer holds THIS member. But the JS Ruffle instance
+            // map is keyed by CHANNEL NUMBER only, while `flash_sprite_loaded` is
+            // keyed by (channel, cast_lib, cast_member) — so a flash→flash swap
+            // leaves BOTH the old and new member entries in the set for the same
+            // channel for a frame. If we blindly `destroyFlashInstance(ch)` for
+            // the stale OLD entry, we destroy the NEW member's instance (same JS
+            // key) that `createFlashInstance` just put there — bogey_nights'
+            // bogeyman swaps longarm↔straw and the straw instance was being
+            // killed the instant it registered (permanent "NO INSTANCE",
+            // frame reads 0, grab stalls into #retreat).
+            //
+            // On a flash→flash swap `createFlashInstance` already replaced the
+            // single per-channel instance itself (its own leading
+            // destroyFlashInstance). So only tear down the JS instance when the
+            // channel no longer shows ANY live Flash member; otherwise just drop
+            // the stale bookkeeping entry and leave the new instance alone.
+            if !self.channel_holds_live_flash(ch) {
+                JsApi::dispatch_flash_member_unloaded(ch as i32);
+                self.flash_frame_buffers.remove(&ch);
+            }
+            self.flash_sprite_loaded.remove(&(ch, cl, cm));
+        }
+
+        // LOAD pass: dispatch newly-present Flash members.
         for channel in &self.movie.score.channels {
             let channel_num = channel.number as i16;
             if let Some(member_ref) = &channel.sprite.member {
                 let dispatch_key = (channel_num, member_ref.cast_lib, member_ref.cast_member);
                 if self.flash_sprite_loaded.contains(&dispatch_key) {
+                    // Already loaded: keep the Ruffle render resolution matched
+                    // to the sprite's current on-stage size so a Flash sprite
+                    // scaled up on stage (bogey_nights' boogyflash/spitflash
+                    // splashes GROW; the bogeyman arm swaps member dims) stays
+                    // sharp — Ruffle re-renders the vector at the new size
+                    // instead of dirplayer upscaling a stale small capture.
+                    // setFlashSize no-ops on sub-2px changes so static sprites
+                    // (StoryScramble posters) never reflow. Only for on-stage
+                    // sprites (positive channel); 3D-texture instances excluded
+                    // in the JS twin.
+                    ruffle_set_size(
+                        channel_num as i32,
+                        channel.sprite.width.max(1) as i32,
+                        channel.sprite.height.max(1) as i32,
+                    );
                     continue;
                 }
                 if let Some(member) = self.movie.cast_manager.find_member_by_ref(member_ref) {
@@ -619,10 +679,14 @@ impl DirPlayer {
                                 .as_ref()
                                 .map(|fi| fi.paused_at_start)
                                 .unwrap_or(false);
+                            // Re-project the sprite's asserted frame onto the new
+                            // instance so shared-member siblings show unique
+                            // posters and swaps keep their frame.
+                            let asserted_frame = channel.sprite.flash_asserted_frame.unwrap_or(-1);
                             debug!(
-                                "[Flash] Pre-dispatching sprite#{} {}:{} ({}x{}, {} bytes, pausedAtStart={})",
+                                "[Flash] Pre-dispatching sprite#{} {}:{} ({}x{}, {} bytes, pausedAtStart={}, assertedFrame={})",
                                 channel_num, member_ref.cast_lib, member_ref.cast_member,
-                                w, h, data.len(), paused_at_start,
+                                w, h, data.len(), paused_at_start, asserted_frame,
                             );
                             JsApi::dispatch_flash_member_loaded(
                                 channel_num as i32,
@@ -632,6 +696,7 @@ impl DirPlayer {
                                 w,
                                 h,
                                 paused_at_start,
+                                asserted_frame,
                             );
                             self.flash_sprite_loaded.insert(dispatch_key);
                         }
@@ -640,32 +705,24 @@ impl DirPlayer {
             }
         }
 
-        // Reconcile: tear down any Ruffle instance whose channel no longer
-        // holds that exact Flash member. Instances are otherwise only destroyed
-        // on an external-cast swap (invalidate_flash_for_cast_lib), so a channel
-        // that showed a Flash member once would keep its WebGL-backed Ruffle
-        // player forever. bogey_nights churns Flash sprites hard — every splash
-        // that reaches #superstar swaps its bitmap member for the boogyflash /
-        // spitflash SWF, and `killer` empties the channel a moment later. Across
-        // hundreds of channels this leaks Ruffle instances until the browser
-        // hits its WebGL context cap ("Too many active WebGL contexts"). Freeing
-        // the instance as soon as its Flash member leaves keeps only the
-        // genuinely-active Flash sprites alive.
-        let loaded: Vec<(i16, i32, i32)> = self.flash_sprite_loaded.iter().cloned().collect();
-        for (ch, cl, cm) in loaded {
-            let still_present = self
-                .movie
-                .score
-                .get_sprite(ch)
-                .and_then(|s| s.member.as_ref())
-                .map(|m| m.cast_lib == cl && m.cast_member == cm)
-                .unwrap_or(false);
-            if !still_present {
-                JsApi::dispatch_flash_member_unloaded(ch as i32);
-                self.flash_sprite_loaded.remove(&(ch, cl, cm));
-                self.flash_frame_buffers.remove(&ch);
-            }
-        }
+    }
+
+    /// True if the given score channel currently holds a Flash (SWF) cast
+    /// member — i.e. there should be exactly one live Ruffle instance keyed by
+    /// this channel number. Used by the reconcile to distinguish a flash→flash
+    /// member swap (keep the instance `createFlashInstance` just made) from a
+    /// flash→non-flash/empty change (genuinely tear the instance down).
+    fn channel_holds_live_flash(&self, ch: i16) -> bool {
+        self.movie
+            .score
+            .get_sprite(ch)
+            .and_then(|s| s.member.as_ref())
+            .and_then(|mref| self.movie.cast_manager.find_member_by_ref(mref))
+            .map(|member| match &member.member_type {
+                CastMemberType::Flash(f) => crate::rendering::has_swf_signature(&f.data),
+                _ => false,
+            })
+            .unwrap_or(false)
     }
 
     /// Tear down any Flash (Ruffle) instances whose source member lives in the
@@ -3827,6 +3884,11 @@ async fn restart_current_movie() {
 extern "C" {
     #[wasm_bindgen(js_name = "dirplayer_isFlashLoading", catch)]
     fn is_flash_loading() -> Result<bool, wasm_bindgen::JsValue>;
+
+    /// Resize a live Ruffle instance so it re-renders the vector sharp at the
+    /// sprite's current on-stage size (splashes grow, arm swaps dims).
+    #[wasm_bindgen(js_name = "dirplayer_ruffleSetSize")]
+    fn ruffle_set_size(sprite_num: i32, w: i32, h: i32);
 }
 /// Execute one complete frame cycle: run frame scripts, then advance to the next frame.
 /// Returns (is_playing, is_script_paused) so callers can check if the movie is still running.

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -363,12 +363,15 @@ pub struct DirPlayer {
     /// `me` correct in `on <handler> me, aInfo, aMessage`.
     pub flash_lc_callbacks:
         std::collections::HashMap<(String, String), (String, ScriptInstanceRef)>,
-    /// Set true whenever a script reads live input state — `keyPressed(...)`,
-    /// `the mouseDown`, `the stillDown`. The bytecode loop's busy-wait yield
-    /// counts a loop iteration toward yielding ONLY when this was set that
-    /// iteration, so it cooperatively yields for input-wait spins (Neopets'
-    /// `repeat while keyPressed(" ") end`) but NEVER for compute/AMF loops (Coke
-    /// Studios' object-graph conversion), where a yield only adds latency.
+    /// Set true whenever a script reads live input OR a wall clock —
+    /// `keyPressed(...)`, `the keyPressed`, `the key`, `the keyCode`,
+    /// `the mouseDown`, `the stillDown`, `the ticks`, `the milliSeconds`,
+    /// `the timer`. The bytecode loop's busy-wait yield counts a loop iteration
+    /// toward yielding ONLY when this was set that iteration, so it cooperatively
+    /// yields for input-wait spins (Neopets' `repeat while keyPressed(" ") end`)
+    /// and for time-based frame throttles (`repeat while (the ticks - t0) < N`),
+    /// but NEVER for compute/AMF loops (Coke Studios' object-graph conversion),
+    /// which read neither, so a yield there only adds latency.
     pub input_polled: bool,
     /// Off-screen Flash members rendered into W3D textures (frog01's environment:
     /// `newTexture(#fromCastMember, flashMember)`). Keyed by a synthetic NEGATIVE
@@ -2346,11 +2349,17 @@ impl DirPlayer {
             "time" => Ok(self.alloc_datum(Datum::String(
                 chrono::Local::now().format("%H:%M %p").to_string(),
             ))),
-            "milliSeconds" => Ok(self.alloc_datum(Datum::Int(
-                chrono::Local::now()
-                    .signed_duration_since(self.system_start_time)
-                    .num_milliseconds() as i32,
-            ))),
+            "milliSeconds" => {
+                // Reading a clock in a loop condition is a time-based busy-wait
+                // (`repeat while (the milliSeconds - t0) < N`); mark it so the
+                // backward-jump handler yields cooperatively (see input_polled).
+                self.input_polled = true;
+                Ok(self.alloc_datum(Datum::Int(
+                    chrono::Local::now()
+                        .signed_duration_since(self.system_start_time)
+                        .num_milliseconds() as i32,
+                )))
+            },
             "keyboardFocusSprite" => {
                 Ok(self.alloc_datum(Datum::Int(self.keyboard_focus_sprite as i32)))
             },
@@ -2423,10 +2432,12 @@ impl DirPlayer {
             },
             "altDown" => Ok(self.alloc_datum(datum_bool(self.keyboard_manager.is_alt_down()))),
             "key" => Ok(self.alloc_datum(Datum::String(self.keyboard_manager.key()))),
-            "keyPressed" => Ok(self.alloc_datum(Datum::String(self.keyboard_manager.key_pressed()))),
+            "keyPressed" => { self.input_polled = true; Ok(self.alloc_datum(Datum::String(self.keyboard_manager.key_pressed()))) },
             "floatPrecision" => Ok(self.alloc_datum(Datum::Int(self.float_precision as i32))),
             "doubleClick" => Ok(self.alloc_datum(datum_bool(self.is_double_click))),
-            "ticks" => Ok(self.alloc_datum(Datum::Int(get_elapsed_ticks(self.system_start_time)))),
+            // Time read in a loop condition = busy-wait throttle; flag it so the
+            // backward-jump handler yields cooperatively (see input_polled).
+            "ticks" => { self.input_polled = true; Ok(self.alloc_datum(Datum::Int(get_elapsed_ticks(self.system_start_time)))) },
             "frameLabel" => {
                 let frame_label = self
                     .movie
@@ -2769,8 +2780,17 @@ impl DirPlayer {
         }
     }
 
-    fn get_anim_prop(&self, prop_id: u16) -> Result<Datum, ScriptError> {
+    fn get_anim_prop(&mut self, prop_id: u16) -> Result<Datum, ScriptError> {
         let prop_name = get_anim_prop_name(prop_id);
+        // `the timer` / `the keyPressed` / `the key` / `the keyCode` are the
+        // classic-syntax time/input polls. Reading any in a `repeat while`
+        // condition (`repeat while the timer < N`, nomiss's Simon delays; or a
+        // key spin) is a busy-wait — flag it so the backward-jump handler yields
+        // cooperatively to the JS event loop (see input_polled). Mirrors the
+        // object-syntax reads in get_movie_prop.
+        if matches!(prop_name, "timer" | "keyPressed" | "key" | "keyCode") {
+            self.input_polled = true;
+        }
         match prop_name {
             "colorDepth" => Ok(Datum::Int(32)),
             "fullColorPermit" => Ok(Datum::Int(1)), // Full color mode is permitted
@@ -3936,16 +3956,23 @@ pub async fn player_call_script_handler_raw_args(
                 return Err(err);
             }
             HandlerExecutionResult::Jump => {
-                // Busy-wait cooperative yield, scoped to INPUT-polling loops.
-                // Added for Neopets' `repeat while keyPressed(" ") end` — an empty
-                // tight loop that must yield so the JS event loop can deliver the
-                // key-up, else it spins forever. Only count this jump toward the
-                // yield when the iteration actually read live input (keyPressed /
-                // the mouseDown / the stillDown set `input_polled`); a heavy
-                // compute/AMF loop (Coke Studios' object-graph conversion) never
-                // sets it, so it never yields — a yield there only adds latency
-                // and was the source of the navigator stalls. Reading+clearing a
-                // bool is far cheaper than the old per-instruction scope lookup.
+                // Busy-wait cooperative yield, scoped to INPUT- and TIME-polling
+                // loops. Added for Neopets' `repeat while keyPressed(" ") end` — an
+                // empty tight loop that must yield so the JS event loop can deliver
+                // the key-up, else it spins forever. Also covers TIME-based frame
+                // throttles that read a clock in the loop condition
+                // (`repeat while (the ticks - t0) < N`, 100s-Marios' game loop;
+                // `repeat while the timer < toneDelay`, nomiss's Simon delays):
+                // without yielding, real time can't advance predictably between
+                // iterations, so the throttle collapses and the game runs at the
+                // wrong speed. Only count this jump toward the yield when the
+                // iteration actually read live input or a clock (keyPressed / the
+                // mouseDown / the stillDown / the ticks / the milliSeconds / the
+                // timer set `input_polled`); a heavy compute/AMF loop (Coke
+                // Studios' object-graph conversion) never sets it, so it never
+                // yields — a yield there only adds latency and was the source of
+                // the navigator stalls. Reading+clearing a bool is far cheaper
+                // than the old per-instruction scope lookup.
                 let polled = reserve_player_mut(|player| std::mem::take(&mut player.input_polled));
                 if polled {
                     backjumps = backjumps.wrapping_add(1);

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -56,6 +56,14 @@ pub struct Movie {
     pub click_loc: (i32, i32),
     pub frame_script_instance: Option<ScriptInstanceRef>,
     pub frame_script_member: Option<CastMemberRef>,
+    /// Start frame of the channel-0 (frame-script) SPAN the cached instance was
+    /// created for. The same behavior member can appear in several consecutive
+    /// spans with DIFFERENT parameters (e.g. the Game Loop dropped on the intro
+    /// frames as `#Nonlooping` and on the gameplay frames as `#CostumeChange`);
+    /// the instance must be recreated (and its params re-applied) when the span
+    /// changes, not only when the member changes — otherwise the gameplay span
+    /// inherits the intro span's stale `pType`.
+    pub frame_script_span_start: Option<u32>,
     pub sound_device: String,
 }
 

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -369,6 +369,14 @@ impl Movie {
             // No-op system prop: nothing to preload-abort in dirplayer.
             // Return the Director default (FALSE) so read-backs don't error.
             "preLoadEventAbort" => Ok(datum_bool(false)),
+            // soundMixMedia (Sound property, read/write) — Flash sound mixing is a
+            // Windows-only nuance we don't model. Return the Director 7+ default (TRUE).
+            "soundMixMedia" => Ok(datum_bool(true)),
+            // machineType (classic Director system property, absent from the 11.5
+            // dictionary): a Macintosh model code, or 256 on Windows/Intel. dirplayer
+            // emulates Windows Shockwave playback, so report 256 — movies branch their
+            // path separators and platform paths on this.
+            "machineType" => Ok(Datum::Int(256)),
             _ => Err(ScriptError::new(format!("Cannot get movie prop {prop}")))
         })
     }
@@ -506,7 +514,12 @@ impl Movie {
             },
             "timeoutLength" | "timeoutKeyDown" | "timeoutMouse" | "timeoutPlay"
             | "timeoutLapsed" | "soundEnabled" | "soundLevel"
-            | "beepOn" | "centerStage" | "exitLock" | "fixStageSize" => {
+            | "beepOn" | "centerStage" | "exitLock" | "fixStageSize"
+            // soundMixMedia (Director 11.5 Scripting Dictionary: Sound property,
+            // read/write) toggles whether Flash cast members mix their audio into the
+            // Score sound channels — a Windows-only playback nuance. dirplayer uses
+            // WebAudio, so we accept the set without acting on it.
+            | "soundMixMedia" => {
                 // Anim props that are set via property_type 0x07 - accept silently
                 Ok(())
             },

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -68,6 +68,49 @@ pub struct Movie {
 }
 
 impl Movie {
+    /// Construct an empty movie with default state (no cast/score loaded).
+    /// Used for the player's primary movie and for nested linked-movie
+    /// (`#movie`) playback, which builds a second Movie from the linked .dcr
+    /// and drives it through the same engine.
+    pub fn empty() -> Self {
+        Movie {
+            rect: IntRect::from(0, 0, 0, 0),
+            cast_manager: CastManager::empty(),
+            score: Score::empty(),
+            current_frame: 1,
+            puppet_tempo: 0,
+            random_seed: None,
+            exit_lock: false,
+            dir_version: 0,
+            item_delimiter: ',',
+            alert_hook: None,
+            base_path: "".to_string(),
+            file_name: "".to_string(),
+            stage_color: (255, 255, 255),
+            stage_color_ref: ColorRef::PaletteIndex(255),
+            frame_rate: 30,
+            file: None,
+            update_lock: false,
+            mouse_down_script: None,
+            mouse_up_script: None,
+            key_down_script: None,
+            key_up_script: None,
+            timeout_script: None,
+            allow_custom_caching: false,
+            trace_script: false,
+            trace_log_file: String::new(),
+            debug_playback_enabled: false,
+            edit_shortcuts_enabled: true,
+            mouse_down: false,
+            right_mouse_down: false,
+            click_loc: (0, 0),
+            frame_script_instance: None,
+            frame_script_member: None,
+            frame_script_span_start: None,
+            sound_device: String::new(),
+        }
+    }
+
     pub async fn load_from_file(
         &mut self,
         file: DirectorFile,

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -48,6 +48,14 @@ pub struct Movie {
     /// so this is stored for round-trip read/write but has no side effect.
     /// Default TRUE for movies authored in Director 8+ (Scripting Dict p.890).
     pub edit_shortcuts_enabled: bool,
+    /// `the enableFlashLingo` — Director movie property (Scripting Dict p.897).
+    /// Gates whether a Flash sprite may run Lingo via Flash's `getURL()` (the
+    /// `lingo:` / `event:` schemes); default FALSE for movies of unknown origin.
+    /// We store it for round-trip read/write ONLY and DO NOT gate the actual
+    /// callback dispatch on it: real movies fire `event:`/`lingo:` without ever
+    /// setting this property, so honoring it as a hard gate would break them
+    /// (see [[flash-lingo-geturl-scheme]]). dirplayer always allows the callback.
+    pub enable_flash_lingo: bool,
     pub mouse_down: bool,
     /// Tracks the right mouse button independently of `mouse_down` — set by
     /// `right_mouse_down(x, y)` / `right_mouse_up(x, y)` from the JS host.
@@ -101,6 +109,7 @@ impl Movie {
             trace_log_file: String::new(),
             debug_playback_enabled: false,
             edit_shortcuts_enabled: true,
+            enable_flash_lingo: false,
             mouse_down: false,
             right_mouse_down: false,
             click_loc: (0, 0),
@@ -356,6 +365,7 @@ impl Movie {
             },
             "debugplaybackenabled" => Ok(datum_bool(self.debug_playback_enabled)),
             "editShortCutsEnabled" => Ok(datum_bool(self.edit_shortcuts_enabled)),
+            "enableFlashLingo" => Ok(datum_bool(self.enable_flash_lingo)),
             // No-op system prop: nothing to preload-abort in dirplayer.
             // Return the Director default (FALSE) so read-backs don't error.
             "preLoadEventAbort" => Ok(datum_bool(false)),
@@ -384,6 +394,12 @@ impl Movie {
             },
             "editShortCutsEnabled" => {
                 self.edit_shortcuts_enabled = value.int_value()? != 0;
+                Ok(())
+            },
+            "enableFlashLingo" => {
+                // Store the flag for read-back; does NOT restrict Flash->Lingo
+                // callbacks (see field comment). Round-trip only.
+                self.enable_flash_lingo = value.int_value()? != 0;
                 Ok(())
             },
             "alertHook" => {

--- a/vm-rust/src/player/net_manager.rs
+++ b/vm-rust/src/player/net_manager.rs
@@ -107,6 +107,20 @@ impl NetManager {
             .map_or(false, |x| x.result.is_some());
     }
 
+    /// True if any net task is still in flight (not yet fulfilled). Used by the
+    /// frame loop to lengthen its per-frame yield so an async fetch/stream gets
+    /// enough event-loop time to finish — a tight high-tempo Lingo loop that
+    /// polls `netDone`/`getStreamStatus` every frame (e.g. Neopets DGS
+    /// state 34 at puppetTempo(999)) can otherwise starve the fetch, leaving
+    /// `gameLoaded()` false forever.
+    pub fn has_in_progress_tasks(&self) -> bool {
+        match self.shared_state.try_lock() {
+            Some(shared_state) => shared_state.task_states.values().any(|s| s.result.is_none()),
+            // Lock held == a fetch task is actively updating progress.
+            None => true,
+        }
+    }
+
     pub fn get_task_result(&self, task_id: Option<u32>) -> Option<NetResult> {
         return self.get_task_state(task_id).and_then(|x| x.result);
     }
@@ -258,7 +272,7 @@ impl NetManager {
         } else {
             // Execute normal HTTP fetch
             let shared_state_arc = Arc::clone(&self.shared_state);
-            async_std::task::spawn_local(async move {
+            crate::player::spawn_player_local(async move {
                 Self::execute_task(task_id.clone(), net_task, shared_state_arc).await;
             });
         }
@@ -304,7 +318,7 @@ impl NetManager {
         self.tasks.insert(task_id, net_task.clone());
 
         let shared_state_arc = Arc::clone(&self.shared_state);
-        async_std::task::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             Self::execute_task(task_id.clone(), net_task, shared_state_arc).await;
         });
 

--- a/vm-rust/src/player/net_task.rs
+++ b/vm-rust/src/player/net_task.rs
@@ -165,6 +165,15 @@ pub async fn fetch_net_task(
                 .unwrap_or(true);
 
             if done {
+                // Final progress. If the server didn't advertise Content-Length
+                // (e.g. a CORS proxy stripped it), report the actual byte count
+                // as the total so getStreamStatus(netID)[#bytestotal] is non-zero
+                // and Director's `percentloaded` reaches 100 on completion
+                // (DGS's showGameLoadStats divides by #bytestotal — 0 leaves the
+                // loading bar stuck and `percentloaded` at 0 forever).
+                let mut state = shared_state.lock().await;
+                let total = content_length.max(bytes.len() as u64);
+                state.update_task_progress(task.id, bytes.len() as u64, total);
                 break;
             }
 
@@ -179,6 +188,7 @@ pub async fn fetch_net_task(
             }
         }
 
+        maybe_hold_dcr_for_preloader(&task.url).await;
         Ok(bytes)
     } else {
         // Fallback: no body stream, read all at once
@@ -188,9 +198,37 @@ pub async fn fetch_net_task(
 
         {
             let mut state = shared_state.lock().await;
-            state.update_task_progress(task.id, bytes.len() as u64, content_length);
+            let total = content_length.max(bytes.len() as u64);
+            state.update_task_progress(task.id, bytes.len() as u64, total);
         }
 
+        maybe_hold_dcr_for_preloader(&task.url).await;
         Ok(bytes)
     }
+}
+
+/// Neopets DGS shows a Flash preloader whose guest-login prompt is only
+/// (re)painted while the nested game `.dcr` is still streaming — the Director
+/// loader sits at load-state 34 calling the SWF's `showLoadingProcess` each
+/// frame, which refills the `pre_main` field *after* the translation's `onLoad`
+/// blanks it. If the `.dcr` completes too soon after that blank, the prompt
+/// never repaints and there are no links to click (the movie only advanced when
+/// a debugger pause stretched that window). Hold a *playing* movie's `.dcr` task
+/// "in progress" for a few seconds so those extra frames happen. The task stays
+/// unresolved, so `netDone` stays false AND the frame loop's net-yield keeps the
+/// offscreen Ruffle instance ticking meanwhile. Only applies once the movie is
+/// playing, so it never delays the initial movie load.
+async fn maybe_hold_dcr_for_preloader(url: &str) {
+    let path = url.split('?').next().unwrap_or(url).to_ascii_lowercase();
+    if !path.ends_with(".dcr") {
+        return;
+    }
+    if !crate::player::reserve_player_ref(|p| p.is_playing) {
+        return;
+    }
+    let _ = async_std::future::timeout(
+        std::time::Duration::from_millis(3000),
+        std::future::pending::<()>(),
+    )
+    .await;
 }

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -5045,6 +5045,24 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
     }
     let member = member.unwrap();
 
+    // Shockwave3D directToStage members render the 3D world into the sprite's
+    // viewport at the member's `defaultRect` size (Director: defaultRect
+    // "controls the default size used for all new sprites"), positioned by the
+    // member regPoint — NOT the raw score channel width/height. Splat's "scene"
+    // sets `defaultRect = rect(0,0,620,410)` + directToStage; without this it
+    // rendered at the 640×480 stage default, distorting the 3D aspect. Gated on
+    // directToStage + a non-degenerate defaultRect + no explicit score stretch,
+    // so non-directToStage / un-sized 3D members keep their existing behavior.
+    if let CastMemberType::Shockwave3d(w3d) = &member.member_type {
+        let dr = w3d.info.default_rect;
+        let (dw, dh) = (dr.2 - dr.0, dr.3 - dr.1);
+        if w3d.info.direct_to_stage && dw > 0 && dh > 0 && sprite.stretch == 0 {
+            let reg_x = w3d.info.reg_point.0;
+            let reg_y = w3d.info.reg_point.1;
+            return IntRect::from_size(sprite.loc_h - reg_x, sprite.loc_v - reg_y, dw, dh);
+        }
+    }
+
     match &member.member_type {
         CastMemberType::Bitmap(bitmap_member) => {
             // Get registration point from bitmap member

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -5038,8 +5038,20 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
             // stretch=1; natural-size sprites whose score box drifts a few px
             // from the bitmap (PinBall, Junkbot) carry stretch=0.
             let stretched = sprite.stretch != 0 || sprite.has_size_tweened;
+            // A ≤1px difference from the bitmap's natural size in BOTH axes is
+            // NOT a real resize — it's the rounding Director's score applies to
+            // a center-registered bitmap of odd dimension. The sprite rect is
+            // stored as `2 * regPoint`, i.e. the bitmap size rounded DOWN to
+            // even, and the stretch bit ends up set. e.g. a 760x521 bitmap with
+            // reg (380,260) gets a 760x520 score box with stretch=1; honoring
+            // it verbatim drops the last row. A genuine resize differs by far
+            // more than a pixel, so snapping to the decoded bitmap size here is
+            // safe and only ever corrects this off-by-one.
+            let near_natural = bitmap_width > 0 && bitmap_height > 0
+                && (sprite.width - bitmap_width).abs() <= 1
+                && (sprite.height - bitmap_height).abs() <= 1;
             let (sprite_width, sprite_height, _size_path) =
-                if stretched && sprite.width > 0 && sprite.height > 0 {
+                if stretched && !near_natural && sprite.width > 0 && sprite.height > 0 {
                     (sprite.width, sprite.height, "STRETCH")
                 } else if bitmap_width > 0 && bitmap_height > 0 {
                     (bitmap_width, bitmap_height, "NATURAL")
@@ -5049,11 +5061,12 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
                 } else {
                     (bitmap_width, bitmap_height, "ZERO")
                 };
-            debug!("[BITMAP_RECT] sprite#{} path={} result={}x{} loc=({},{}) reg=({},{}) sprite={}x{} bitmap={}x{} flags(tweened={} owned={} changed={})",
-                sprite.number, _size_path, sprite_width, sprite_height,
+            debug!("[BITMAP_RECT] sprite#{} member={:?} path={} result={}x{} loc=({},{}) reg=({},{}) sprite={}x{} bitmap(decoded)={}x{} info={}x{} stretch={} flags(tweened={} owned={} changed={})",
+                sprite.number, sprite.member, _size_path, sprite_width, sprite_height,
                 sprite.loc_h, sprite.loc_v,
                 reg_x, reg_y,
                 sprite.width, sprite.height, bitmap_width, bitmap_height,
+                bitmap_member.info.width, bitmap_member.info.height, sprite.stretch,
                 sprite.has_size_tweened, sprite.bitmap_size_owned_by_sprite, sprite.has_size_changed);
 
             // If centerRegPoint is enabled, set reg point to bitmap center.

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -589,6 +589,23 @@ impl Score {
 
         for sprite_num in sprites_to_finish {
             reserve_player_mut(|player| {
+                // Capture the last on-screen rect BEFORE reset for visible stage
+                // sprites that still have a member. Director keeps a channel's
+                // `the rect of sprite` at its last value after the sprite leaves
+                // its span (member clears to 0); 3D init scripts read
+                // sprite(1).rect on the between-spans transition frame.
+                let retained_rect = if matches!(score_ref, ScoreRef::Stage) {
+                    player.movie.score.get_sprite(sprite_num as i16).and_then(|sprite| {
+                        if sprite.visible && !sprite.puppet && sprite.member.is_some() {
+                            let r = get_concrete_sprite_rect(player, sprite);
+                            Some((r.left, r.top, r.right, r.bottom))
+                        } else {
+                            None
+                        }
+                    })
+                } else {
+                    None
+                };
                 let did_reset = {
                     let score = match &score_ref {
                         ScoreRef::Stage => &mut player.movie.score,
@@ -611,8 +628,10 @@ impl Score {
                         sprite.exited = false;
                         false
                     } else if sprite.visible {
-                        // Visible non-puppet sprite leaving its span → full reset.
+                        // Visible non-puppet sprite leaving its span → full reset,
+                        // but keep the last on-screen rect for empty-channel reads.
                         sprite.reset();
+                        sprite.retained_rect = retained_rect;
                         true
                     } else {
                         // Invisible non-puppet exited sprite: clear ONLY the
@@ -5041,6 +5060,12 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
         .as_ref()
         .and_then(|member_ref| player.movie.cast_manager.find_member_by_ref(member_ref));
     if member.is_none() {
+        // Empty channel: Director keeps `the rect of sprite` at the value it had
+        // before the sprite left its span (member→0). retained_rect carries that
+        // last rect so transition-frame reads of sprite(n).rect stay meaningful.
+        if let Some((l, t, r, b)) = sprite.retained_rect {
+            return IntRect::from(l, t, r, b);
+        }
         return IntRect::from_size(sprite.loc_h, sprite.loc_v, sprite.width, sprite.height);
     }
     let member = member.unwrap();

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -3414,6 +3414,24 @@ pub fn sprite_get_prop(
                 .map(|x| x.clone())
                 .unwrap_or(NULL_CAST_MEMBER_REF),
         )),
+        // `the type of sprite` (Director 11.5): "can be tested and set". An
+        // occupied channel reports its member's type symbol (#bitmap, #flash,
+        // …); an empty channel reports 0 (matching `sprite(ch).type = 0`
+        // clearing a channel). bogeyman tests `if sprite(pBogey).type = #flash`.
+        "type" => {
+            let member_ref = sprite.and_then(|s| s.member.clone());
+            match member_ref {
+                Some(m) if m.is_valid() => {
+                    match player.movie.cast_manager.find_member_by_ref(&m) {
+                        Some(member) => {
+                            Ok(Datum::Symbol(member.member_type.type_string().to_string()))
+                        }
+                        None => Ok(Datum::Int(0)),
+                    }
+                }
+                _ => Ok(Datum::Int(0)),
+            }
+        }
         "camera" => {
             // Shockwave3D sprite camera — returns the active camera as a Shockwave3dObjectRef
             let member_ref = sprite.and_then(|s| s.member.as_ref()).cloned().unwrap_or(NULL_CAST_MEMBER_REF);
@@ -3568,10 +3586,32 @@ pub fn sprite_get_prop(
             }
         }
         "currentFrame" | "frame" => {
-            if sprite.and_then(|s| s.member.as_ref()).is_some() {
-                Ok(Datum::Int(ruffle_get_current_frame(sprite_id as i32)))
-            } else {
-                Ok(Datum::Int(0))
+            // A behavior's own `property frame` / `property currentFrame` takes
+            // precedence over the Flash playhead reading. Many behaviors track
+            // an animation frame in a property literally named `frame`
+            // (bogey_nights' bogeyman behavior does). Without checking the
+            // behaviors first, `sprite(N).frame` was unconditionally hijacked
+            // into the Ruffle currentFrame for ANY sprite with a member — the
+            // behavior's real value was unreachable and the paired setter
+            // blanked the SWF (see the setter arm). Only when no behavior owns
+            // the property do we read the Flash playhead (storyscramble tiles).
+            let behavior_val = sprite.and_then(|sprite| {
+                reserve_player_mut(|player| {
+                    sprite.script_instance_list.iter().find_map(|behavior| {
+                        script_get_prop_opt(player, behavior, &prop_name.to_string())
+                    })
+                })
+            });
+            match behavior_val {
+                Some(ref_) => {
+                    let datum_clone = player.get_datum(&ref_).clone();
+                    player.last_sprite_prop_ref = Some(ref_);
+                    Ok(datum_clone)
+                }
+                None if sprite.and_then(|s| s.member.as_ref()).is_some() => {
+                    Ok(Datum::Int(ruffle_get_current_frame(sprite_id as i32)))
+                }
+                None => Ok(Datum::Int(0)),
             }
         }
         "actionsEnabled" | "buttonsEnabled" | "imageEnabled" | "sound" | "static" => {
@@ -4055,6 +4095,45 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
         // different frames (storyscramble's 3 story tiles use cast 2:1 but
         // display poster frames 2/4/6 simultaneously).
         "frame" | "currentFrame" => {
+            // Mirror the getter: a behavior that declares its own `property
+            // frame`/`currentFrame` OWNS this assignment — store it there and
+            // do NOT touch the Flash playhead. Only sprites with no such
+            // behavior property route to Ruffle gotoAndStop (poster-frame Flash
+            // tiles like storyscramble's). This stops a behavior's animation
+            // counter being misrouted into the Flash bridge — bogey_nights sets
+            // `sprite(16).frame = VOID` every frame, which was calling
+            // gotoAndStop("VOID") (a nonexistent label) and blanking the SWF.
+            let declared = borrow_sprite_mut(
+                sprite_id,
+                |_| {},
+                |sprite, _| {
+                    sprite.script_instance_list.iter().find_map(|behavior| {
+                        reserve_player_mut(|player| {
+                            let value_ref = player.alloc_datum(value.clone());
+                            match script_set_prop(
+                                player,
+                                behavior,
+                                &prop_name.to_string(),
+                                &value_ref,
+                                true, // only if the behavior already declares it
+                            ) {
+                                Ok(_) => Some(()),
+                                Err(_) => None,
+                            }
+                        })
+                    })
+                },
+            );
+            if declared.is_some() {
+                return Ok(());
+            }
+            // No behavior owns `frame`: this is a Flash playhead navigation.
+            // Director ignores a VOID frame value (no valid target), so guard
+            // it — otherwise value.string_value() yields "VOID", which the
+            // bridge treats as a (nonexistent) label and blanks the sprite.
+            if matches!(value, Datum::Void) {
+                return Ok(());
+            }
             let frame_or_label = value.string_value()?;
             let has_member = reserve_player_ref(|player| {
                 player
@@ -4666,6 +4745,44 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                 Ok(())
             },
         ),
+        // `the type of sprite` setter. Director games activate a
+        // script-created sprite in an otherwise-empty channel by assigning
+        // e.g. `sprite(ch).type = #bitmap`. bogey_nights' Eustice `#sneeze`
+        // spawns its boogy/spit splashes exactly this way — `newchannel`
+        // finds a free channel, then `sprite(ch).type = #bitmap` before
+        // setting ink/member. dirplayer renders a channel only if it has a
+        // score span OR is a puppet (see get_sorted_channels), so without a
+        // `type` setter the spawned sprites got a member but never became
+        // renderable ("many on the score but not visible"). A non-empty type
+        // activates the channel via the puppet flag; #none/0/VOID clears it.
+        "type" => {
+            let activate = match &value {
+                Datum::Void => false,
+                Datum::Int(n) => *n != 0,
+                Datum::Symbol(s) => {
+                    !s.eq_ignore_ascii_case("none") && !s.eq_ignore_ascii_case("empty")
+                }
+                _ => true,
+            };
+            borrow_sprite_mut(
+                sprite_id,
+                |_| {},
+                |sprite, _| {
+                    if activate {
+                        // Activate the channel so a script-created sprite
+                        // renders even without a score span. The caller sets
+                        // .member/.ink/.loc separately (bogey_nights' Eustice).
+                        sprite.puppet = true;
+                    } else {
+                        // Per the Director 11.5 reference, `sprite(ch).type = 0`
+                        // CLEARS the channel — empty it and stop it rendering.
+                        sprite.member = None;
+                        sprite.puppet = false;
+                    }
+                    Ok(())
+                },
+            )
+        }
         "puppet" => borrow_sprite_mut(
             sprite_id,
             |_| {},
@@ -4759,13 +4876,16 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             || prop_name.eq_ignore_ascii_case("member")
             || prop_name.eq_ignore_ascii_case("memberNum")
             || prop_name.eq_ignore_ascii_case("castNum")
-            || prop_name.eq_ignore_ascii_case("puppet");
+            || prop_name.eq_ignore_ascii_case("puppet")
+            // `type` activates/clears a channel via the puppet flag, so it
+            // changes which channels render (bogey_nights' spawned splashes).
+            || prop_name.eq_ignore_ascii_case("type");
         if affects_render_order {
             reserve_player_mut(|player| {
                 player.movie.score.invalidate_render_channel_cache();
             });
         }
-        if prop_name.eq_ignore_ascii_case("puppet") {
+        if prop_name.eq_ignore_ascii_case("puppet") || prop_name.eq_ignore_ascii_case("type") {
             reserve_player_mut(|player| {
                 player.refresh_stage_behavior_channel_cache_entry(sprite_id);
             });

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -826,6 +826,15 @@ impl Score {
                 // natural size. Drives get_concrete_sprite_rect's sprite-vs-bitmap
                 // dimension choice and `the stretch of sprite`.
                 sprite.stretch = data.stretch as i32;
+                // Apply the score channel's flipH/flipV bits (sprite_flags bit 5
+                // / bit 6). Previously only Lingo `sprite.flipH =` set these, so
+                // score-authored flipped Flash/bitmap sprites rendered
+                // un-mirrored — bogey_nights' end-game grab hands (sprites 17/20,
+                // authored flipH/flipV in the score) reached from the wrong side.
+                // A behavior that sets flipH in exitFrame still wins (scripts run
+                // after the channel update), matching Director's puppet semantics.
+                sprite.flip_h = data.flip_h();
+                sprite.flip_v = data.flip_v();
 
                 // Check if member is a shape to determine ink/blend handling
                 // Use find_member_by_ref which handles relative cast references (65535)
@@ -3579,10 +3588,27 @@ pub fn sprite_get_prop(
             }
         }
         "frameCount" => {
-            if sprite.and_then(|s| s.member.as_ref()).is_some() {
-                Ok(Datum::Int(ruffle_get_frame_count(sprite_id as i32)))
-            } else {
-                Ok(Datum::Int(0))
+            // Prefer the SWF header's FrameCount (parsed from the member bytes)
+            // over asking Ruffle: the header is correct even while the instance
+            // is still (re)loading, whereas ruffle_get_frame_count returns 0 in
+            // that window. A 0 here poisons movies that seed state from
+            // frameCount (bogey_nights #hiding). Fall back to Ruffle for
+            // compressed CWS members the header parser doesn't handle.
+            let header_fc = sprite
+                .and_then(|s| s.member.as_ref())
+                .and_then(|m| player.movie.cast_manager.find_member_by_ref(m))
+                .and_then(|cm| match &cm.member_type {
+                    crate::player::cast_member::CastMemberType::Flash(f) => {
+                        crate::player::cast_member::CastMember::parse_swf_frame_count(&f.data)
+                    }
+                    _ => None,
+                });
+            match header_fc {
+                Some(n) => Ok(Datum::Int(n as i32)),
+                None if sprite.and_then(|s| s.member.as_ref()).is_some() => {
+                    Ok(Datum::Int(ruffle_get_frame_count(sprite_id as i32)))
+                }
+                None => Ok(Datum::Int(0)),
             }
         }
         "currentFrame" | "frame" => {
@@ -4144,6 +4170,15 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                     .is_some()
             });
             if has_member {
+                // Record the asserted numeric frame on the SPRITE so it survives
+                // a member swap and re-projects onto a freshly-created Ruffle
+                // instance (StoryScramble poster tiles / bogeyman pre-swap
+                // frame). Non-numeric (label) targets don't set it.
+                if let Ok(n) = frame_or_label.parse::<i32>() {
+                    reserve_player_mut(|player| {
+                        player.movie.score.get_sprite_mut(sprite_id).flash_asserted_frame = Some(n);
+                    });
+                }
                 ruffle_goto_frame_and_stop(sprite_id as i32, &frame_or_label);
             }
             Ok(())
@@ -5936,25 +5971,45 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
             let mut reg_x = flash_member.reg_point.0 as i32;
             let mut reg_y = flash_member.reg_point.1 as i32;
 
-            // If centerRegPoint, use center of the flash rect dimensions
-            if flash_member.flash_info.as_ref().map_or(true, |i| i.center_reg_point) {
-                if flash_width > 0 && flash_height > 0 {
-                    reg_x = flash_width / 2;
-                    reg_y = flash_height / 2;
-                }
+            // Director anchors a Flash sprite at the member's STORED regPoint
+            // even when centerRegPoint is set — it keeps that stored point synced
+            // to the member's center, and `member.regPoint` returns it verbatim
+            // (bogey_nights' arm: point(109, 63), NOT the geometric center
+            // (69, 43)). So only synthesize a center when there is no stored
+            // reg point; otherwise honor it, matching Director's placement.
+            if reg_x == 0 && reg_y == 0
+                && flash_member.flash_info.as_ref().map_or(true, |i| i.center_reg_point)
+                && flash_width > 0 && flash_height > 0
+            {
+                reg_x = flash_width / 2;
+                reg_y = flash_height / 2;
             }
 
             // Scale registration point proportionally when sprite is stretched
-            let scaled_reg_x = if flash_width > 0 {
+            let mut scaled_reg_x = if flash_width > 0 {
                 ((reg_x * sprite.width) as f32 / flash_width as f32).round() as i32
             } else {
                 reg_x
             };
-            let scaled_reg_y = if flash_height > 0 {
+            let mut scaled_reg_y = if flash_height > 0 {
                 ((reg_y * sprite.height) as f32 / flash_height as f32).round() as i32
             } else {
                 reg_y
             };
+
+            // When the sprite is flipped, Director mirrors the content around the
+            // registration point, moving the bounding box to the opposite side of
+            // loc. The renderers flip only the texture WITHIN the rect (webgl2 tex
+            // coords / CPU copy), so mirror the reg point here to place the rect on
+            // the correct side. Without this, bogey_nights' straw (always flipH)
+            // landed on the wrong side of the spit splash even though longarm
+            // (usually flipH:0) looked right.
+            if sprite.flip_h {
+                scaled_reg_x = sprite.width - scaled_reg_x;
+            }
+            if sprite.flip_v {
+                scaled_reg_y = sprite.height - scaled_reg_y;
+            }
 
             IntRect::from(
                 sprite.loc_h - scaled_reg_x,

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -65,6 +65,14 @@ extern "C" {
     /// looping animations under each label) use `dirplayer_ruffleGoToFrame`.
     #[wasm_bindgen(js_name = "dirplayer_ruffleGoToFrameAndStop")]
     fn ruffle_goto_frame_and_stop(sprite_num: i32, frame_or_label: &str);
+    /// Classify what's under a sprite-local point in the SWF, mirroring
+    /// Director's Flash `sprite.hitTest()`: 0 = #background, 1 = #normal,
+    /// 2 = #button, 3 = #editText. The fork injects a synthetic MouseMove at
+    /// the point (the offscreen player gets no real motion) then reads the
+    /// resolved cursor + a stage shape pick. Drives `mouseOverButton`
+    /// (== #button) — no dependency on continuous mouse routing.
+    #[wasm_bindgen(js_name = "dirplayer_ruffleHitTest")]
+    fn ruffle_hit_test(sprite_num: i32, x: f64, y: f64) -> i32;
 }
 
 #[derive(Clone, Debug)]
@@ -3514,7 +3522,31 @@ pub fn sprite_get_prop(
         "broadcastProps" => Ok(datum_bool(false)),
         "linked" => Ok(datum_bool(false)),
         "posterFrame" => Ok(Datum::Int(1)),
-        "mouseOverButton" => Ok(datum_bool(false)),
+        "mouseOverButton" => {
+            // Flash sprite property: TRUE when the mouse pointer is over a
+            // button within the SWF, FALSE when outside the sprite or over a
+            // non-button object (e.g. the background). Per the Director
+            // dictionary this is exactly `hitTest(mouseLoc) = #button`, so we
+            // reuse the Flash hit-test classifier (2 == #button). Splat's
+            // titleJump gates `on mouseDown ... go(6)` on
+            // `sprite(3).mouseOverButton = 1`; a constant FALSE left the Flash
+            // start button dead.
+            //
+            // The offscreen Ruffle player never sees real mouse motion (we only
+            // capture its frames and forward clicks), so the classifier itself
+            // injects a synthetic MouseMove at this point before reading the
+            // resolved cursor — no dependency on continuous mouse routing. We
+            // pass sprite-local pixels (mouseLoc minus the sprite's top-left).
+            if sprite.and_then(|s| s.member.as_ref()).is_some() {
+                let rect = get_sprite_rect_in_context(player, sprite_id);
+                let (mx, my) = player.mouse_loc;
+                let lx = (mx - rect.0 as i32) as f64;
+                let ly = (my - rect.1 as i32) as f64;
+                Ok(datum_bool(ruffle_hit_test(sprite_id as i32, lx, ly) == 2))
+            } else {
+                Ok(datum_bool(false))
+            }
+        }
         "viewScale" => Ok(Datum::Float(100.0)),
         "originMode" => Ok(Datum::Int(0)),
         "originH" | "originV" => Ok(Datum::Int(0)),

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -372,10 +372,11 @@ impl Score {
         }
 
         if !script_exists {
-            web_sys::console::warn_1(
-                &format!("Script not found: {:?} (original cast_lib: {}, default_cast_lib: {:?}), skipping behavior creation",
-                    script_ref, cast_lib, default_cast_lib).into(),
-            );
+            // debug!, not console::warn_1 — the latter always prints to the
+            // browser console (which retains every entry); a missing behavior
+            // script is handled gracefully by skipping creation.
+            debug!("Script not found: {:?} (original cast_lib: {}, default_cast_lib: {:?}), skipping behavior creation",
+                script_ref, cast_lib, default_cast_lib);
             return None;
         }
 

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -1121,17 +1121,21 @@ impl Score {
             }
         }
 
-        // D6+ per-frame MEMBER swap within a span. Some D6 movies "score-record"
-        // a sprite that changes its cast member every frame inside a single span
-        // — e.g. SpongeBob "JellyFishin'"'s instructions/controls text field
-        // (sprite 46) cycling members 36→37→38 across frames 36-39. The span
-        // system sets the member only at span entry, so without this the sprite
-        // is stuck on the first page. We update ONLY the member (not pos/size, to
-        // avoid disturbing tweens or Lingo-driven motion) when the current
-        // frame's delta names a different, non-empty member for an
-        // already-entered, non-puppet sprite. Runs after span entry so it also
-        // corrects the entry frame if the span picked a stale member.
-        if dir_version >= 600 {
+        // D6-ONLY per-frame MEMBER swap within a span. Some D6 movies
+        // "score-record" a sprite that changes its cast member every frame
+        // inside a single span — e.g. SpongeBob "JellyFishin'"'s instructions/
+        // controls text field (sprite 46) cycling members 36→37→38 across
+        // frames 36-39. In D6 the span system sets the member only at span
+        // entry, so without this the sprite is stuck on the first page. We
+        // update ONLY the member (not pos/size, to avoid disturbing tweens or
+        // Lingo-driven motion) when the current frame's delta names a
+        // different, non-empty member for an already-entered, non-puppet sprite.
+        //
+        // Restricted to D6 (==600): D7+ (e.g. dir_version 700, raw 1406) carry
+        // per-frame member changes inside the keyframe-bearing 52+ byte spans
+        // we now parse, so applying this delta-based swap there double-updates
+        // and fights the span data. Only D6 lacks those member keyframes.
+        if dir_version == 600 {
             let member_updates: Vec<(i16, CastMemberRef)> = self.channel_initialization_data
                 .iter()
                 .filter_map(|(frame_idx, channel_idx, data)| {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -5338,6 +5338,27 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
                 (m.max(sprite.height.max(1)), "adjust+measured")
             } else if field_member.word_wrap && is_adjust && field_member.text_height > 0 {
                 ((field_member.text_height as i32 + extras).max(sprite.height), "wrap+adjust+text_height")
+            } else if field_member.word_wrap
+                && measured_plus_extras.is_some()
+                && sprite.height > 0
+                && {
+                    // #scroll/#fixed/#limit fields normally clip to the authored
+                    // height (handled by the `sprite.height>0` arm below), but a
+                    // short dialogue that overflows by only a few lines would then
+                    // lose text. This happens in Summer Resort: "sign.text" is an
+                    // authored 16px (one-line) #scroll field, but its messages wrap
+                    // to two lines because we substitute a wider font for the
+                    // authored "Osaka" — the second line ("…resort!") was clipped.
+                    // Grow to the measured content height, but only when the
+                    // overflow is small so genuinely large scrolling documents
+                    // (help panels wrapping to thousands of px) still clip + scroll
+                    // as authored. MAX_GROW caps the *extra* height (~10 lines).
+                    const MAX_GROW: i32 = 160;
+                    let m = measured_plus_extras.unwrap();
+                    m > sprite.height && (m - sprite.height) <= MAX_GROW
+                }
+            {
+                (measured_plus_extras.unwrap(), "wrap+scroll+grow-dialogue")
             } else if sprite.height > 0 {
                 (sprite.height, "sprite.height>0")
             } else if field_member.text_height > 0 {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -518,10 +518,59 @@ impl Score {
                 }
 
                 Ok::<(), ScriptError>(())
-            })
-        } else {
-            Ok(())
+            })?;
         }
+
+        // Director instantiates a score BEHAVIOR as a child object and calls
+        // its `on new me` handler (if defined) at sprite-entry, BEFORE
+        // beginSprite (and after property defaults are seeded above, so the
+        // handler sees its authored/default props). Many older behaviors do
+        // ALL their setup in `on new` — pengapop's Sparkle01 parks its sprite
+        // offscreen (`the locV of sprite mysprite = -500`) there and defines
+        // no beginSprite; without this the sparkle sprite stays at its
+        // authored (visible) position and a stale `tiny_sparkle0001` frame
+        // lingers on screen at game start.
+        //
+        // ONLY for ScriptType::Score (score behaviors). Parent scripts
+        // (ScriptType::Parent) already had `on new` run when they were
+        // explicitly `new()`'d — a parent-script instance sitting in a
+        // sprite's script_instance_list (e.g. via scriptInstanceList.add or
+        // parent-script-as-field-member) must NOT be re-`new`'d here, or it
+        // gets double-initialized. Dispatched only to instances that actually
+        // define `on new`, so beginSprite-only behaviors no-op; it never falls
+        // through to movie-script `on new`.
+        let should_call_new = reserve_player_ref(|player| {
+            let Some(inst) = player.allocator.get_script_instance_opt(&script_instance_ref) else {
+                return false;
+            };
+            let Some(script) = player.movie.cast_manager.get_script_by_ref(&inst.script) else {
+                return false;
+            };
+            // Behaviors only (see above). Parent scripts already had `on new` run.
+            if script.script_type != crate::director::enums::ScriptType::Score {
+                return false;
+            }
+            // Only auto-call a NO-ARG `on new me`. A handler that declares extra
+            // parameters (`on new me, aSprite, ...`) is meant to be called
+            // explicitly with those args; auto-dispatching with none would run
+            // it with VOID arguments and misbehave. `argument_name_ids` includes
+            // the implicit `me`, so length <= 1 means "me only".
+            match script.get_own_handler("new") {
+                Some(h) => h.argument_name_ids.len() <= 1,
+                None => false,
+            }
+        });
+        if should_call_new {
+            let receivers = vec![script_instance_ref.clone()];
+            let _ = crate::player::events::player_invoke_event_to_instances(
+                &"new".to_string(),
+                &vec![],
+                &receivers,
+            )
+            .await;
+        }
+
+        Ok(())
     }
 
     pub fn begin_sprites(&mut self, score_ref: ScoreRef, frame_num: u32) {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -6063,6 +6063,23 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
             let flash_height = if b != t { (b - t) as i32 } else { sprite.height };
             let _ = (l, t);
 
+            // When the sprite hasn't been explicitly resized, a Flash member
+            // displays at its natural (SWF stage / member) dimensions — Director
+            // ignores the score channel's approximate box, exactly as it does for
+            // an un-stretched bitmap (see the Bitmap arm above). leo3d's "menue"
+            // (626x100, regPoint 313,50) landed in a 100x320 score box and
+            // rendered squashed until this used the member dims. A genuine resize
+            // (stretch flag / size tween) still honours the sprite dimensions.
+            let stretched = sprite.stretch != 0 || sprite.has_size_tweened;
+            let (render_width, render_height) =
+                if stretched && sprite.width > 0 && sprite.height > 0 {
+                    (sprite.width, sprite.height)
+                } else if flash_width > 0 && flash_height > 0 {
+                    (flash_width, flash_height)
+                } else {
+                    (sprite.width, sprite.height)
+                };
+
             let mut reg_x = flash_member.reg_point.0 as i32;
             let mut reg_y = flash_member.reg_point.1 as i32;
 
@@ -6080,14 +6097,15 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
                 reg_y = flash_height / 2;
             }
 
-            // Scale registration point proportionally when sprite is stretched
+            // Scale registration point proportionally to the rendered size (equals
+            // 1:1 at natural size, scaled up/down when the sprite was resized).
             let mut scaled_reg_x = if flash_width > 0 {
-                ((reg_x * sprite.width) as f32 / flash_width as f32).round() as i32
+                ((reg_x * render_width) as f32 / flash_width as f32).round() as i32
             } else {
                 reg_x
             };
             let mut scaled_reg_y = if flash_height > 0 {
-                ((reg_y * sprite.height) as f32 / flash_height as f32).round() as i32
+                ((reg_y * render_height) as f32 / flash_height as f32).round() as i32
             } else {
                 reg_y
             };
@@ -6100,17 +6118,17 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
             // landed on the wrong side of the spit splash even though longarm
             // (usually flipH:0) looked right.
             if sprite.flip_h {
-                scaled_reg_x = sprite.width - scaled_reg_x;
+                scaled_reg_x = render_width - scaled_reg_x;
             }
             if sprite.flip_v {
-                scaled_reg_y = sprite.height - scaled_reg_y;
+                scaled_reg_y = render_height - scaled_reg_y;
             }
 
             IntRect::from(
                 sprite.loc_h - scaled_reg_x,
                 sprite.loc_v - scaled_reg_y,
-                sprite.loc_h - scaled_reg_x + sprite.width,
-                sprite.loc_v - scaled_reg_y + sprite.height,
+                sprite.loc_h - scaled_reg_x + render_width,
+                sprite.loc_v - scaled_reg_y + render_height,
             )
         }
         CastMemberType::Shockwave3d(w3d) => {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -2030,7 +2030,15 @@ impl Score {
         // Discard the cached instance if the script member OR the span changed (or it
         // no longer applies). Without this, the previous span's instance lingers when
         // entering a new span, keeping stale properties/parameters.
-        let should_discard = reserve_player_ref(|player| {
+        //
+        // CRITICAL: only the MAIN movie (Stage) drives `player.movie.frame_script_instance`.
+        // Film loops / nested scores have their own frame numbering, and at a film-loop
+        // frame with no channel-0 script `new_script_member` is None — without this gate
+        // the film loop's begin_sprites discards the MAIN movie's channel-0 frame-script
+        // instance every tick, forcing it to be recreated each frame (the "Game Loop"
+        // frame script in Trick-or-Treat-Beat was recreated 329×, resetting its state).
+        let is_stage = matches!(score_ref, ScoreRef::Stage);
+        let should_discard = is_stage && reserve_player_ref(|player| {
             player.movie.frame_script_instance.is_some()
                 && (player.movie.frame_script_member != new_script_member
                     || player.movie.frame_script_span_start != new_span_start)
@@ -2043,7 +2051,9 @@ impl Score {
             });
         }
 
-        if let Some(behavior_ref) = self.get_script_in_frame(frame_num) {
+        if let Some(behavior_ref) = self.get_script_in_frame(frame_num)
+            .filter(|_| is_stage)
+        {
             // Only create when no instance is cached (covers initial entry and post-discard).
             let needs_creation = reserve_player_ref(|player| {
                 player.movie.frame_script_instance.is_none()

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -6036,6 +6036,43 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
                 reg_y,
             )
         }
+        CastMemberType::Movie(_) => {
+            // Linked movie (`#movie`): Director displays the sub-movie at its own
+            // native stage size, anchored at the sprite location — it does NOT
+            // scale the movie to fill the sprite rect. The DGS loader sizes the
+            // #movie sprite to the whole stage (1190x575) as a container; without
+            // this the 600x440 sub-stage bitmap stretched to fill it ≈ 2x zoom.
+            // Match the sub-player's actual rendered bitmap dims (rendered at
+            // `sub.movie.rect`) so compositing is 1:1. `sprite.stretch` still
+            // honors an explicit resize.
+            // Native stage dims: prefer the nested player's movie.rect; fall back
+            // to the composited bitmap dims (both equal the sub-stage size).
+            let native = unsafe {
+                sprite
+                    .member
+                    .as_ref()
+                    .and_then(|m| crate::player::nested_player_id(m))
+                    .and_then(|id| crate::player::NESTED_PLAYERS.get(id - 1))
+                    .and_then(|o| o.as_ref())
+                    .map(|sub| (sub.movie.rect.width(), sub.movie.rect.height()))
+            }
+            .or_else(|| {
+                sprite
+                    .member
+                    .as_ref()
+                    .and_then(|m| player.nested_movie_images.get(m).copied())
+                    .and_then(|img| player.bitmap_manager.get_bitmap(img))
+                    .map(|b| (b.width as i32, b.height as i32))
+            });
+            // A linked movie plays at its own stage size — it does NOT scale to
+            // fill the sprite rect (ignore the score's stretch flag/oversized box).
+            if let Some((w, h)) = native {
+                if w > 1 && h > 1 {
+                    return IntRect::from_size(sprite.loc_h, sprite.loc_v, w, h);
+                }
+            }
+            IntRect::from_size(sprite.loc_h, sprite.loc_v, sprite.width, sprite.height)
+        }
         _ => IntRect::from_size(sprite.loc_h, sprite.loc_v, sprite.width, sprite.height),
     }
 }

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -316,6 +316,19 @@ impl Score {
             .and_then(|span| span.scripts.first().cloned());
     }
 
+    /// Start frame of the channel-0 (frame-script) span covering `frame`.
+    /// Identifies the span so the cached frame-script instance can be recreated
+    /// when the playhead crosses into a different span (even of the same behavior
+    /// member, which may carry different parameters).
+    pub fn get_frame_script_span_start(&self, frame: u32) -> Option<u32> {
+        self.sprite_spans
+            .iter()
+            .find(|span| {
+                span.channel_number == 0 && frame >= span.start_frame && frame <= span.end_frame
+            })
+            .map(|span| span.start_frame)
+    }
+
     /// Create a behavior script instance.
     ///
     /// `default_cast_lib` is used to resolve cast_lib when it's 65535 or -1 (which means
@@ -2005,18 +2018,28 @@ impl Score {
             cast_lib: b.cast_lib as i32,
             cast_member: b.cast_member as i32,
         });
+        // Identity of the channel-0 span at this frame. The same behavior member can
+        // be dropped on several consecutive spans with different parameters (the Game
+        // Loop is `#Nonlooping` on the intro frames and `#CostumeChange`/`#Looping` on
+        // the gameplay frames). Tracking the span start lets us recreate + re-apply
+        // parameters when crossing a span boundary instead of carrying the previous
+        // span's stale `pType` (which made the gameplay `case pType of` fall through →
+        // no `go(the frame)` → the playhead marched through every frame to the end).
+        let new_span_start = self.get_frame_script_span_start(frame_num);
 
-        // Discard the cached instance if the script has changed or no longer applies.
-        // Without this, the previous-span's instance would linger when entering a new
-        // span, and `the frame` inside a different script's beginSprite would see stale state.
+        // Discard the cached instance if the script member OR the span changed (or it
+        // no longer applies). Without this, the previous span's instance lingers when
+        // entering a new span, keeping stale properties/parameters.
         let should_discard = reserve_player_ref(|player| {
             player.movie.frame_script_instance.is_some()
-                && player.movie.frame_script_member != new_script_member
+                && (player.movie.frame_script_member != new_script_member
+                    || player.movie.frame_script_span_start != new_span_start)
         });
         if should_discard {
             reserve_player_mut(|player| {
                 player.movie.frame_script_instance = None;
                 player.movie.frame_script_member = None;
+                player.movie.frame_script_span_start = None;
             });
         }
 
@@ -2118,10 +2141,12 @@ impl Score {
                     });
                 }
 
-                // Cache BOTH the instance and the member ref
+                // Cache the instance, member ref, AND the span it belongs to so we
+                // recreate (and re-apply params) when the playhead enters a new span.
                 reserve_player_mut(|player| {
                     player.movie.frame_script_instance = Some(actual_instance_ref);
                     player.movie.frame_script_member = Some(cast_member_ref);
+                    player.movie.frame_script_span_start = new_span_start;
                 });
 
                 debug!("✓ Frame script instance created and cached");

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -407,6 +407,43 @@ impl Score {
             player.alloc_datum(Datum::ScriptInstanceRef(script_instance_ref.clone()))
         });
 
+        // Snapshot the authored Score PARAMETER values BEFORE anything else runs.
+        // Behaviour parameters (e.g. RaycastCar's Chassis="chassis", set in the
+        // Score's parameter dialog) are applied to the instance during begin-sprite
+        // attachment, which happens BEFORE this init pass — so at this point the only
+        // non-void properties are those authored params (plus spriteNum). Director's
+        // order is `on new me` (code defaults) THEN the authored parameter overrides,
+        // but this function calls `on new` below (needed for behaviours like pengapop's
+        // Sparkle01 that do ALL setup there). A behaviour whose `on new` re-seeds its
+        // own defaults — RaycastCar sets pChassisName="None" etc. — would clobber the
+        // already-applied params back to those defaults, so `rigidBody("None")` then
+        // fails and the physics car never initialises. Capture the params here and
+        // re-apply them after `on new` so the Score values win, as Director does.
+        let param_snapshot: Vec<(String, Datum)> = reserve_player_ref(|player| {
+            let prop_refs: Vec<(String, DatumRef)> = match player
+                .allocator
+                .get_script_instance_opt(&script_instance_ref)
+            {
+                Some(inst) => inst
+                    .properties
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.clone()))
+                    .collect(),
+                None => Vec::new(),
+            };
+            prop_refs
+                .into_iter()
+                .filter_map(|(name, val_ref)| {
+                    let d = player.get_datum(&val_ref);
+                    if matches!(d, Datum::Void) {
+                        None
+                    } else {
+                        Some((name, d.clone()))
+                    }
+                })
+                .collect()
+        });
+
         // Try to call getPropertyDescriptionList
 
         let result = player_call_datum_handler(
@@ -569,6 +606,27 @@ impl Score {
                 &receivers,
             )
             .await;
+
+            // Re-apply the authored Score parameters captured before `on new`.
+            // Director applies behaviour parameters AFTER `on new me`, so the
+            // authored values must win over any code defaults the handler just
+            // re-seeded (RaycastCar's pChassisName="None" -> back to "chassis").
+            // gPDL-only props (not authored, not in the snapshot) keep whatever
+            // `on new` set, matching Director's gPDL-skips-non-void rule.
+            if !param_snapshot.is_empty() {
+                reserve_player_mut(|player| {
+                    for (name, datum) in &param_snapshot {
+                        let value_ref = player.alloc_datum(datum.clone());
+                        let _ = script_set_prop(
+                            player,
+                            &script_instance_ref,
+                            name,
+                            &value_ref,
+                            false,
+                        );
+                    }
+                });
+            }
         }
 
         Ok(())

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -216,30 +216,37 @@ pub fn get_channel_number_from_index(index: u32) -> u32 {
 }
 
 /// Convert raw blend byte from score data to a 0-100 percentage.
-/// D8+ uses inverted 0-255 scale: 0 → 100% (opaque), 255 → 0% (transparent
-/// / default not-set, treated as opaque).
-/// D5-D7 uses direct 0-100 percentage: 0 → 100% (opaque/not set).
 ///
-/// Director D8+ stores blend INVERTED in the score byte: raw=0 means fully
-/// opaque (100%), raw=255 means fully transparent (0%), intermediate values
-/// linearly interpolate. raw=0 is also the "no override" sentinel used when
-/// the author hasn't touched blend in the Score, which matches the desired
-/// 100% default — handled by the same linear formula.
+/// D6+ stores blend on an inverted 0-255 scale (raw 0 → 100%, 255 → 0%,
+/// 128 → ~50%), BUT the raw byte is only meaningful when the sprite's
+/// "blend enabled" flag is set — `sprite_flags` (score byte 22) bit 4
+/// (0x10). When the flag is clear the raw byte is an unused default (it
+/// can be 0 OR 255 depending on the sprite) and the sprite is fully opaque.
 ///
-/// Previously we also clamped raw=255 → 100 on the theory that some v850
-/// sprites authored with no explicit blend stored raw=255. That heuristic
-/// masked legitimate `blend=0` authoring: spineworld_dcr's pDropList
-/// sprite 799 is a fullscreen click-catching modal background authored at
-/// `blend=0` (verified in Director Property Inspector) so it stays
-/// invisible. Forcing raw=255 → 100 turned that sprite into a fullscreen
-/// black overlay. The override is removed; if a v850 movie surfaces
-/// unintended raw=255 invisibility, the right fix is to identify the
-/// missing "blend is set" flag in the score chunk, not to clamp the value.
-pub(crate) fn convert_raw_blend(raw: u8, dir_version: u16) -> i32 {
-    if dir_version > 600 {
-        ((255.0 - raw as f32) * 100.0 / 255.0).round() as i32
+/// This flag gate is what reconciles two same-version (D6) movies that the
+/// raw value alone cannot:
+///   - SpongeBob "JellyFishin'" sprite 40: flag SET, raw 127 → 50% overlay.
+///   - load_bug.dcr loader (sprite 2): flag CLEAR, raw 255 → 100% (NOT 0%).
+/// An earlier value-only approach (inverted for all D6+) correctly dimmed
+/// sprite 40 but wrongly made the loader transparent (raw 255 → 0%); the
+/// old direct-0-100 path did the reverse. Only the flag disambiguates.
+/// It also matches spineworld_dcr's pDropList sprite 799 (D8+), authored at
+/// `blend=0`: that has the flag SET, so raw 255 → 0% as intended.
+///
+/// `human_version` maps the late-Director-6 file version 1223 to exactly
+/// 600 (1224+ → 700), so the threshold is `>= 600` to include D6. D5 and
+/// earlier have no authored sprite blend and keep the direct path.
+pub(crate) fn convert_raw_blend(raw: u8, sprite_flags: u8, dir_version: u16) -> i32 {
+    if dir_version >= 600 {
+        // Blend only applies when the "blend enabled" flag (bit 4) is set;
+        // otherwise the raw byte is a junk default → fully opaque.
+        if sprite_flags & 0x10 != 0 {
+            ((255.0 - raw as f32) * 100.0 / 255.0).round() as i32
+        } else {
+            100
+        }
     } else {
-        // D5-D7: direct percentage, 0 = fully opaque (not set)
+        // D5 and earlier: direct percentage, 0 = fully opaque (not set)
         if raw == 0 { 100 } else { (raw as i32).min(100) }
     }
 }
@@ -725,6 +732,11 @@ impl Score {
                 sprite.rotation = data.rotation as f64;
                 sprite.moveable = data.moveable;
                 sprite.trails = data.trails;
+                // Score "stretch" flag (sprite ink byte bit 0x80): authoritative
+                // signal for whether the sprite was resized off its member's
+                // natural size. Drives get_concrete_sprite_rect's sprite-vs-bitmap
+                // dimension choice and `the stretch of sprite`.
+                sprite.stretch = data.stretch as i32;
 
                 // Check if member is a shape to determine ink/blend handling
                 // Use find_member_by_ref which handles relative cast references (65535)
@@ -737,13 +749,13 @@ impl Score {
 
                 if is_shape {
                     // Shape sprites use different ink/blend encoding
-                    sprite.blend = convert_raw_blend(data.blend, dir_version);
+                    sprite.blend = convert_raw_blend(data.blend, data.sprite_flags, dir_version);
                     // Shape ink encoding: mask off the high bit and divide by 5
                     sprite.ink = if dir_version > 700 { ((data.ink & 0x7F) / 5) as i32 } else { data.ink as i32 }
                 } else {
                     // Non-shape sprites: mask off the high bit (bit 7 is a flag, not part of ink number)
                     sprite.ink = (data.ink & 0x7F) as i32;
-                    sprite.blend = convert_raw_blend(data.blend, dir_version);
+                    sprite.blend = convert_raw_blend(data.blend, data.sprite_flags, dir_version);
                 }
 
                 // Get bitmap's palette for RGB<->index conversion
@@ -968,8 +980,13 @@ impl Score {
                 sprite.rotation = data.rotation as f64;
                 sprite.moveable = data.moveable;
                 sprite.trails = data.trails;
+                // Score "stretch" flag (sprite ink byte bit 0x80): authoritative
+                // signal for whether the sprite was resized off its member's
+                // natural size. Drives get_concrete_sprite_rect's sprite-vs-bitmap
+                // dimension choice and `the stretch of sprite`.
+                sprite.stretch = data.stretch as i32;
                 sprite.ink = (data.ink & 0x7F) as i32;
-                sprite.blend = convert_raw_blend(data.blend, dir_version);
+                sprite.blend = convert_raw_blend(data.blend, data.sprite_flags, dir_version);
 
                 // Attach a sprite-script behavior that appears mid-span. D5
                 // sprites can change member per frame and bring a scriptId with
@@ -1088,8 +1105,9 @@ impl Score {
                     sprite.rotation = data.rotation as f64;
                     sprite.moveable = data.moveable;
                     sprite.trails = data.trails;
+                    sprite.stretch = data.stretch as i32;
                     sprite.ink = (data.ink & 0x7F) as i32;
-                    sprite.blend = convert_raw_blend(data.blend, dir_version);
+                    sprite.blend = convert_raw_blend(data.blend, data.sprite_flags, dir_version);
                     // Set base_* values so tweens can work
                     sprite.base_loc_h = sprite.loc_h;
                     sprite.base_loc_v = sprite.loc_v;
@@ -1099,6 +1117,61 @@ impl Score {
                     sprite.base_blend = sprite.blend;
                     sprite.base_skew = sprite.skew;
                     sprite.entered = true;
+                }
+            }
+        }
+
+        // D6+ per-frame MEMBER swap within a span. Some D6 movies "score-record"
+        // a sprite that changes its cast member every frame inside a single span
+        // — e.g. SpongeBob "JellyFishin'"'s instructions/controls text field
+        // (sprite 46) cycling members 36→37→38 across frames 36-39. The span
+        // system sets the member only at span entry, so without this the sprite
+        // is stuck on the first page. We update ONLY the member (not pos/size, to
+        // avoid disturbing tweens or Lingo-driven motion) when the current
+        // frame's delta names a different, non-empty member for an
+        // already-entered, non-puppet sprite. Runs after span entry so it also
+        // corrects the entry frame if the span picked a stale member.
+        if dir_version >= 600 {
+            let member_updates: Vec<(i16, CastMemberRef)> = self.channel_initialization_data
+                .iter()
+                .filter_map(|(frame_idx, channel_idx, data)| {
+                    if frame_idx + 1 != frame_num || data.cast_member == 0 {
+                        return None;
+                    }
+                    let channel_number = get_channel_number_from_index(*channel_idx as u32);
+                    if channel_number < 1 {
+                        return None;
+                    }
+                    let sprite_num = channel_number as i16;
+                    let sprite = self.get_sprite(sprite_num)?;
+                    if !sprite.entered || sprite.puppet {
+                        return None;
+                    }
+                    let resolved_cast_lib = if data.cast_lib == 65535 && matches!(score_ref, ScoreRef::Stage) {
+                        1
+                    } else if data.cast_lib == 0 {
+                        1
+                    } else {
+                        data.cast_lib as i32
+                    };
+                    let member = CastMemberRef {
+                        cast_lib: resolved_cast_lib,
+                        cast_member: data.cast_member as i32,
+                    };
+                    if sprite.member.as_ref() == Some(&member) {
+                        return None; // already on the right member
+                    }
+                    Some((sprite_num, member))
+                })
+                .collect();
+            for (sprite_num, member) in member_updates {
+                match &score_ref {
+                    ScoreRef::Stage => {
+                        let _ = sprite_set_prop(sprite_num, "member", Datum::CastMember(member));
+                    }
+                    ScoreRef::FilmLoop(_) => {
+                        self.get_sprite_mut(sprite_num).member = Some(member);
+                    }
                 }
             }
         }
@@ -2164,6 +2237,7 @@ impl Score {
             sprite.rotation = data.rotation as f64;
             sprite.moveable = data.moveable;
             sprite.trails = data.trails;
+            sprite.stretch = data.stretch as i32;
 
             // Check if member is a shape to determine ink/blend handling
             // Use find_member_by_ref which handles relative cast references (65535)
@@ -2176,13 +2250,13 @@ impl Score {
 
             if is_shape {
                 // Shape sprites use different ink/blend encoding
-                sprite.blend = convert_raw_blend(data.blend, dir_version);
+                sprite.blend = convert_raw_blend(data.blend, data.sprite_flags, dir_version);
                 // Shape ink encoding: mask off the high bit and divide by 5
                 sprite.ink = ((data.ink & 0x7F) / 5) as i32;
             } else {
                 // Non-shape sprites use standard encoding
                 sprite.ink = data.ink as i32;
-                sprite.blend = convert_raw_blend(data.blend, dir_version);
+                sprite.blend = convert_raw_blend(data.blend, data.sprite_flags, dir_version);
             }
 
             // Get bitmap's palette for RGB<->index conversion
@@ -3911,10 +3985,10 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             |sprite, value| {
                 sprite.width = value?;
                 sprite.has_size_changed = true;
-                // Explicit Lingo size is authoritative — bypass the bbox
-                // heuristic and the bitmap-owned-size override.
-                sprite.explicit_lingo_size = true;
-                sprite.bitmap_size_owned_by_sprite = false;
+                // Director sets `the stretch of sprite` TRUE on any manual
+                // resize; this makes get_concrete_sprite_rect honor the new
+                // size verbatim instead of snapping back to the bitmap's.
+                sprite.stretch = 1;
                 Ok(())
             },
         ),
@@ -3924,8 +3998,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             |sprite, value| {
                 sprite.height = value?;
                 sprite.has_size_changed = true;
-                sprite.explicit_lingo_size = true;
-                sprite.bitmap_size_owned_by_sprite = false;
+                sprite.stretch = 1;
                 Ok(())
             },
         ),
@@ -3966,6 +4039,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                 let new_right = new_right?;
                 sprite.width = new_right - left;
                 sprite.has_size_changed = true;
+                sprite.stretch = 1;
                 Ok(())
             },
         ),
@@ -3980,6 +4054,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                 let new_bottom = new_bottom?;
                 sprite.height = new_bottom - top;
                 sprite.has_size_changed = true;
+                sprite.stretch = 1;
                 Ok(())
             },
         ),
@@ -4349,6 +4424,11 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             probe.width = new_width;
             probe.height = new_height;
             probe.has_size_changed = true;
+            // Setting `the rect of sprite` is a resize: mark it stretched so
+            // get_concrete_sprite_rect uses these dims verbatim (STRETCH path)
+            // instead of snapping to the bitmap's natural size. Must match the
+            // real sprite below or the reg-offset round-trip breaks.
+            probe.stretch = 1;
             let probe_rect = get_concrete_sprite_rect(player, &probe);
             // probe_rect.left = -effective_reg_x with loc=0, so to make the
             // real getter return `left`, write loc_h = left - probe_rect.left.
@@ -4361,6 +4441,7 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
             s.width = new_width;
             s.height = new_height;
             s.has_size_changed = true;
+            s.stretch = 1;
             Ok(())
         }),
         "scriptInstanceList" => {
@@ -4910,229 +4991,35 @@ pub fn get_concrete_sprite_rect(player: &DirPlayer, sprite: &Sprite) -> IntRect 
                     (bitmap_member.info.width as i32, bitmap_member.info.height as i32)
                 };
 
-            // Determine the actual dimensions to use for the sprite rectangle.
+            // Choose sprite vs bitmap dimensions from the Score's authoritative
+            // "stretch" flag (sprite ink byte bit 0x80, plumbed to
+            // sprite.stretch). This replaces the old size heuristic that tried
+            // to GUESS whether the score's width/height were an intentional
+            // resize or just an approximate bounding box.
             //
-            // Priority:
-            //  1. has_size_tweened  → tween is authoritative, use sprite dims
-            //  2. bitmap_size_owned_by_sprite → bitmap member changed, sprite dims
-            //     are stale from the previous member, use bitmap dims
-            //  3. has_size_changed  → Score or Lingo explicitly set dimensions,
-            //     trust them (the old simple behaviour that covers the majority)
-            //  4. Neither flag set  → dimensions are inherited/default and may be
-            //     an approximate bounding box. Apply heuristics to decide.
-
-            let (sprite_width, sprite_height, _size_path) = if sprite.explicit_lingo_size
-                && sprite.width > 0 && sprite.height > 0 {
-                // A Lingo script explicitly set `the width/height of sprite`.
-                // This is authoritative: use it verbatim and skip every
-                // bbox/sentinel heuristic below (those exist to disambiguate
-                // SCORE-authored sizes, which can be approximate). hackey's
-                // pseudo-3D `Translate` scales sprites by distance with
-                // integer-rounded proportional dims — the rounding made them
-                // look non-proportional, so the bbox catch-all wrongly snapped
-                // them back to the bitmap's native size and nothing shrank.
-                (sprite.width, sprite.height, "LINGO_EXPLICIT")
-            } else if sprite.width <= 2
-                && sprite.height <= 2 && bitmap_width >= 4 && bitmap_height >= 4 {
-                // Degenerate "use natural size" sentinel: a 1x1 / 2x2 score box
-                // on a real bitmap is never an intentional display size.
-                // Handled before the aspect-based bbox tests, which miss it for
-                // SQUARE bitmaps (a 1x1 box is "proportional" to any square, so
-                // it slips past the non-proportional check and renders 1px
-                // tiny). netjack icons #38/#66/#100/#109 hit this.
-                (bitmap_width, bitmap_height, "NATURAL_SENTINEL")
-            } else if sprite.has_size_tweened {
-                (sprite.width, sprite.height, "TWEENED")
-            } else if sprite.bitmap_size_owned_by_sprite
-                && bitmap_width >= 10 && bitmap_height >= 10 {
-                (bitmap_width, bitmap_height, "BITMAP_OWNED")
-            } else if sprite.has_size_changed {
-                // Score or Lingo explicitly set dimensions — but Score can still
-                // store approximate bounding box values. Detect bbox: sprite dims
-                // differ from bitmap AND are not an exact proportional scale.
-                // An exact proportional scale (e.g. 2× in both axes) is intentional;
-                // any non-proportional difference means the Score approximated.
-
-                // Special case: one dim ≈matches AND the other is significantly
-                // larger in the sprite. This is a thin/narrow bitmap whose sprite
-                // box approximates a larger area — render at native bitmap size
-                // rather than stretching. Handled before the >=10 guard so thin
-                // bitmaps (e.g. 7x182 vertical separators) get bitmap dims.
-                // Guard: the NON-matching bitmap dim must be >= 3px, else it's a
-                // stretchable pattern (e.g. 1px line) and sprite dims should win.
-                let expand_w = bitmap_height >= 3 && (sprite.width - bitmap_width).abs() <= 3
-                    && 10 * sprite.height > 11 * bitmap_height;
-                let expand_h = bitmap_width >= 3 && (sprite.height - bitmap_height).abs() <= 3
-                    && 10 * sprite.width > 11 * bitmap_width;
-
-                // Special case: one dim ≈matches with sprite STRICTLY LARGER
-                // (extends beyond bitmap) AND the other dim is shrunk in sprite.
-                // The bitmap fits inside the sprite bbox — render at native size.
-                // Note: must be STRICTLY greater — when dims match exactly, it's
-                // the existing crop pattern (handled below by crop_w/crop_h).
-                // Tight 1px threshold — being noticeably larger means a real
-                // size difference, not a small bbox approximation.
-                let extend_h_shrink_w = (sprite.height - bitmap_height).abs() <= 1
-                    && sprite.height > bitmap_height && sprite.width < bitmap_width;
-                let extend_w_shrink_h = (sprite.width - bitmap_width).abs() <= 1
-                    && sprite.width > bitmap_width && sprite.height < bitmap_height;
-
-                // True crop pattern: one dim ≈matches AND other shrunk (<90%) AND
-                // sprite mostly fits inside bitmap. Allow up to 3px overshoot in
-                // either dim. The extend rule above (1px tight) takes priority for
-                // "barely extends" cases. wide_h_shrink/tall_w_shrink below fire
-                // BEFORE crop, so moderate shrinks on wide/tall bitmaps go to bbox.
-                let inside_loose = sprite.width <= bitmap_width + 3
-                    && sprite.height <= bitmap_height + 3;
-                let crop_w = inside_loose && (sprite.width - bitmap_width).abs() <= 3
-                    && 10 * sprite.height < 9 * bitmap_height;
-                let crop_h = inside_loose && (sprite.height - bitmap_height).abs() <= 3
-                    && 10 * sprite.width < 9 * bitmap_width;
-
-                // WIDE bitmap (bw>bh) with width matching and height moderately
-                // shrunk (≥50% of bitmap) → BBOX. The sprite is approximating a
-                // smaller bbox of a wide image. Distinguished from tall-bitmap
-                // top-crop pattern by requiring bitmap_width > bitmap_height.
-                let wide_h_shrink = bitmap_width > bitmap_height
-                    && (sprite.width - bitmap_width).abs() <= 3
-                    && sprite.height < bitmap_height
-                    && 2 * sprite.height >= bitmap_height;
-                let tall_w_shrink = bitmap_height > bitmap_width
-                    && (sprite.height - bitmap_height).abs() <= 3
-                    && sprite.width < bitmap_width
-                    && 2 * sprite.width >= bitmap_width;
-                // WIDE bitmap (bw>bh) with HEIGHT matching and WIDTH moderately
-                // shrunk (≥2/3 of bitmap) → BBOX. Stricter threshold than
-                // wide_h_shrink because a horizontal crop of a horizontal bar
-                // is a plausible "real crop"; only treat as bbox when the
-                // sprite is ≥66.7% wide. This separates #80 (134x9 in a 189x9
-                // bitmap, 71%, bbox) from true crops like #779/#782/#772
-                // (sprite ~57% of bitmap width, SPRITE).
-                let wide_w_shrink = bitmap_width > bitmap_height
-                    && (sprite.height - bitmap_height).abs() <= 3
-                    && sprite.width < bitmap_width
-                    && 3 * sprite.width >= 2 * bitmap_width;
-
-                // Bypass the >=10 size guard when sprite is much larger than bitmap
-                // in BOTH dims (small bitmap drawn at native size inside larger bbox).
-                // Guard: bitmap must have real dims (>=2 each) — 1x1 bitmaps are
-                // always stretchable patterns/click targets, not visual elements.
-                // Also require max(bw,bh) >= 8 — very small bitmaps (4x4, 3x3)
-                // are solid color fills / patterns meant to be stretched.
-                let sprite_much_larger = sprite.width > 2 * bitmap_width
-                    && sprite.height > 2 * bitmap_height
-                    && bitmap_width >= 2 && bitmap_height >= 2
-                    && bitmap_width.max(bitmap_height) >= 8;
-                let size_ok = (bitmap_width >= 10 && bitmap_height >= 10) || sprite_much_larger;
-
-                // Strong non-proportional downscale → intentional scaling, not
-                // a bbox approximation. Both sprite dims are <=60% of the
-                // bitmap AND the aspect is clearly skewed (>~15% off
-                // proportional). A bbox approximation stays close to the image
-                // size or is roughly proportional, so it never lands here —
-                // e.g. #5 (24x11 of 42x20) is near-proportional and stays
-                // BBOX. Catches a 373x92 logo squished into a 105x20 score box
-                // (netjack sprite 20, which otherwise rendered at native size
-                // off the top of the stage). Mutually exclusive with the
-                // expand/wide/crop rules above (all require one dim within 3px
-                // of the bitmap), so it is safe to test first.
-                // Guard: the sprite box must be a plausible display size
-                // (>=8px each). Tiny boxes (1x1, 2x2) are "use natural size"
-                // sentinels/defaults — Director stores them when a sprite was
-                // placed without an explicit resize — not an intentional
-                // scale. Those stay BBOX so card/coin bitmaps (netjack #66,
-                // #100, #109) render at native size instead of 1px tiny.
-                let strong_downscale_sprite = sprite.width >= 8
-                    && sprite.height >= 8
-                    && sprite.width < bitmap_width
-                    && sprite.height < bitmap_height
-                    && 5 * sprite.width <= 3 * bitmap_width
-                    && 5 * sprite.height <= 3 * bitmap_height
-                    && {
-                        let a = sprite.width as i64 * bitmap_height as i64;
-                        let b = sprite.height as i64 * bitmap_width as i64;
-                        20 * a.min(b) < 17 * a.max(b)
-                    };
-
-                let is_bbox = if strong_downscale_sprite {
-                    false
-                } else if expand_w || expand_h
-                    || extend_h_shrink_w || extend_w_shrink_h
-                    || wide_h_shrink || tall_w_shrink || wide_w_shrink {
-                    true
-                } else if size_ok
-                    && sprite.width > 0 && sprite.height > 0
-                    && (sprite.width != bitmap_width || sprite.height != bitmap_height)
-                    && !crop_w
-                    && !crop_h
-                    // Skip bbox detection when BOTH dims are scaled up beyond 190%,
-                    // the scale factors are within 2.5× of each other, AND the
-                    // bitmap itself is roughly square (aspect ≤ 2:1). A non-square
-                    // bitmap scaled to a different aspect is still a bbox.
-                    && !(10 * sprite.width >= 19 * bitmap_width
-                         && 10 * sprite.height >= 19 * bitmap_height
-                         && {
-                             let a = sprite.width as i64 * bitmap_height as i64;
-                             let b = sprite.height as i64 * bitmap_width as i64;
-                             5 * a.min(b) >= 2 * a.max(b)
-                         }
-                         && 9 * bitmap_width <= 10 * bitmap_height
-                         && 9 * bitmap_height <= 10 * bitmap_width
-                         && bitmap_width >= 50 && bitmap_height >= 50)
-                {
-                    sprite.width as i64 * bitmap_height as i64 != sprite.height as i64 * bitmap_width as i64
-                } else {
-                    false
-                };
-                if is_bbox {
-                    (bitmap_width, bitmap_height, "EXPLICIT_BBOX")
+            // - stretched → the sprite was resized off the member's natural
+            //   size (manual handle drag, Lingo `the width/height of sprite`,
+            //   or a size tween) → use the sprite (score) dimensions verbatim.
+            // - not stretched → the bitmap displays at its natural size; the
+            //   score's width/height are an approximate bounding box and are
+            //   ignored → use the bitmap's real pixel dimensions.
+            //
+            // Verified against Director: a 4x4 fill stretched to 352x282
+            // (nomiss) and a 5x5 fill to 338x253 (SpongeBob) both carry
+            // stretch=1; natural-size sprites whose score box drifts a few px
+            // from the bitmap (PinBall, Junkbot) carry stretch=0.
+            let stretched = sprite.stretch != 0 || sprite.has_size_tweened;
+            let (sprite_width, sprite_height, _size_path) =
+                if stretched && sprite.width > 0 && sprite.height > 0 {
+                    (sprite.width, sprite.height, "STRETCH")
+                } else if bitmap_width > 0 && bitmap_height > 0 {
+                    (bitmap_width, bitmap_height, "NATURAL")
                 } else if sprite.width > 0 && sprite.height > 0 {
-                    (sprite.width, sprite.height, "EXPLICIT_SPRITE")
+                    // Bitmap not loaded yet — fall back to the score box.
+                    (sprite.width, sprite.height, "NATURAL_FALLBACK")
                 } else {
-                    (bitmap_width, bitmap_height, "EXPLICIT_FALLBACK")
-                }
-            } else {
-                // No explicit size set — apply heuristics.
-                let aspect_ratio_matches = if bitmap_width > 0 && bitmap_height > 0
-                    && sprite.width > 0 && sprite.height > 0
-                {
-                    let scale_x = sprite.width as f32 / bitmap_width as f32;
-                    let scale_y = sprite.height as f32 / bitmap_height as f32;
-                    let ratio = if scale_x > scale_y { scale_x / scale_y } else { scale_y / scale_x };
-                    ratio <= 1.1
-                } else {
-                    true
+                    (bitmap_width, bitmap_height, "ZERO")
                 };
-
-                let intentionally_stretched = sprite.width > 0 && sprite.height > 0
-                    && bitmap_width > 0 && bitmap_height > 0
-                    && sprite.width > bitmap_width * 3 / 2
-                    && sprite.height > bitmap_height * 3 / 2
-                    && {
-                        let a = sprite.width as i64 * bitmap_height as i64;
-                        let b = sprite.height as i64 * bitmap_width as i64;
-                        2 * a < 5 * b && 2 * b < 5 * a
-                    };
-
-                if !aspect_ratio_matches && bitmap_width >= 10 && bitmap_height >= 10 {
-                    if intentionally_stretched {
-                        (sprite.width, sprite.height, "H_STRETCHED")
-                    } else {
-                        (bitmap_width, bitmap_height, "H_ASPECT_MISMATCH")
-                    }
-                } else if (bitmap_width + bitmap_height) > (sprite.width + sprite.height)
-                    && bitmap_width >= 10 && bitmap_height >= 10 {
-                    (bitmap_width, bitmap_height, "H_BITMAP_LARGER")
-                } else if (sprite.width != bitmap_width || sprite.height != bitmap_height)
-                    && (sprite.width as i64 * bitmap_height as i64 != sprite.height as i64 * bitmap_width as i64)
-                    && bitmap_width >= 10 && bitmap_height >= 10 {
-                    (bitmap_width, bitmap_height, "H_NON_PROPORTIONAL")
-                } else if sprite.width > 0 && sprite.height > 0 {
-                    (sprite.width, sprite.height, "H_DEFAULT_SPRITE")
-                } else {
-                    (bitmap_width, bitmap_height, "H_DEFAULT_BITMAP")
-                }
-            };
             debug!("[BITMAP_RECT] sprite#{} path={} result={}x{} loc=({},{}) reg=({},{}) sprite={}x{} bitmap={}x{} flags(tweened={} owned={} changed={})",
                 sprite.number, _size_path, sprite_width, sprite_height,
                 sprite.loc_h, sprite.loc_v,

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -574,6 +574,34 @@ impl Score {
         Ok(())
     }
 
+    /// Deferred revert for sprites unpuppeted via `puppetSprite(N, FALSE)` that
+    /// were NOT re-puppeted (or given a new member) before the next frame tick.
+    /// Director defers reverting an unpuppeted sprite to the Score until the next
+    /// frame update; a PURE-PUPPET channel (no Score span this frame — Coke
+    /// Studios' furniture pool) reverts to empty via reset(). Span-backed
+    /// channels are left alone (begin_sprites reloads them). Returns true if any
+    /// sprite was reset so the caller can invalidate the render cache. Runs every
+    /// frame (not just on frame change) so single-frame movies revert too.
+    pub fn process_pending_unpuppet_reverts(&mut self, frame_num: u32) -> bool {
+        let span_channels: std::collections::HashSet<usize> = self
+            .active_channel_numbers_for_frame(frame_num)
+            .into_iter()
+            .collect();
+        let mut any = false;
+        for channel in &mut self.channels {
+            let sprite = &mut channel.sprite;
+            if !sprite.pending_unpuppet_revert {
+                continue;
+            }
+            sprite.pending_unpuppet_revert = false;
+            if !sprite.puppet && !span_channels.contains(&channel.number) {
+                sprite.reset();
+                any = true;
+            }
+        }
+        any
+    }
+
     pub fn begin_sprites(&mut self, score_ref: ScoreRef, frame_num: u32) {
         // Clean up sound channel triggers - but only once per frame to prevent double-triggering
         // Check if we already processed this frame
@@ -4448,6 +4476,11 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                 // Assign the new member
                 sprite.member = mem_ref.clone();
 
+                // The sprite is being given a member (e.g. reused from a pool),
+                // so cancel any pending deferred unpuppet-revert — it must not be
+                // reset out from under a fresh assignment on the next tick.
+                sprite.pending_unpuppet_revert = false;
+
                 // Initialize size and reset rotation/skew ONLY if:
                 //  - member actually changed
                 if member_changed {
@@ -4815,6 +4848,9 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: &str, value: Datum) -> Result<
                         sprite.member = None;
                         sprite.puppet = false;
                     }
+                    // Either way the sprite was explicitly set here, so cancel a
+                    // pending deferred unpuppet-revert.
+                    sprite.pending_unpuppet_revert = false;
                     Ok(())
                 },
             )

--- a/vm-rust/src/player/script_ref.rs
+++ b/vm-rust/src/player/script_ref.rs
@@ -1,4 +1,4 @@
-use super::{allocator::{ScriptInstanceAllocatorTrait, ALLOCATOR_RESETTING}, script::ScriptInstanceId, PLAYER_OPT};
+use super::{allocator::{ScriptInstanceAllocatorTrait, ALLOCATOR_RESETTING}, script::ScriptInstanceId, ACTIVE_PLAYER_ID, NESTED_PLAYERS, PLAYER_OPT};
 
 #[derive(Debug)]
 pub struct ScriptInstanceRef(ScriptInstanceId, *mut u32);
@@ -45,7 +45,16 @@ impl Drop for ScriptInstanceRef {
             let rc = &mut *self.1;
             *rc -= 1;
             if *rc == 0 {
-                if let Some(player) = PLAYER_OPT.as_mut() {
+                // Route to the ACTIVE player's allocator (a nested sub-player owns
+                // its own script instances) — see the DatumRef::drop note.
+                let player_opt = if ACTIVE_PLAYER_ID == 0 {
+                    PLAYER_OPT.as_mut()
+                } else {
+                    NESTED_PLAYERS
+                        .get_mut(ACTIVE_PLAYER_ID - 1)
+                        .and_then(|o| o.as_mut())
+                };
+                if let Some(player) = player_opt {
                     player.allocator.on_script_instance_ref_dropped(self.0);
                 }
             }

--- a/vm-rust/src/player/sprite.rs
+++ b/vm-rust/src/player/sprite.rs
@@ -94,6 +94,14 @@ pub struct Sprite {
     pub trails: bool,
     pub entered: bool,
     pub exited: bool,
+    /// Set by `puppetSprite(N, FALSE)`: the sprite keeps its member/visual state
+    /// for the rest of the CURRENT handler (Director defers the revert), but if
+    /// it is still unpuppeted at the next frame tick it reverts to the Score.
+    /// For a pure-puppet channel (no Score span — Coke Studios' furniture pool)
+    /// that revert is a reset to empty. Cleared the moment the sprite is
+    /// re-puppeted or given a new member (BrickOut re-puppets in the same
+    /// handler, so it never reverts and keeps its makeStage member).
+    pub pending_unpuppet_revert: bool,
     pub quad: Option<[(i32, i32); 4]>, // [topLeft, topRight, bottomRight, bottomLeft] -- TODO: Tie this to position and size
     pub fore_color: i32,
     pub has_fore_color: bool,
@@ -211,6 +219,7 @@ impl Sprite {
             trails: false,
             entered: false,
             exited: false,
+            pending_unpuppet_revert: false,
             quad: None,
             fore_color: 255,
             has_fore_color: false,
@@ -287,6 +296,7 @@ impl Sprite {
         self.constraint = 0;
         self.entered = false;
         self.exited = false;
+        self.pending_unpuppet_revert = false;
         self.quad = None;
         self.fore_color = 255;
         self.has_fore_color = false;

--- a/vm-rust/src/player/sprite.rs
+++ b/vm-rust/src/player/sprite.rs
@@ -131,6 +131,16 @@ pub struct Sprite {
     /// real viewport size. Set only on span exit (begin_sprites); reset() clears
     /// it, so a genuinely cleared channel still reports a zero rect.
     pub retained_rect: Option<(i32, i32, i32, i32)>,
+    /// Last frame Lingo asserted on this Flash sprite via `sprite.frame = N`
+    /// (numeric). Sprite-owned so it SURVIVES a member swap (Director contract:
+    /// the sprite `frame` property persists across `sprite.member =`) and is
+    /// re-projected onto a freshly (re)created Ruffle instance at load time —
+    /// which is how shared-member sprites show DIFFERENT frames (StoryScramble's
+    /// 3 story tiles show unique posters even though they share cast 2:1) and how
+    /// the bogeyman's `frame = 1` before a straw/longarm swap carries over.
+    /// `None` = Lingo never set a numeric frame (free-run / pausedAtStart).
+    /// Cleared by `reset()` (channel clear / endSprite / member=0).
+    pub flash_asserted_frame: Option<i32>,
 }
 
 /// Threshold for detecting skew flip (in degrees)
@@ -218,6 +228,7 @@ impl Sprite {
             w3d_camera: None,
             w3d_cameras: Vec::new(),
             retained_rect: None,
+            flash_asserted_frame: None,
         }
     }
 
@@ -280,5 +291,6 @@ impl Sprite {
         self.bitmap_size_owned_by_sprite = false;
         self.explicit_lingo_size = false;
         self.retained_rect = None;
+        self.flash_asserted_frame = None;
     }
 }

--- a/vm-rust/src/player/sprite.rs
+++ b/vm-rust/src/player/sprite.rs
@@ -124,6 +124,13 @@ pub struct Sprite {
     pub w3d_camera: Option<String>,
     /// Additional cameras for multi-camera rendering (index 2+)
     pub w3d_cameras: Vec<String>,
+    /// Last on-screen rect captured when this sprite left its span. Director
+    /// keeps a score channel's `the rect of sprite` at its last value even
+    /// after the member clears to 0 (empty channel between two spans), so init
+    /// scripts that read `sprite(1).rect` on a transition frame still see the
+    /// real viewport size. Set only on span exit (begin_sprites); reset() clears
+    /// it, so a genuinely cleared channel still reports a zero rect.
+    pub retained_rect: Option<(i32, i32, i32, i32)>,
 }
 
 /// Threshold for detecting skew flip (in degrees)
@@ -210,6 +217,7 @@ impl Sprite {
             base_bg_color: ColorRef::PaletteIndex(0),
             w3d_camera: None,
             w3d_cameras: Vec::new(),
+            retained_rect: None,
         }
     }
 
@@ -271,5 +279,6 @@ impl Sprite {
         self.has_size_changed = false;
         self.bitmap_size_owned_by_sprite = false;
         self.explicit_lingo_size = false;
+        self.retained_rect = None;
     }
 }

--- a/vm-rust/src/player/sprite.rs
+++ b/vm-rust/src/player/sprite.rs
@@ -141,6 +141,11 @@ pub struct Sprite {
     /// `None` = Lingo never set a numeric frame (free-run / pausedAtStart).
     /// Cleared by `reset()` (channel clear / endSprite / member=0).
     pub flash_asserted_frame: Option<i32>,
+    /// Last sampled Flash root frame, used to detect a wrap (end-of-timeline)
+    /// so a `loop = false` Flash member is halted at its final frame instead of
+    /// looping forever (Director plays it once; `the playing of sprite`
+    /// becomes FALSE). 0 = not yet sampled.
+    pub flash_prev_frame: i32,
 }
 
 /// Threshold for detecting skew flip (in degrees)
@@ -229,6 +234,7 @@ impl Sprite {
             w3d_cameras: Vec::new(),
             retained_rect: None,
             flash_asserted_frame: None,
+            flash_prev_frame: 0,
         }
     }
 
@@ -292,5 +298,6 @@ impl Sprite {
         self.explicit_lingo_size = false;
         self.retained_rect = None;
         self.flash_asserted_frame = None;
+        self.flash_prev_frame = 0;
     }
 }

--- a/vm-rust/src/player/stage.rs
+++ b/vm-rust/src/player/stage.rs
@@ -149,6 +149,14 @@ pub fn stage_scale(player: &DirPlayer) -> (f64, f64) {
 /// scaled per-rect via `get_concrete_sprite_render_rect` rather than via a
 /// global projection transform — keeps text/bitmaps sharp at the target size.
 pub fn apply_stage_draw_rect(player: &DirPlayer) {
+    // The WebGL2 renderer is shared and belongs to the HOST stage. A nested
+    // `#movie` sub-player is headless (rendered via render_stage_to_bitmap into
+    // a bitmap), so it must never resize the shared renderer — doing so
+    // reprojected the host's content to the sub's dimensions, zooming the whole
+    // stage. Only the host (active id 0) owns the on-screen renderer.
+    if unsafe { crate::player::ACTIVE_PLAYER_ID } != 0 {
+        return;
+    }
     let (draw_w, draw_h) = stage_canvas_dims(player);
     // 1x1 only occurs before any movie has loaded (movie.rect is 0x0, clamped).
     // Skip resizing to avoid triggering external canvas-size observers (e.g.

--- a/vm-rust/src/player/testing.rs
+++ b/vm-rust/src/player/testing.rs
@@ -44,7 +44,7 @@ impl TestPlayer {
             PLAYER_OPT = Some(DirPlayer::new(tx.clone()));
         }
 
-        async_std::task::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             run_event_loop(event_rx).await;
         });
 
@@ -88,7 +88,7 @@ impl TestHarness for TestPlayer {
         });
 
         unsafe {
-            let player = PLAYER_OPT.as_mut().unwrap();
+            let player = crate::player::player_mut();
             player.load_movie_from_dir(dir_file).await;
         }
     }

--- a/vm-rust/src/player/testing_browser.rs
+++ b/vm-rust/src/player/testing_browser.rs
@@ -134,10 +134,10 @@ impl BrowserTestPlayer {
             crate::player::xtra::curl::CURL_XTRA_MANAGER_OPT =
                 Some(crate::player::xtra::curl::CurlXtraManager::new());
             // Spawn fresh command and event loops for the new channels
-            async_std::task::spawn_local(async move {
+            crate::player::spawn_player_local(async move {
                 crate::player::commands::run_command_loop(rx).await;
             });
-            async_std::task::spawn_local(async move {
+            crate::player::spawn_player_local(async move {
                 crate::player::events::run_event_loop(event_rx).await;
             });
         }
@@ -209,7 +209,7 @@ impl TestHarness for BrowserTestPlayer {
             player.is_playing = false;
         });
         unsafe {
-            let player = PLAYER_OPT.as_mut().unwrap();
+            let player = crate::player::player_mut();
             player.play();
         }
     }
@@ -229,7 +229,7 @@ impl TestHarness for BrowserTestPlayer {
         Self::reset_player().await;
 
         unsafe {
-            let player = PLAYER_OPT.as_mut().unwrap();
+            let player = crate::player::player_mut();
             let _ = player.load_movie_from_file(&full_url).await;
         }
 

--- a/vm-rust/src/player/testing_browser.rs
+++ b/vm-rust/src/player/testing_browser.rs
@@ -34,13 +34,33 @@ impl BrowserTestPlayer {
         };
 
         // Stop the current movie and clear all timeouts before resetting.
+        // Stop every playing sound too: the old player is about to be dropped,
+        // but dropping an `Rc<AudioBufferSourceNode>` does NOT halt the node —
+        // the AudioContext keeps it running until it ends, so a looping sound
+        // from the previous movie would keep playing over the next test.
         unsafe {
             if let Some(player) = PLAYER_OPT.as_mut() {
                 player.stop();
+                player.sound_manager.stop_all();
                 player.timeout_manager.clear();
+                // Drop the outgoing movie's cast bitmaps up front (they're
+                // anchored, so nothing else frees them until the whole player is
+                // dropped below). Doing it here, before the ~120-frame drain and
+                // before the new player is allocated, releases a bitmap-heavy
+                // movie's pixels (Infestation ~10 MB+ decoded) early so it doesn't
+                // overlap the incoming movie's load — cutting the reset peak.
+                player.bitmap_manager.clear_movie_bitmaps();
             }
         }
         crate::js_api::JsApi::dispatch_clear_timeouts();
+        // Tear down every Ruffle/Flash instance from the previous movie so its
+        // per-frame capture RAF loop, Ruffle player, and SWF audio don't leak
+        // across the movie switch (the per-sprite unload path only fires for
+        // sprites the frame actually changed).
+        crate::js_api::JsApi::dispatch_flash_reset_all();
+        // JS-Lingo runtimes live in a thread_local, so dropping the old player
+        // below does NOT free them — clear them explicitly.
+        crate::player::js_lingo_loader::clear_all_runtimes();
 
         // Bump the generation so any in-flight loops from the previous movie
         // detect staleness on their next await and exit. Then drain: wait
@@ -89,7 +109,14 @@ impl BrowserTestPlayer {
 
         unsafe {
             if let Some(old) = PLAYER_OPT.take() {
-                std::mem::forget(old);
+                // Actually free the previous player. `DirPlayer` has no `Drop`
+                // impl, and the drain loop above already waited for every
+                // in-flight handler to unwind, so there is no outstanding
+                // borrow — dropping just reclaims its heap (cast bitmaps,
+                // datums, score). The old code `mem::forget`-ed it, which
+                // leaked the entire player (tens of MB of cast bitmaps) on
+                // every movie load — the browser test run climbed past a GB.
+                drop(old);
             }
 
             // Create fresh channels to disconnect any old command/event loops

--- a/vm-rust/src/player/timeout.rs
+++ b/vm-rust/src/player/timeout.rs
@@ -122,6 +122,16 @@ impl Timeout {
     pub fn schedule(&mut self) {
         self.cancel();
 
+        // A timeout whose period is 0 is dormant — it sends no events until its
+        // period is set to a value > 0 (Director Scripting Dictionary,
+        // `timeout.period`). Habbo's DM_CurlDetacher depends on this: it creates
+        // the timeout at period 0, then sets `period = 1` from the cURL
+        // completion callback to start it. Scheduling a 0 ms interval here would
+        // fire it immediately and break that hand-off, so leave it un-scheduled.
+        if self.period == 0 {
+            return;
+        }
+
         let timeout_name = self.name.to_owned();
         JsApi::dispatch_schedule_timeout(&timeout_name, self.period);
         self.is_scheduled = true;

--- a/vm-rust/src/player/xtra/budapi/mod.rs
+++ b/vm-rust/src/player/xtra/budapi/mod.rs
@@ -341,7 +341,7 @@ fn ba_copy_text(args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
     if let Some(window) = web_sys::window() {
         let clipboard = window.navigator().clipboard();
         let promise = clipboard.write_text(&text);
-        wasm_bindgen_futures::spawn_local(async move {
+        crate::player::spawn_player_local(async move {
             let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
         });
     }

--- a/vm-rust/src/player/xtra/external.rs
+++ b/vm-rust/src/player/xtra/external.rs
@@ -62,6 +62,7 @@ enum HostOp {
     MouseLoc = 16,
     KeyDown = 17,
     SetLingoGlobal = 18,
+    MemberSize = 19,
 }
 
 impl HostOp {
@@ -85,6 +86,7 @@ impl HostOp {
             16 => HostOp::MouseLoc,
             17 => HostOp::KeyDown,
             18 => HostOp::SetLingoGlobal,
+            19 => HostOp::MemberSize,
             _ => return None,
         })
     }
@@ -459,7 +461,11 @@ pub fn host_call_dispatch(op_id: u32, args_bytes: &[u8]) -> Vec<u8> {
     match op {
         HostOp::Log => {
             if let Some(XDatum::String(msg)) = args.first() {
-                log::debug!("[xtra] {}", msg);
+                // console::log_1, NOT log::debug! — the latter is invisible in the
+                // browser, so every plugin `host_env::log` call was silently
+                // dropped, making the SDK's "visible in the host's developer
+                // console" contract a lie.
+                web_sys::console::log_1(&format!("[xtra] {}", msg).into());
             }
             Vec::new() // void sentinel
         }
@@ -634,6 +640,29 @@ pub fn host_call_dispatch(op_id: u32, args_bytes: &[u8]) -> Vec<u8> {
             });
             match bytes {
                 Some(b) => wire::encode_return(&XDatum::ByteArray(b)),
+                None => wire::encode_return(&XDatum::Void),
+            }
+        }
+        HostOp::MemberSize => {
+            let name = match args.first() {
+                Some(XDatum::String(s)) => s.clone(),
+                _ => return wire::encode_error("member_size: expected String name"),
+            };
+            use crate::player::cast_member::CastMemberType;
+            let size = reserve_player_ref(|player| {
+                let mref = player.movie.cast_manager.find_member_ref_by_name(&name)?;
+                let member = player.movie.cast_manager.find_member_by_ref(&mref)?;
+                let bref = match &member.member_type {
+                    CastMemberType::Bitmap(b) => b.image_ref,
+                    _ => return None,
+                };
+                let bitmap = player.bitmap_manager.get_bitmap(bref)?;
+                Some((bitmap.width as i32, bitmap.height as i32))
+            });
+            match size {
+                Some((w, h)) => {
+                    wire::encode_return(&XDatum::List(vec![XDatum::Int(w), XDatum::Int(h)]))
+                }
                 None => wire::encode_return(&XDatum::Void),
             }
         }

--- a/vm-rust/src/player/xtra/external.rs
+++ b/vm-rust/src/player/xtra/external.rs
@@ -22,15 +22,18 @@
 //! Three places. No JS-side change required (the JS dispatcher is a pure
 //! passthrough that doesn't decode postcard).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use futures::channel::oneshot;
 
-use crate::director::lingo::datum::{Datum, XtraInstanceId, datum_bool};
-use crate::player::{DatumRef, ScriptError, reserve_player_mut};
+use crate::director::lingo::datum::{Datum, DatumType, XtraInstanceId, datum_bool};
+use crate::player::{DatumRef, DirPlayer, ScriptError, reserve_player_mut, reserve_player_ref};
 
 use xtra_sdk::Datum as XDatum;
+use xtra_sdk::scene3d::{FrameData as SceneFrameData, MeshData as SceneMeshData};
 use xtra_sdk::wire;
+
+use super::scene3d;
 
 /// Discriminator for the single `dx_host_call` extern that every plugin
 /// imports. Must match `HostOp` in `dirplayer-xtra/src/host_env.rs` and
@@ -48,6 +51,17 @@ enum HostOp {
     CreateXtraInstance = 5,
     CallXtraHandler = 6,
     DestroyXtraInstance = 7,
+    Scene3dCreate = 8,
+    Scene3dUploadMesh = 9,
+    Scene3dDropMesh = 10,
+    Scene3dUploadTexture = 11,
+    Scene3dSubmitFrame = 12,
+    Scene3dDestroy = 13,
+    CastMemberBytes = 14,
+    StageInfo = 15,
+    MouseLoc = 16,
+    KeyDown = 17,
+    SetLingoGlobal = 18,
 }
 
 impl HostOp {
@@ -60,6 +74,17 @@ impl HostOp {
             5 => HostOp::CreateXtraInstance,
             6 => HostOp::CallXtraHandler,
             7 => HostOp::DestroyXtraInstance,
+            8 => HostOp::Scene3dCreate,
+            9 => HostOp::Scene3dUploadMesh,
+            10 => HostOp::Scene3dDropMesh,
+            11 => HostOp::Scene3dUploadTexture,
+            12 => HostOp::Scene3dSubmitFrame,
+            13 => HostOp::Scene3dDestroy,
+            14 => HostOp::CastMemberBytes,
+            15 => HostOp::StageInfo,
+            16 => HostOp::MouseLoc,
+            17 => HostOp::KeyDown,
+            18 => HostOp::SetLingoGlobal,
             _ => return None,
         })
     }
@@ -292,6 +317,28 @@ pub fn call_static_handler(
     Some(decode_return_to_datum_ref(&result_bytes, xtra_name, handler_name))
 }
 
+/// Try every registered external xtra as the owner of a **bare** global
+/// (no-instance) handler — the shape Groove uses (`InitGroove()`,
+/// `MoveObject(...)`). Unlike [`call_static_handler`], the caller doesn't know
+/// which xtra owns the name, so we ask each registered plugin
+/// `__xtra_has_static_handler(handler)` and dispatch to the first that claims
+/// it. Returns `None` when no external plugin owns the handler, so the caller
+/// falls through to built-ins.
+///
+/// Because external plugins are consulted before the built-in Groove fallback
+/// in `manager.rs`, a loaded Groove plugin transparently shadows the built-in.
+pub fn try_any_static_handler(
+    handler_name: &str,
+    args: &Vec<DatumRef>,
+) -> Option<Result<DatumRef, ScriptError>> {
+    for name in registered_names() {
+        if has_static_handler(&name, handler_name) {
+            return call_static_handler(&name, handler_name, args);
+        }
+    }
+    None
+}
+
 /// Create an instance on an external xtra. Returns `Some(id)` or
 /// `Some(Err(...))`; `None` means the xtra isn't external.
 pub fn create_instance(
@@ -490,6 +537,144 @@ pub fn host_call_dispatch(op_id: u32, args_bytes: &[u8]) -> Vec<u8> {
             // hanging.
             wire::encode_error("inter-xtra dispatch not yet implemented")
         }
+
+        // ── 3D scene rendering ────────────────────────────────────────────
+        // These arrive mid-Lingo-execution (no GL context in scope), so they
+        // only mutate the CPU-side scene store; the webgl2 `XtraSceneRenderer`
+        // uploads and composites during the normal draw pass. Note the player
+        // lock is free here — `call_static_handler`/`call_instance_handler`
+        // release `reserve_player_mut` (in `encode_args_from_refs`) before the
+        // JS hop that runs the plugin, so these may re-take it safely.
+        HostOp::Scene3dCreate => {
+            let tag = match args.first() {
+                Some(XDatum::String(s)) => s.clone(),
+                _ => return wire::encode_error("scene3d_create: expected String tag"),
+            };
+            let id = scene3d::with_store_mut(|s| s.create(&tag));
+            wire::encode_return(&XDatum::Int(id))
+        }
+        HostOp::Scene3dUploadMesh => {
+            let (scene_id, mesh_id, bytes) = match (args.first(), args.get(1), args.get(2)) {
+                (Some(XDatum::Int(s)), Some(XDatum::Int(m)), Some(XDatum::ByteArray(b))) => {
+                    (*s, *m as u32, b)
+                }
+                _ => return wire::encode_error("scene3d_upload_mesh: expected (Int, Int, ByteArray)"),
+            };
+            match SceneMeshData::from_bytes(bytes) {
+                Ok(data) => {
+                    scene3d::with_store_mut(|s| s.upload_mesh(scene_id, mesh_id, data));
+                    Vec::new()
+                }
+                Err(e) => wire::encode_error(&format!("scene3d_upload_mesh: bad MeshData: {:?}", e)),
+            }
+        }
+        HostOp::Scene3dDropMesh => {
+            let (scene_id, mesh_id) = match (args.first(), args.get(1)) {
+                (Some(XDatum::Int(s)), Some(XDatum::Int(m))) => (*s, *m as u32),
+                _ => return wire::encode_error("scene3d_drop_mesh: expected (Int, Int)"),
+            };
+            scene3d::with_store_mut(|s| s.drop_mesh(scene_id, mesh_id));
+            Vec::new()
+        }
+        HostOp::Scene3dUploadTexture => {
+            let (scene_id, name, w, h, rgba) = match (
+                args.first(), args.get(1), args.get(2), args.get(3), args.get(4),
+            ) {
+                (
+                    Some(XDatum::Int(s)), Some(XDatum::String(n)),
+                    Some(XDatum::Int(w)), Some(XDatum::Int(h)), Some(XDatum::ByteArray(b)),
+                ) => (*s, n.clone(), *w as u32, *h as u32, b.clone()),
+                _ => {
+                    return wire::encode_error(
+                        "scene3d_upload_texture: expected (Int, String, Int, Int, ByteArray)",
+                    );
+                }
+            };
+            scene3d::with_store_mut(|s| s.upload_texture(scene_id, &name, w, h, rgba));
+            Vec::new()
+        }
+        HostOp::Scene3dSubmitFrame => {
+            let (scene_id, bytes) = match (args.first(), args.get(1)) {
+                (Some(XDatum::Int(s)), Some(XDatum::ByteArray(b))) => (*s, b),
+                _ => return wire::encode_error("scene3d_submit_frame: expected (Int, ByteArray)"),
+            };
+            match SceneFrameData::from_bytes(bytes) {
+                Ok(frame) => {
+                    let movie_frame =
+                        reserve_player_mut(|player| player.movie.current_frame as i32);
+                    scene3d::with_store_mut(|s| s.submit_frame(scene_id, frame, movie_frame));
+                    Vec::new()
+                }
+                Err(e) => wire::encode_error(&format!("scene3d_submit_frame: bad FrameData: {:?}", e)),
+            }
+        }
+        HostOp::Scene3dDestroy => {
+            let scene_id = match args.first() {
+                Some(XDatum::Int(s)) => *s,
+                _ => return wire::encode_error("scene3d_destroy: expected Int scene_id"),
+            };
+            scene3d::with_store_mut(|s| s.destroy(scene_id));
+            Vec::new()
+        }
+
+        // ── Host state a compute-only plugin reads ────────────────────────
+        HostOp::CastMemberBytes => {
+            use crate::player::cast_member::CastMemberType;
+            let (name, kind) = match (args.first(), args.get(1)) {
+                (Some(XDatum::String(n)), Some(XDatum::String(k))) => (n.clone(), k.to_lowercase()),
+                _ => return wire::encode_error("cast_member_bytes: expected (String, String)"),
+            };
+            let bytes = reserve_player_ref(|player| {
+                let mref = player.movie.cast_manager.find_member_ref_by_name(&name)?;
+                let member = player.movie.cast_manager.find_member_by_ref(&mref)?;
+                match (kind.as_str(), &member.member_type) {
+                    ("groove3gm", CastMemberType::Groove3gm(m)) => Some(m.data.clone()),
+                    _ => None,
+                }
+            });
+            match bytes {
+                Some(b) => wire::encode_return(&XDatum::ByteArray(b)),
+                None => wire::encode_return(&XDatum::Void),
+            }
+        }
+        HostOp::StageInfo => {
+            let (w, h, frame) = reserve_player_ref(|player| {
+                (
+                    player.movie.rect.width(),
+                    player.movie.rect.height(),
+                    player.movie.current_frame as i32,
+                )
+            });
+            wire::encode_return(&XDatum::List(vec![
+                XDatum::Int(w),
+                XDatum::Int(h),
+                XDatum::Int(frame),
+            ]))
+        }
+        HostOp::MouseLoc => {
+            let (x, y) = reserve_player_ref(|player| player.mouse_loc);
+            wire::encode_return(&XDatum::Point(x as f64, y as f64))
+        }
+        HostOp::KeyDown => {
+            let key = match args.first() {
+                Some(XDatum::String(s)) => s.clone(),
+                _ => return wire::encode_error("key_down: expected String key"),
+            };
+            let down = reserve_player_ref(|player| player.keyboard_manager.is_key_down(&key));
+            wire::encode_return(&XDatum::Bool(down))
+        }
+        HostOp::SetLingoGlobal => {
+            let (name, value) = match (args.first(), args.get(1)) {
+                (Some(XDatum::String(n)), Some(v)) => (n.clone(), v.clone()),
+                _ => return wire::encode_error("set_lingo_global: expected (String, value)"),
+            };
+            // Allocate the value into the datum arena, then bind the global.
+            let value_ref = xdatum_to_host_datum_ref(&value);
+            reserve_player_mut(|player| {
+                player.globals.insert(name, value_ref);
+            });
+            Vec::new()
+        }
     }
 }
 
@@ -515,13 +700,35 @@ fn encode_args_from_refs(args: &Vec<DatumRef>) -> Option<Vec<u8>> {
 /// Director represents booleans as `Datum::Int(0)` / `Datum::Int(1)`
 /// (there is no separate Bool variant on the host), so we forward Ints
 /// as-is. Plugins that want bool semantics can compare to `Int(0)`.
-fn host_datum_to_xdatum(d: &Datum, _player: &crate::player::DirPlayer) -> XDatum {
+fn host_datum_to_xdatum(d: &Datum, player: &DirPlayer) -> XDatum {
     match d {
         Datum::Void => XDatum::Void,
         Datum::Int(i) => XDatum::Int(*i),
         Datum::Float(f) => XDatum::Float(*f),
         Datum::String(s) => XDatum::String(s.clone()),
         Datum::Symbol(s) => XDatum::Symbol(s.clone()),
+        // Container variants recurse, resolving each child DatumRef through
+        // the player's datum arena. Groove passes/returns lists, prop-lists,
+        // points and rects, so these must survive the boundary intact.
+        Datum::List(_, items, _) => XDatum::List(
+            items
+                .iter()
+                .map(|r| host_datum_to_xdatum(player.get_datum(r), player))
+                .collect(),
+        ),
+        Datum::PropList(pairs, _) => XDatum::PropList(
+            pairs
+                .iter()
+                .map(|(k, v)| {
+                    (
+                        host_datum_to_xdatum(player.get_datum(k), player),
+                        host_datum_to_xdatum(player.get_datum(v), player),
+                    )
+                })
+                .collect(),
+        ),
+        Datum::Point([x, y], _) => XDatum::Point(*x, *y),
+        Datum::Rect([l, t, r, b], _) => XDatum::Rect(*l, *t, *r, *b),
         _ => XDatum::Void,
     }
 }
@@ -530,18 +737,47 @@ fn host_datum_to_xdatum(d: &Datum, _player: &crate::player::DirPlayer) -> XDatum
 /// into the player's datum manager, returning a fresh `DatumRef`.
 fn xdatum_to_host_datum_ref(d: &XDatum) -> DatumRef {
     reserve_player_mut(|player| {
-        let host = xdatum_to_host_datum(d);
+        let host = xdatum_to_host_datum(d, player);
         player.alloc_datum(host)
     })
 }
 
-fn xdatum_to_host_datum(d: &XDatum) -> Datum {
+fn xdatum_to_host_datum(d: &XDatum, player: &mut DirPlayer) -> Datum {
     match d {
         XDatum::Void => Datum::Void,
         XDatum::Int(i) => Datum::Int(*i),
         XDatum::Float(f) => Datum::Float(*f),
         XDatum::String(s) => Datum::String(s.clone()),
         XDatum::Symbol(s) => Datum::Symbol(s.clone()),
+        // Container variants recurse: each child is converted and allocated
+        // into the player's datum arena first, then the parent references the
+        // fresh DatumRefs. Mirrors `host_datum_to_xdatum` in the other
+        // direction so Groove's list/prop-list/point/rect returns survive.
+        XDatum::List(items) => {
+            let refs: VecDeque<DatumRef> = items
+                .iter()
+                .map(|it| {
+                    let child = xdatum_to_host_datum(it, player);
+                    player.alloc_datum(child)
+                })
+                .collect();
+            Datum::List(DatumType::List, refs, false)
+        }
+        XDatum::PropList(pairs) => {
+            let entries: VecDeque<(DatumRef, DatumRef)> = pairs
+                .iter()
+                .map(|(k, v)| {
+                    let kd = xdatum_to_host_datum(k, player);
+                    let kr = player.alloc_datum(kd);
+                    let vd = xdatum_to_host_datum(v, player);
+                    let vr = player.alloc_datum(vd);
+                    (kr, vr)
+                })
+                .collect();
+            Datum::PropList(entries, false)
+        }
+        XDatum::Point(x, y) => Datum::Point([*x, *y], 0),
+        XDatum::Rect(l, t, r, b) => Datum::Rect([*l, *t, *r, *b], 0),
         // Director booleans are Int(0)/Int(1). Use the helper so a future
         // change to the bool representation only touches one place.
         XDatum::Bool(b) => datum_bool(*b),

--- a/vm-rust/src/player/xtra/fileio/mod.rs
+++ b/vm-rust/src/player/xtra/fileio/mod.rs
@@ -213,7 +213,7 @@ impl FileIoXtraManager {
 
                 // Await the fetch outside of reserve_player_mut
                 {
-                    let player = unsafe { crate::PLAYER_OPT.as_mut().unwrap() };
+                    let player = unsafe { crate::player::player_mut() };
                     if !player.net_manager.is_task_done(Some(task_id)) {
                         player.net_manager.await_task(task_id).await;
                     }

--- a/vm-rust/src/player/xtra/manager.rs
+++ b/vm-rust/src/player/xtra/manager.rs
@@ -64,6 +64,13 @@ pub fn try_call_xtra_static_handler(
     if CurlXtra::has_static_handler(name) {
         return Some(CurlXtra::call_static_handler(name, args));
     }
+    // External plugins own bare global handlers too — e.g. the Groove plugin's
+    // `InitGroove()`/`MoveObject()`, which games call as bare globals (never
+    // `new(xtra "Groove")`). This is the sole path that serves Groove now that
+    // the built-in engine is gone.
+    if let Some(result) = external::try_any_static_handler(name, args) {
+        return Some(result);
+    }
     None
 }
 

--- a/vm-rust/src/player/xtra/mod.rs
+++ b/vm-rust/src/player/xtra/mod.rs
@@ -5,5 +5,6 @@ pub mod fileio;
 pub mod manager;
 pub mod multiuser;
 pub mod openurl;
+pub mod scene3d;
 pub mod sysmenu;
 pub mod xmlparser;

--- a/vm-rust/src/player/xtra/multiuser/mod.rs
+++ b/vm-rust/src/player/xtra/multiuser/mod.rs
@@ -458,7 +458,7 @@ impl MultiuserXtraManager {
 
                 let (tx, rx) = async_std::channel::unbounded();
                 instance.socket_tx = Some(tx);
-                spawn_local(async move {
+                crate::player::spawn_player_local(async move {
                     while let Ok(message) = rx.recv().await {
                         // Check if WebSocket is open (readyState == 1) before sending
                         // readyState: 0 = CONNECTING, 1 = OPEN, 2 = CLOSING, 3 = CLOSED

--- a/vm-rust/src/player/xtra/scene3d.rs
+++ b/vm-rust/src/player/xtra/scene3d.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+//! Host-side store for the external Xtra 3D scene API (`HostOp::Scene3d*`).
+//!
+//! An external plugin (e.g. a Groove-Xtra wasm) owns all world simulation and,
+//! per step, pushes *retained* draw data at the host through the `scene3d_*`
+//! host services. Those calls arrive mid-Lingo-execution, with no GL context in
+//! scope, so they cannot touch WebGL directly. This module is the buffer
+//! between them and the renderer: the [`host_call_dispatch`] arms in
+//! `external.rs` write here, and [`XtraSceneRenderer`] in
+//! `rendering_gpu::webgl2::xtra_scene` reads here during the normal draw pass,
+//! uploading GL buffers/textures lazily and compositing the latest frame.
+//!
+//! This mirrors the built-in Groove split (`GrooveXtraManager` state ←
+//! `GrooveSceneRenderer`), but is engine-agnostic: any plugin driving the
+//! `scene3d` ops shares it.
+
+use std::collections::HashMap;
+
+use xtra_sdk::scene3d::{FrameData, MeshData};
+
+/// One uploaded mesh (the batch set for a shape or a deformed object). `generation`
+/// bumps on every re-upload so the renderer knows to rebuild its GL buffers.
+pub struct SceneMesh {
+    pub data: MeshData,
+    pub generation: u64,
+}
+
+/// One CPU-composed texture uploaded by the plugin (`Scene3dUploadTexture`).
+/// Cast-member textures are *not* stored here — the renderer resolves those by
+/// name against movie bitmaps. `generation` bumps on re-upload.
+pub struct UploadedTexture {
+    pub w: u32,
+    pub h: u32,
+    pub rgba: Vec<u8>,
+    pub generation: u64,
+}
+
+/// One scene: its meshes, plugin-uploaded textures, and the latest frame to
+/// composite, plus the staleness bookkeeping the renderer uses to stop
+/// painting once the game stops stepping.
+pub struct Scene {
+    pub meshes: HashMap<u32, SceneMesh>,
+    pub textures: HashMap<String, UploadedTexture>,
+    pub frame: Option<FrameData>,
+    /// The movie frame in effect when the latest frame was submitted. The
+    /// renderer only composites while this equals the current movie frame, so
+    /// stale 3D stops painting over later 2D/Flash content (mirrors the
+    /// Groove `last_active_frame` gate).
+    pub last_submit_frame: i32,
+    /// Draws since the last submit; the renderer bumps this and stops after a
+    /// small tolerance so a redraw not paired with a step doesn't linger.
+    pub draws_since_submit: i32,
+}
+
+impl Scene {
+    fn new() -> Self {
+        Scene {
+            meshes: HashMap::new(),
+            textures: HashMap::new(),
+            frame: None,
+            last_submit_frame: -1,
+            draws_since_submit: 0,
+        }
+    }
+}
+
+/// The whole store: tag→id map (for idempotent `create`) plus the live scenes.
+#[derive(Default)]
+pub struct Scene3dStore {
+    tags: HashMap<String, i32>,
+    pub scenes: HashMap<i32, Scene>,
+    next_id: i32,
+}
+
+impl Scene3dStore {
+    pub fn new() -> Self {
+        Scene3dStore { tags: HashMap::new(), scenes: HashMap::new(), next_id: 1 }
+    }
+
+    /// Idempotent per tag: returns the existing scene id or mints a new one.
+    pub fn create(&mut self, tag: &str) -> i32 {
+        if let Some(id) = self.tags.get(tag) {
+            return *id;
+        }
+        let id = self.next_id;
+        self.next_id += 1;
+        self.tags.insert(tag.to_string(), id);
+        self.scenes.insert(id, Scene::new());
+        id
+    }
+
+    pub fn upload_mesh(&mut self, scene_id: i32, mesh_id: u32, data: MeshData) {
+        if let Some(scene) = self.scenes.get_mut(&scene_id) {
+            let generation = scene.meshes.get(&mesh_id).map(|m| m.generation + 1).unwrap_or(0);
+            scene.meshes.insert(mesh_id, SceneMesh { data, generation });
+        }
+    }
+
+    pub fn drop_mesh(&mut self, scene_id: i32, mesh_id: u32) {
+        if let Some(scene) = self.scenes.get_mut(&scene_id) {
+            scene.meshes.remove(&mesh_id);
+        }
+    }
+
+    pub fn upload_texture(&mut self, scene_id: i32, name: &str, w: u32, h: u32, rgba: Vec<u8>) {
+        if let Some(scene) = self.scenes.get_mut(&scene_id) {
+            let generation = scene.textures.get(name).map(|t| t.generation + 1).unwrap_or(0);
+            scene.textures.insert(name.to_string(), UploadedTexture { w, h, rgba, generation });
+        }
+    }
+
+    /// Store the latest frame and stamp the movie frame it was submitted on.
+    pub fn submit_frame(&mut self, scene_id: i32, frame: FrameData, movie_frame: i32) {
+        if let Some(scene) = self.scenes.get_mut(&scene_id) {
+            scene.frame = Some(frame);
+            scene.last_submit_frame = movie_frame;
+            scene.draws_since_submit = 0;
+        }
+    }
+
+    pub fn destroy(&mut self, scene_id: i32) {
+        self.scenes.remove(&scene_id);
+        self.tags.retain(|_, id| *id != scene_id);
+    }
+}
+
+/// The global store. WASM is single-threaded, so `static mut` is sound — the
+/// same pattern the built-in Groove manager uses. Populated by
+/// `external::host_call_dispatch`, read by the webgl2 `XtraSceneRenderer`.
+pub static mut XTRA_SCENE_STORE: Option<Scene3dStore> = None;
+
+/// Run `f` against the store, initializing it on first use.
+pub fn with_store_mut<R>(f: impl FnOnce(&mut Scene3dStore) -> R) -> R {
+    unsafe {
+        let ptr = &raw mut XTRA_SCENE_STORE;
+        let store = (*ptr).get_or_insert_with(Scene3dStore::new);
+        f(store)
+    }
+}
+
+/// Drop every scene. Called from `DirPlayer::reset` so a plugin's scenes from a
+/// previous movie don't linger across loads (their GL resources are freed the
+/// next time the renderer sees the scene is gone).
+pub fn clear_all() {
+    with_store_mut(|s| {
+        s.scenes.clear();
+        s.tags.clear();
+    });
+}

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -2997,7 +2997,10 @@ pub fn render_score_to_bitmap_with_offset(
                     // First time this sprite renders a Flash member — ask
                     // JS to spin up a dedicated Ruffle instance for it.
                     let dispatch_key = (channel_num as i16, member_ref.cast_lib, member_ref.cast_member);
-                    if !player.flash_sprite_loaded.contains(&dispatch_key) {
+                    // Host-only: a nested sub-player's Flash lifecycle is owned by
+                    // its own pre_dispatch_flash_members (see webgl2 render_sprite).
+                    let is_host = unsafe { crate::player::ACTIVE_PLAYER_ID } == 0;
+                    if is_host && !player.flash_sprite_loaded.contains(&dispatch_key) {
                         let sprite = get_score_sprite(&player.movie, score_source, channel_num).unwrap();
                         let w = sprite.width.max(1) as u32;
                         let h = sprite.height.max(1) as u32;
@@ -3467,6 +3470,17 @@ where
 
 pub fn draw_frame_immediate() {
     use crate::rendering_gpu::Renderer;
+    // A nested `#movie` sub-player is headless: its stage is composited by the
+    // HOST once per host frame via render_nested_player_stages into an
+    // off-screen FBO. If the sub calls updateStage()/nothing() (very common
+    // during keyboard movement and busy-wait loops), draw_frame here would run
+    // against the HOST's framebuffer + size, smearing the sub's sprites (wide
+    // scrolling background, off-screen tiles) across the whole host stage
+    // unclipped — flickering on every such call. Never let a sub draw directly
+    // to the host stage; leave stage_dirty so the host recomposites its FBO.
+    if unsafe { crate::player::ACTIVE_PLAYER_ID } != 0 {
+        return;
+    }
     let (tempo, dirty) = reserve_player_ref(|player| {
         (player.current_frame_tempo as f64, player.stage_dirty)
     });
@@ -3888,7 +3902,7 @@ pub fn player_create_canvas() -> Result<(), JsValue> {
             // renderer was dropped between movies) reuse the existing loop.
             if !DRAW_LOOP_SPAWNED.with(|f| f.get()) {
                 DRAW_LOOP_SPAWNED.with(|f| f.set(true));
-                spawn_local(async {
+                crate::player::spawn_player_local(async {
                     run_draw_loop().await;
                 });
             }

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -2954,7 +2954,19 @@ pub fn render_score_to_bitmap_with_offset(
                     let src_bitmap = player.bitmap_manager.get_bitmap(bitmap_ref);
                     if let Some(src_bitmap) = src_bitmap {
                         let src_rect = IntRect::from(0, 0, src_bitmap.width as i32, src_bitmap.height as i32);
-                        let dst_rect = sprite_rect;
+                        // Apply flipH/flipV by inverting the dst_rect (left↔right,
+                        // top↔bottom) so copy_pixels mirrors the content — the same
+                        // way the bitmap path does it. get_concrete_sprite_rect
+                        // already mirrored the reg point to place the box on the
+                        // correct side; without this inversion the Flash content
+                        // filled the box un-mirrored (bogey_nights' end-game grab
+                        // hands are flipV — they grabbed downward instead of up).
+                        let dst_rect = IntRect::from(
+                            if sprite.flip_h { sprite_rect.right } else { sprite_rect.left },
+                            if sprite.flip_v { sprite_rect.bottom } else { sprite_rect.top },
+                            if sprite.flip_h { sprite_rect.left } else { sprite_rect.right },
+                            if sprite.flip_v { sprite_rect.top } else { sprite_rect.bottom },
+                        );
 
                         let params = CopyPixelsParams {
                             blend: sprite.effective_blend(),
@@ -2967,7 +2979,7 @@ pub fn render_score_to_bitmap_with_offset(
                             skew: sprite.skew,
                             sprite: Some(sprite),
                             mask_offset: (0, 0),
-                            original_dst_rect: Some(dst_rect.clone()),
+                            original_dst_rect: Some(sprite_rect.clone()),
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
@@ -2998,6 +3010,7 @@ pub fn render_score_to_bitmap_with_offset(
                             .as_ref()
                             .map(|fi| fi.paused_at_start)
                             .unwrap_or(false);
+                        let asserted_frame = sprite.flash_asserted_frame.unwrap_or(-1);
                         JsApi::dispatch_flash_member_loaded(
                             channel_num as i32,
                             member_ref.cast_lib,
@@ -3006,6 +3019,7 @@ pub fn render_score_to_bitmap_with_offset(
                             w,
                             h,
                             paused_at_start,
+                            asserted_frame,
                         );
                         player.flash_sprite_loaded.insert(dispatch_key);
                     }

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -1211,7 +1211,7 @@ fn render_filmloop_from_channel_data(
 
                 // Filmloop blend: inverted 0-255 scale (0 → 100%, 127 → ~50%)
                 // 255 is treated as default/opaque (same as shape/vector paths)
-                let blend = crate::player::score::convert_raw_blend(data.blend, player.movie.dir_version);
+                let blend = crate::player::score::convert_raw_blend(data.blend, data.sprite_flags, player.movie.dir_version);
 
                 // Only use matte mask for inks that support it:
                 // - Ink 0 (copy): for trimWhiteSpace edge transparency (indexed and 16-bit)
@@ -1569,7 +1569,7 @@ fn render_filmloop_from_channel_data(
                     }),
                 );
 
-                let blend = crate::player::score::convert_raw_blend(data.blend, player.movie.dir_version);
+                let blend = crate::player::score::convert_raw_blend(data.blend, data.sprite_flags, player.movie.dir_version);
 
                 // Mirror the Bitmap arm's flip handling so nested filmloops
                 // honor the child sprite's flipH/flipV bits.

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -3405,6 +3405,24 @@ thread_local! {
     /// each rAF, so we only need one loop across the whole WASM lifetime —
     /// dropping and recreating the renderer between tests must not respawn it.
     pub static DRAW_LOOP_SPAWNED: Cell<bool> = Cell::new(false);
+    /// True while the stage WebGL2 context is lost (browser reclaimed it, e.g.
+    /// the tab was backgrounded). Drawing is skipped until `webglcontextrestored`
+    /// re-initializes the renderer. See `register_webgl_context_handlers`.
+    pub static WEBGL_CONTEXT_LOST: Cell<bool> = Cell::new(false);
+}
+
+/// True when the document/tab is hidden (backgrounded). Rendering to a hidden
+/// tab's GL context is wasted work and provokes context-loss; skip it.
+fn document_is_hidden() -> bool {
+    web_sys::window()
+        .and_then(|w| w.document())
+        .map(|d| d.hidden())
+        .unwrap_or(false)
+}
+
+/// Skip the stage draw when the context is lost or the tab is hidden.
+fn should_skip_stage_draw() -> bool {
+    WEBGL_CONTEXT_LOST.with(|c| c.get()) || document_is_hidden()
 }
 
 pub fn mark_frame_drawn() {
@@ -3439,6 +3457,9 @@ pub fn draw_frame_immediate() {
         (player.current_frame_tempo as f64, player.stage_dirty)
     });
     if !dirty {
+        return;
+    }
+    if should_skip_stage_draw() {
         return;
     }
     let interval = if tempo > 0.0 {
@@ -3703,6 +3724,12 @@ pub(crate) fn try_create_webgl2_renderer(
     preview_canvas.set_width(1);
     preview_canvas.set_height(1);
 
+    // Mark the stage canvas so the Flash manager's global `getContext`
+    // monkey-patch does NOT force `preserveDrawingBuffer: true` on it (that
+    // patch is only needed for Ruffle's frame-capture readback; on the stage
+    // it just wastes GPU memory and makes background context-loss more likely).
+    let _ = canvas.set_attribute("data-dp-stage", "1");
+
     set_pixelated_canvas_style(&canvas);
     set_pixelated_canvas_style(&preview_canvas);
 
@@ -3710,6 +3737,7 @@ pub(crate) fn try_create_webgl2_renderer(
     match WebGL2Renderer::new(canvas, preview_canvas) {
         Ok(renderer) => {
             debug!("WebGL2 renderer created successfully");
+            register_webgl_context_handlers(renderer.canvas());
             Some(renderer)
         }
         Err(e) => {
@@ -3717,6 +3745,63 @@ pub(crate) fn try_create_webgl2_renderer(
             None
         }
     }
+}
+
+/// Register `webglcontextlost` / `webglcontextrestored` listeners on the stage
+/// canvas. Browsers reclaim a tab's WebGL context when it is backgrounded; the
+/// default is to NOT restore it, so without `preventDefault()` the stage would
+/// stay dead after the tab regains focus. On loss we pause drawing; on restore
+/// we rebuild the renderer on the same canvas (fresh programs/buffers/textures).
+/// The closures are leaked (`forget`) so they live for the canvas's lifetime.
+fn register_webgl_context_handlers(canvas: &web_sys::HtmlCanvasElement) {
+    let lost_cb = Closure::<dyn FnMut(web_sys::Event)>::new(move |e: web_sys::Event| {
+        // preventDefault tells the browser we will restore -> it will fire
+        // webglcontextrestored once the tab is visible again.
+        e.prevent_default();
+        WEBGL_CONTEXT_LOST.with(|c| c.set(true));
+        warn!("[webgl] stage context lost — pausing draw until restored");
+    });
+    let _ = canvas.add_event_listener_with_callback(
+        "webglcontextlost",
+        lost_cb.as_ref().unchecked_ref(),
+    );
+    lost_cb.forget();
+
+    let restored_cb = Closure::<dyn FnMut(web_sys::Event)>::new(move |_e: web_sys::Event| {
+        on_webgl_context_restored();
+    });
+    let _ = canvas.add_event_listener_with_callback(
+        "webglcontextrestored",
+        restored_cb.as_ref().unchecked_ref(),
+    );
+    restored_cb.forget();
+}
+
+/// Rebuild the WebGL2 renderer on the existing (now-restored) canvas so its GL
+/// objects are recreated, then resume drawing. Caches (textures/text) start
+/// empty and re-populate on the next frame.
+fn on_webgl_context_restored() {
+    use crate::rendering_gpu::webgl2::WebGL2Renderer;
+    with_renderer_mut(|renderer_lock| {
+        if let Some(DynamicRenderer::WebGL2(old)) = renderer_lock.as_ref() {
+            let canvas = old.canvas().clone();
+            let preview = old.preview_canvas().clone();
+            match WebGL2Renderer::new(canvas, preview) {
+                Ok(new_renderer) => {
+                    *renderer_lock = Some(DynamicRenderer::WebGL2(new_renderer));
+                    warn!("[webgl] stage context restored — renderer rebuilt");
+                }
+                Err(e) => {
+                    warn!("[webgl] failed to rebuild renderer after context restore: {:?}", e);
+                }
+            }
+        }
+    });
+    WEBGL_CONTEXT_LOST.with(|c| c.set(false));
+    // Force a full redraw on the next frame.
+    reserve_player_mut(|player| {
+        player.stage_dirty = true;
+    });
 }
 
 fn get_stage_container() -> Result<web_sys::HtmlElement, JsValue> {
@@ -3853,13 +3938,14 @@ async fn run_draw_loop() {
         let frame_interval = 1000 / draw_fps as i64;
         if Local::now().timestamp_millis() - last_frame_ms >= frame_interval {
             last_frame_ms = Local::now().timestamp_millis();
+            let skip_stage = should_skip_stage_draw();
             with_renderer_mut(|renderer_lock| {
                 if let Some(renderer) = renderer_lock {
-                    if (player.is_playing || player.stage_dirty) && !was_frame_drawn_recently(frame_interval) {
+                    if !skip_stage && (player.is_playing || player.stage_dirty) && !was_frame_drawn_recently(frame_interval) {
                         renderer.draw_frame(&mut player);
                         player.stage_dirty = false;
                     }
-                    if player.preview_dirty {
+                    if !skip_stage && player.preview_dirty {
                         renderer.draw_preview_frame(&mut player);
                         player.preview_dirty = false;
                     }

--- a/vm-rust/src/rendering_gpu/webgl2/context.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/context.rs
@@ -187,6 +187,7 @@ impl WebGL2Context {
 
     /// Set blend mode for additive blending (ink 33 — Add Pin)
     pub fn set_blend_additive(&self) {
+        self.gl.enable(WebGl2RenderingContext::BLEND); // see set_blend_alpha
         // Ensure blend equation is FUNC_ADD (additive needs: dst + src)
         self.gl.blend_equation(WebGl2RenderingContext::FUNC_ADD);
         // Use separate blend for RGB and Alpha:
@@ -214,6 +215,14 @@ impl WebGL2Context {
 
     /// Set blend mode for standard alpha blending (ink 0)
     pub fn set_blend_alpha(&self) {
+        // Re-enable GL_BLEND. The 3D scene renderer (scene3d.rs) toggles
+        // GL_BLEND off per draw and doesn't always restore it, so a blended 2D
+        // sprite drawn AFTER a 3D scene would render OPAQUE — PacMan3D2's mBlue
+        // status bar (a bitmap at blend 40 over the white score text) covered
+        // the text instead of letting it show through. Enabling here makes
+        // every 2D sprite blend regardless of the prior GL state (set_blend_*
+        // means "set up blending", which implies blending must be on).
+        self.gl.enable(WebGl2RenderingContext::BLEND);
         // Always reset blend equation to FUNC_ADD in case a previous sprite
         // used a different equation (Lighten uses MAX, SubPin uses REVERSE_SUBTRACT)
         self.gl.blend_equation(WebGl2RenderingContext::FUNC_ADD);
@@ -232,6 +241,7 @@ impl WebGL2Context {
 
     /// Set blend mode for multiply (ink 41 - darken)
     pub fn set_blend_multiply(&self) {
+        self.gl.enable(WebGl2RenderingContext::BLEND); // see set_blend_alpha
         // Ensure blend equation is FUNC_ADD for multiply blend
         self.gl.blend_equation(WebGl2RenderingContext::FUNC_ADD);
         // Preserve destination alpha (same fix as other blend modes)
@@ -246,6 +256,7 @@ impl WebGL2Context {
     /// Set blend mode for lighten (ink 40)
     /// Uses MAX blend equation to only show lighter pixels
     pub fn set_blend_lighten(&self) {
+        self.gl.enable(WebGl2RenderingContext::BLEND); // see set_blend_alpha
         self.gl.blend_equation(WebGl2RenderingContext::MAX);
         // Preserve destination alpha (same fix as AddPin)
         self.gl.blend_func_separate(
@@ -259,6 +270,7 @@ impl WebGL2Context {
     /// Set blend mode for Dark ink (ink 39)
     /// Uses MIN blend equation: result = min(src, dst)
     pub fn set_blend_darken(&self) {
+        self.gl.enable(WebGl2RenderingContext::BLEND); // see set_blend_alpha
         self.gl.blend_equation(WebGl2RenderingContext::MIN);
         // Preserve destination alpha (same fix as AddPin)
         self.gl.blend_func_separate(
@@ -272,6 +284,7 @@ impl WebGL2Context {
     /// Set blend mode for subtractive blending (ink 35 - Sub Pin)
     /// Uses FUNC_REVERSE_SUBTRACT equation: result = dst - src
     pub fn set_blend_subtractive(&self) {
+        self.gl.enable(WebGl2RenderingContext::BLEND); // see set_blend_alpha
         self.gl.blend_equation(WebGl2RenderingContext::FUNC_REVERSE_SUBTRACT);
         // Preserve destination alpha (same fix as AddPin)
         self.gl.blend_func_separate(

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -2958,6 +2958,21 @@ impl WebGL2Renderer {
         let is_rendered_text = matches!(texture_source, TextureSource::RenderedText { .. });
         let is_button_alpha_matte = matches!(texture_source, TextureSource::ButtonBitmap { ink: i, .. } if i == 2 || i == 36 || i == 8 || i == 7);
 
+        // These sources rasterize a FRESH texture here every frame and, unlike
+        // Bitmap / FilmLoop / RenderedText, do NOT put it in any cache. Dropping a
+        // `WebGlTexture` handle does not call `gl.deleteTexture`, so without an
+        // explicit delete after drawing, each frame leaks one GL texture per such
+        // sprite — GPU/JS memory climbs and never comes back (the cause of the
+        // spike on vector-shape-heavy movies like Infestation and lore). Deleted
+        // after the draw below; cached sources must NOT be deleted (their texture
+        // is shared with the cache).
+        let owns_dynamic_texture = matches!(
+            texture_source,
+            TextureSource::VectorShapeBitmap { .. }
+                | TextureSource::ShapeBitmap { .. }
+                | TextureSource::ButtonBitmap { .. }
+        );
+
         let tex = match texture_source {
             TextureSource::Bitmap { image_ref, is_flash } => {
                 // Pass sprite's bgColor for matte/transparency computation for inks that need it
@@ -3155,7 +3170,8 @@ impl WebGL2Renderer {
                     if self.context.upload_texture_rgba(&texture, width, height, &filmloop_bitmap.data).is_err() {
                         return;
                     }
-                    self.texture_cache.insert(cache_key, texture.clone(), width, height, filmloop_frame);
+                    let gl = self.context.gl().clone();
+                    self.texture_cache.insert(&gl, cache_key, texture.clone(), width, height, filmloop_frame);
                     texture
                 }
             }
@@ -3870,6 +3886,13 @@ impl WebGL2Renderer {
 
         // Unbind texture
         gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
+
+        // Free the per-frame dynamic texture now that the quad is drawn — it is
+        // not held by any cache (see `owns_dynamic_texture`). Without this, each
+        // frame leaks one GL texture per vector-shape/shape/button sprite.
+        if owns_dynamic_texture {
+            gl.delete_texture(Some(&tex));
+        }
 
         // Reset blend equation if we used an ink that changes it from the default FUNC_ADD
         if effective_ink == InkMode::SubPin || effective_ink == InkMode::Light || effective_ink == InkMode::Dark {
@@ -4822,7 +4845,9 @@ impl WebGL2Renderer {
             .ok()?;
 
         // Cache the texture with current bitmap version
+        let gl = self.context.gl().clone();
         self.texture_cache.insert(
+            &gl,
             cache_key,
             texture.clone(),
             width,
@@ -6794,7 +6819,9 @@ impl WebGL2Renderer {
             .upload_texture_rgba(&texture, render_width as u32, upload_height, &text_bitmap.data)
             .ok()?;
         // Cache the texture
+        let gl = self.context.gl().clone();
         self.rendered_text_cache.insert(
+            &gl,
             cache_key.clone(),
             texture.clone(),
             render_width as u32,

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -1389,23 +1389,46 @@ impl WebGL2Renderer {
         // This triggers when the sprite first appears on stage during playback.
         if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
             if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                if w3d.info.animation_enabled
-                    && !w3d.runtime_state.animation_playing
-                    && w3d.runtime_state.current_motion.is_none()
-                {
-                    if let Some(scene) = w3d.parsed_scene.as_ref() {
-                        if let Some(first_motion) = scene.motions.first() {
-                            // Detect animation type: bones (skeleton) vs keyframe (node transforms)
-                            let has_skeleton = !scene.skeletons.is_empty()
-                                && scene.skeletons.iter().any(|s| s.bones.len() > 1);
-                            let anim_type = if has_skeleton { "bones" } else { "keyframe" };
-                            debug!(
-                                "[3D] animationEnabled: auto-starting {} motion '{}' (loop={})",
-                                anim_type, first_motion.name, w3d.info.loops
-                            );
-                            w3d.runtime_state.current_motion = Some(first_motion.name.clone());
+                if w3d.info.animation_enabled {
+                    let first_motion = w3d.parsed_scene.as_ref()
+                        .and_then(|s| s.motions.first()).map(|m| m.name.clone());
+                    let loops = w3d.info.loops;
+                    if let Some(motion_name) = first_motion {
+                        // Per-MODEL auto-play: seed the first motion into EACH skinned
+                        // model's own bonesPlayer entry. The dino animates only via
+                        // auto-play (its behavior never calls play()/rootLock), so its
+                        // pause()/resume() buttons must act on the SAME per-model state
+                        // the renderer reads — otherwise they hit a bare stub whose sync
+                        // clobbered the legacy clock (pause restarted, play froze).
+                        let skinned: Vec<String> = w3d.parsed_scene.as_ref().map(|s| {
+                            s.nodes.iter()
+                                .filter(|n| n.node_type == crate::director::chunks::w3d::types::W3dNodeType::Model)
+                                .filter(|n| {
+                                    let key = if !n.model_resource_name.is_empty() {
+                                        n.model_resource_name.as_str()
+                                    } else { n.resource_name.as_str() };
+                                    s.skeletons.iter().any(|sk| sk.name.eq_ignore_ascii_case(key) && sk.bones.len() > 1)
+                                })
+                                .map(|n| n.name.clone())
+                                .collect()
+                        }).unwrap_or_default();
+                        let any_skinned = !skinned.is_empty();
+                        for model in &skinned {
+                            let bp = w3d.runtime_state.bones_player_mut(model);
+                            if bp.current_motion.is_none() && !bp.animation_playing {
+                                bp.current_motion = Some(motion_name.clone());
+                                bp.animation_playing = true;
+                                bp.animation_loop = loops;
+                            }
+                        }
+                        // Legacy member-level auto-play for non-skinned (keyframe) content.
+                        if !any_skinned
+                            && !w3d.runtime_state.animation_playing
+                            && w3d.runtime_state.current_motion.is_none()
+                        {
+                            w3d.runtime_state.current_motion = Some(motion_name);
                             w3d.runtime_state.animation_playing = true;
-                            w3d.runtime_state.animation_loop = w3d.info.loops;
+                            w3d.runtime_state.animation_loop = loops;
                         }
                     }
                 }

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -1292,6 +1292,12 @@ impl WebGL2Renderer {
                                 .as_ref()
                                 .map(|fi| fi.paused_at_start)
                                 .unwrap_or(false);
+                            let asserted_frame = player
+                                .movie
+                                .score
+                                .get_sprite(channel_num)
+                                .and_then(|s| s.flash_asserted_frame)
+                                .unwrap_or(-1);
                             JsApi::dispatch_flash_member_loaded(
                                 channel_num as i32,
                                 member_ref.cast_lib,
@@ -1300,6 +1306,7 @@ impl WebGL2Renderer {
                                 w,
                                 h,
                                 paused_at_start,
+                                asserted_frame,
                             );
                             player.flash_sprite_loaded.insert(dispatch_key);
                         }

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -1114,6 +1114,13 @@ impl WebGL2Renderer {
                 font_id: Option<u16>,
                 line_spacing: u16,
                 top_spacing: i16,
+                /// The member's authored top_spacing (leading), BEFORE the
+                /// scroll fold-in that produces `top_spacing` above. Director
+                /// adds top_spacing as inter-line leading, NOT before the first
+                /// line, so the PFR anchor subtracts this to land the first
+                /// baseline at the strike ascent while keeping scroll
+                /// (`top_spacing - member_top_spacing == -scroll_top`).
+                member_top_spacing: i16,
                 bottom_spacing: i16,
                 width: u32,
                 height: u32,
@@ -1560,6 +1567,7 @@ impl WebGL2Renderer {
                         font_id: Some(font_member.font_info.font_id),
                         line_spacing: font_member.fixed_line_space,
                         top_spacing: font_member.top_spacing,
+                        member_top_spacing: font_member.top_spacing,
                         bottom_spacing: 0,
                         width,
                         height,
@@ -2193,6 +2201,7 @@ impl WebGL2Renderer {
                         font_id: None,
                         line_spacing: text_member.fixed_line_space,
                         top_spacing: effective_top_spacing,
+                        member_top_spacing: text_member.top_spacing,
                         bottom_spacing: text_member.bottom_spacing,
                         width,
                         height,
@@ -2555,6 +2564,7 @@ impl WebGL2Renderer {
                         font_id: field_member.font_id,
                         line_spacing: field_member.fixed_line_space,
                         top_spacing: effective_top_spacing,
+                        member_top_spacing: field_member.top_spacing,
                         bottom_spacing: 0,
                         width,
                         height,
@@ -2901,6 +2911,7 @@ impl WebGL2Renderer {
                 font_id,
                 line_spacing,
                 top_spacing,
+                member_top_spacing,
                 bottom_spacing,
                 width,
                 height,
@@ -2962,6 +2973,7 @@ impl WebGL2Renderer {
                         font_id,
                         line_spacing,
                         top_spacing,
+                        member_top_spacing,
                         bottom_spacing,
                         width,
                         height,
@@ -4810,6 +4822,7 @@ impl WebGL2Renderer {
         font_id: Option<u16>,
         line_spacing: u16,
         top_spacing: i16,
+        member_top_spacing: i16,
         bottom_spacing: i16,
         width: u32,
         height: u32,
@@ -4864,6 +4877,7 @@ impl WebGL2Renderer {
         let font_size = ((font_size as f64) * scale).round().max(1.0) as u16;
         let line_spacing = ((line_spacing as f64) * scale).round() as u16;
         let top_spacing = ((top_spacing as f64) * scale).round() as i16;
+        let member_top_spacing = ((member_top_spacing as f64) * scale).round() as i16;
         let bottom_spacing = ((bottom_spacing as f64) * scale).round() as i16;
         let styled_spans_scaled: Option<Vec<StyledSpan>> = styled_spans.map(|spans| {
             spans.iter().map(|s| {
@@ -5336,7 +5350,29 @@ impl WebGL2Renderer {
             // equal so behavior is unchanged.
             let max_width = width as i32;
             let wrap_max_width = wrap_width as i32;
-            let mut y = top_spacing as i32;
+            // PFR strikes: anchor the first line so its baseline lands at the
+            // strike's true ascent (Paige: baseline = lineTop + ascent), not at
+            // top_spacing + round(outlineAscender) which sits ~2px low. The atlas
+            // scan gives cap_top (empty rows above caps within a cell); the cell's
+            // baseline_row_px overstates ascent by exactly cap_top. Director also
+            // applies top_spacing as inter-line leading, NOT before the first
+            // line, so subtract member_top_spacing too — while `top_spacing`
+            // (effective = member_top_spacing - scroll) keeps any scroll offset:
+            //   y = top_spacing - member_top_spacing - cap_top = -scroll - cap_top.
+            let (pfr_cap_top, _pfr_desc_bottom) =
+                crate::player::font::pfr_strike_vertical_metrics(&font, font_bitmap);
+            // Anchor the atlas cell top at the line top (keeping the natural
+            // ascender-to-cap gap), matching the `.image` getter's PFR anchor
+            // (`Some(_) => 0`) so on-stage field/text sprites align with baked
+            // member.image text. Previously this subtracted `cap_top` (pulling
+            // the caps onto row 0), which renders ~cap_top px too HIGH — visible
+            // once Volter login fields render from the (gap-bearing) outline atlas
+            // at 18px: the text sat 2px high. `top_spacing - member_top_spacing`
+            // equals `-scroll` (0 when unscrolled), preserving any scroll offset.
+            let mut y = match pfr_cap_top {
+                Some(_) => top_spacing as i32 - member_top_spacing as i32,
+                None => top_spacing as i32,
+            };
             // Track max y of any glyph extent (including descender) across
             // both styled-multi and PFR-simple paths. Used to extend
             // `content_height_actual` so the texture trim doesn't clip
@@ -6775,6 +6811,11 @@ impl WebGL2Renderer {
     /// Get the canvas
     pub fn canvas(&self) -> &HtmlCanvasElement {
         &self.canvas
+    }
+
+    /// Get the preview canvas (used to rebuild the renderer on context restore)
+    pub fn preview_canvas(&self) -> &HtmlCanvasElement {
+        &self.preview_canvas
     }
 
     /// Get the size

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -10,7 +10,7 @@ pub mod context;
 mod geometry;
 pub mod mesh3d;
 pub mod scene3d;
-pub mod groove_scene;
+pub mod xtra_scene;
 mod shaders;
 mod texture_cache;
 
@@ -107,8 +107,9 @@ pub struct WebGL2Renderer {
     stage_image_texture: Option<web_sys::WebGlTexture>,
     /// Shockwave 3D scene renderer
     scene3d: scene3d::Scene3dRenderer,
-    /// 3D Groove Xtra scene renderer
-    groove: groove_scene::GrooveSceneRenderer,
+    /// Engine-agnostic external-Xtra 3D scene renderer (scene3d host API — used
+    /// by the Groove plugin and any future 3D xtra)
+    xtra_scenes: xtra_scene::XtraSceneRenderer,
     native_cursor_cache: crate::cursor::NativeCursorCache,
     /// Off-screen framebuffer for rendering nested `#movie` sub-players via the
     /// full WebGL2 pipeline (so they match the host's fidelity instead of the
@@ -198,7 +199,7 @@ impl WebGL2Renderer {
             trails_size: (0, 0),
             stage_image_texture: None,
             scene3d: scene3d::Scene3dRenderer::new(),
-            groove: groove_scene::GrooveSceneRenderer::new(),
+            xtra_scenes: xtra_scene::XtraSceneRenderer::new(),
             native_cursor_cache: None,
             nested_fbo: None,
             nested_fbo_texture: None,
@@ -745,12 +746,13 @@ impl WebGL2Renderer {
             self.render_sprite(player, *ch);
         }
 
-        // Draw the active 3D Groove Xtra world onto the stage (RenderToStage),
-        // on top of the 2D layer — like the directToStage 3D above.
+        // Draw external-Xtra 3D scenes (scene3d host API) onto the stage
+        // (RenderToStage), on top of the 2D layer — like the directToStage 3D
+        // above. The Groove plugin drives these.
         {
             let w = player.movie.rect.width() as i32;
             let h = player.movie.rect.height() as i32;
-            self.groove.draw(&self.context, player, w, h);
+            self.xtra_scenes.draw(&self.context, player, w, h);
             self.shader_manager.clear_active();
         }
 

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -4023,6 +4023,7 @@ impl WebGL2Renderer {
             || effective_ink == InkMode::AddPin
             || effective_ink == InkMode::SubPin
             || effective_ink == InkMode::Lighten
+            || effective_ink == InkMode::Reverse
         {
             if let Some(ref loc) = u_bg_color {
                 gl.uniform4f(

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -4129,7 +4129,7 @@ impl WebGL2Renderer {
     /// destructively strip artwork whose fill happens to equal the bg.
     /// Plain authored 32-bit bitmaps with embedded alpha (PNG imports) still
     /// need the color-key to make ink 36 actually do its job.
-    fn bitmap_to_rgba(
+    pub(crate) fn bitmap_to_rgba(
         bitmap: &Bitmap,
         palettes: &crate::player::bitmap::palette_map::PaletteMap,
         ink: i32,

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -107,6 +107,17 @@ pub struct WebGL2Renderer {
     /// Shockwave 3D scene renderer
     scene3d: scene3d::Scene3dRenderer,
     native_cursor_cache: crate::cursor::NativeCursorCache,
+    /// Off-screen framebuffer for rendering nested `#movie` sub-players via the
+    /// full WebGL2 pipeline (so they match the host's fidelity instead of the
+    /// lower-quality CPU rasterizer).
+    nested_fbo: Option<web_sys::WebGlFramebuffer>,
+    nested_fbo_texture: Option<web_sys::WebGlTexture>,
+    nested_fbo_size: (u32, u32),
+    /// Per-nested-player caches, swapped in around the sub's off-screen draw so
+    /// the host's texture/text caches (keyed by castLib:member, which collides
+    /// across players) and palette-version tracking are not corrupted or
+    /// thrashed. Keyed by nested player id.
+    nested_caches: HashMap<usize, (TextureCache, RenderedTextCache, u32)>,
 }
 
 impl WebGL2Renderer {
@@ -185,7 +196,142 @@ impl WebGL2Renderer {
             stage_image_texture: None,
             scene3d: scene3d::Scene3dRenderer::new(),
             native_cursor_cache: None,
+            nested_fbo: None,
+            nested_fbo_texture: None,
+            nested_fbo_size: (0, 0),
+            nested_caches: HashMap::new(),
         })
+    }
+
+    /// Ensure the nested off-screen FBO exists at `(width, height)` with an RGBA
+    /// color texture attachment. Recreated when the size changes.
+    fn ensure_nested_fbo(&mut self, width: u32, height: u32) {
+        if self.nested_fbo.is_some() && self.nested_fbo_size == (width, height) {
+            return;
+        }
+        let gl = self.context.gl();
+        if let Some(fbo) = self.nested_fbo.take() {
+            gl.delete_framebuffer(Some(&fbo));
+        }
+        if let Some(tex) = self.nested_fbo_texture.take() {
+            gl.delete_texture(Some(&tex));
+        }
+        let texture = gl.create_texture();
+        gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, texture.as_ref());
+        let _ = gl.tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array(
+            WebGl2RenderingContext::TEXTURE_2D,
+            0,
+            WebGl2RenderingContext::RGBA as i32,
+            width as i32,
+            height as i32,
+            0,
+            WebGl2RenderingContext::RGBA,
+            WebGl2RenderingContext::UNSIGNED_BYTE,
+            None,
+        );
+        gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MIN_FILTER, WebGl2RenderingContext::NEAREST as i32);
+        gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_MAG_FILTER, WebGl2RenderingContext::NEAREST as i32);
+        gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_S, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_T, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        let fbo = gl.create_framebuffer();
+        gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, fbo.as_ref());
+        gl.framebuffer_texture_2d(
+            WebGl2RenderingContext::FRAMEBUFFER,
+            WebGl2RenderingContext::COLOR_ATTACHMENT0,
+            WebGl2RenderingContext::TEXTURE_2D,
+            texture.as_ref(),
+            0,
+        );
+        gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+        gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, None);
+        self.nested_fbo = fbo;
+        self.nested_fbo_texture = texture;
+        self.nested_fbo_size = (width, height);
+    }
+
+    /// Render a nested `#movie` sub-player's stage through the full WebGL2
+    /// pipeline into the off-screen FBO, then read it back into a `Bitmap` for
+    /// compositing (same path the CPU rasterizer produced, but at WebGL2
+    /// fidelity). `owner_id` scopes the sub's texture/text caches so they don't
+    /// collide with the host's (both use castLib:member keys).
+    pub fn render_player_to_bitmap(
+        &mut self,
+        player: &mut DirPlayer,
+        owner_id: usize,
+        width: u32,
+        height: u32,
+    ) -> Bitmap {
+        self.ensure_nested_fbo(width, height);
+
+        // Swap in this sub-player's own caches + palette-version tracking so the
+        // shared host state (keyed by castLib:member, which overlaps) is neither
+        // returned in error nor cleared/thrashed by the alternating draws.
+        let (mut sub_tex, mut sub_text, sub_palette) = self
+            .nested_caches
+            .remove(&owner_id)
+            .unwrap_or_else(|| (TextureCache::new(), RenderedTextCache::new(), u32::MAX));
+        std::mem::swap(&mut self.texture_cache, &mut sub_tex);
+        std::mem::swap(&mut self.rendered_text_cache, &mut sub_text);
+        let saved_palette = self.last_palette_version;
+        self.last_palette_version = sub_palette;
+        let saved_size = self.size;
+        let saved_proj = self.projection_matrix;
+
+        // Point the pipeline at the off-screen FBO at the sub's stage size.
+        {
+            let gl = self.context.gl();
+            gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, self.nested_fbo.as_ref());
+            gl.viewport(0, 0, width as i32, height as i32);
+        }
+        self.size = (width, height);
+        self.projection_matrix = Self::create_ortho_matrix(width as f32, height as f32);
+
+        self.draw_frame(player);
+
+        // Read the rendered pixels back (RGBA, bottom-up → flip to top-down).
+        let mut pixels = vec![0u8; (width * height * 4) as usize];
+        {
+            let gl = self.context.gl();
+            gl.bind_framebuffer(WebGl2RenderingContext::READ_FRAMEBUFFER, self.nested_fbo.as_ref());
+            let _ = gl.read_pixels_with_opt_u8_array(
+                0, 0, width as i32, height as i32,
+                WebGl2RenderingContext::RGBA, WebGl2RenderingContext::UNSIGNED_BYTE,
+                Some(&mut pixels),
+            );
+        }
+        let row = (width * 4) as usize;
+        let mut flipped = vec![0u8; pixels.len()];
+        for y in 0..height as usize {
+            let src = (height as usize - 1 - y) * row;
+            let dst = y * row;
+            flipped[dst..dst + row].copy_from_slice(&pixels[src..src + row]);
+        }
+
+        // Restore host framebuffer / viewport / projection / caches.
+        {
+            let gl = self.context.gl();
+            gl.bind_framebuffer(WebGl2RenderingContext::FRAMEBUFFER, None);
+            gl.viewport(0, 0, saved_size.0 as i32, saved_size.1 as i32);
+        }
+        self.size = saved_size;
+        self.projection_matrix = saved_proj;
+        let sub_palette = self.last_palette_version;
+        self.last_palette_version = saved_palette;
+        std::mem::swap(&mut self.texture_cache, &mut sub_tex);
+        std::mem::swap(&mut self.rendered_text_cache, &mut sub_text);
+        self.nested_caches.insert(owner_id, (sub_tex, sub_text, sub_palette));
+
+        let mut bitmap = Bitmap::new(
+            width as u16,
+            height as u16,
+            32,
+            32,
+            8,
+            PaletteRef::BuiltIn(get_system_default_palette()),
+        );
+        bitmap.data = flipped;
+        bitmap.use_alpha = true;
+        bitmap
     }
 
     /// Create an orthographic projection matrix (column-major for WebGL)
@@ -641,6 +787,23 @@ impl WebGL2Renderer {
     }
 
     pub fn capture_stage_bitmap(&mut self, player: &mut DirPlayer) -> Bitmap {
+        // A nested `#movie` sub-player reads `(the stage).image` while running
+        // in the HOST GL context: framebuffer = host canvas, `self.size` = the
+        // host stage (e.g. 1190x575). Drawing `draw_frame(sub)` here would
+        // render the sub's sprites at host size onto the host framebuffer —
+        // the sub's wide scrolling background and its off-screen (x>stage-width)
+        // sprites smear across the whole host stage, unclipped. Render through
+        // the off-screen FBO at the sub's own stage size instead (same headless
+        // path as render_nested_player_stages).
+        let active = unsafe { crate::player::ACTIVE_PLAYER_ID };
+        if active != 0 {
+            let w = player.movie.rect.width().max(1) as u32;
+            let h = player.movie.rect.height().max(1) as u32;
+            let mut bmp = self.render_player_to_bitmap(player, active, w, h);
+            bmp.use_alpha = true;
+            return bmp;
+        }
+
         self.draw_frame(player);
 
         let (width, height) = self.size;
@@ -1274,7 +1437,17 @@ impl WebGL2Renderer {
         // to different poster frames of the same SWF simultaneously.
         {
             let dispatch_key = (channel_num, member_ref.cast_lib, member_ref.cast_member);
-            if !player.flash_sprite_loaded.contains(&dispatch_key) {
+            // Only the HOST dispatches Flash from the render path. A nested
+            // `#movie` sub-player's Flash lifecycle is owned SOLELY by its own
+            // `pre_dispatch_flash_members` (load + unload + reconcile, all in the
+            // sub's frame loop). Letting this render-path (which runs in the HOST
+            // loop during `render_nested_player_stages -> draw_frame(sub)`) also
+            // dispatch created TWO sources reading the sub's score at different
+            // playhead moments — they raced over flash_sprite_loaded and the
+            // Ruffle instance was create/destroy-thrashed, so its capture loop
+            // died before pushing a frame (sub Flash never showed).
+            let is_host = unsafe { crate::player::ACTIVE_PLAYER_ID } == 0;
+            if is_host && !player.flash_sprite_loaded.contains(&dispatch_key) {
                 if let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) {
                     if let CastMemberType::Flash(flash_member) = &member.member_type {
                         debug!(
@@ -2692,6 +2865,18 @@ impl WebGL2Renderer {
                             TextureSource::Bitmap { image_ref: bitmap_ref, is_flash: true }
                         }
                         _ => return, // Instance not ready yet; first frame hasn't arrived.
+                    }
+                }
+                CastMemberType::Movie(_) => {
+                    // Linked Movie (`#movie`): the sub-player's stage was rendered
+                    // into the host's bitmap_manager by `render_nested_player_stages`,
+                    // keyed by this member. Composite it like a Flash frame buffer
+                    // (a plain Director bitmap).
+                    match player.nested_movie_images.get(&member_ref).copied() {
+                        Some(image_ref) if image_ref != 0 => {
+                            TextureSource::Bitmap { image_ref, is_flash: false }
+                        }
+                        _ => return, // Sub-player stage not rendered yet.
                     }
                 }
                 CastMemberType::FilmLoop(film_loop) => {
@@ -4175,6 +4360,73 @@ impl WebGL2Renderer {
             None
         };
 
+        // FAST PATH — a plain Copy (ink 0) bitmap with no colorize / matte /
+        // mask / flash processing maps 1:1 to its pixels; ink-0 alpha is either
+        // the embedded byte (32-bit use_alpha) or a constant 255 (line ~4441).
+        // The general loop calls `get_pixel_color` + runs the ink branch-soup
+        // PER PIXEL — ~15ms for a 1000×1000 map / water viewport re-uploaded
+        // every frame (g349 scrolling). Convert in a tight loop instead;
+        // bit-identical output.
+        let colorize_active = matches!(colorize, Some((f, b, ..)) if f || b);
+        // Ink 36 (BgTransparent) on an indexed bitmap bakes its alpha as a plain
+        // per-pixel color-key: `(rgb == sprite_bg) ? 0 : 255` (line ~4529). Ink 0
+        // is fully opaque. Both are just a palette lookup + a trivial alpha rule
+        // — no matte/mask/colorize/flash — so a tight loop replaces the per-pixel
+        // `get_pixel_color` + branch soup that cost ~15ms for the map and ~4ms
+        // for each ink-36 tile every frame.
+        // ink 36's alpha handling differs for Flash captures (`is_flash_bitmap`
+        // skips the bgColor color-key, line ~4516), so only fast-path ink 36 for
+        // non-flash. ink 0 is identical either way (embedded alpha / 255), so it
+        // fast-paths regardless — this is what covers the game's large Flash
+        // captures (member 1:1 1000x1000, 1:13 1190x575) that cost ~21/10ms each.
+        let ink36_indexed_key = ink == 36 && !is_flash_bitmap
+            && bitmap.original_bit_depth >= 2 && bitmap.original_bit_depth <= 8;
+        if (ink == 0 || ink36_indexed_key)
+            && !colorize_active
+            && mask_bitmap.is_none()
+            && !should_use_matte
+            && computed_matte.is_none()
+        {
+            // 32-bit ink 0: RGBA bytes are already the output.
+            if ink == 0 && bitmap.bit_depth == 32 && bitmap.data.len() == width * height * 4 {
+                if bitmap.use_alpha {
+                    return bitmap.data.clone();
+                }
+                let mut out = bitmap.data.clone();
+                let mut i = 3;
+                while i < out.len() {
+                    out[i] = 255;
+                    i += 4;
+                }
+                return out;
+            }
+            // 8-bit indexed (ink 0 opaque, or ink 36 bg-color-keyed): pre-resolve
+            // the 256-entry palette once, then a tight index→RGBA loop.
+            if bitmap.bit_depth == 8 && bitmap.data.len() == width * height {
+                let mut pal = [(0u8, 0u8, 0u8); 256];
+                for (i, slot) in pal.iter_mut().enumerate() {
+                    *slot = resolve_color_ref(
+                        palettes,
+                        &ColorRef::PaletteIndex(i as u8),
+                        &bitmap.palette_ref,
+                        bitmap.original_bit_depth,
+                    );
+                }
+                let bg = sprite_bg_color.unwrap_or((255, 255, 255));
+                let mut out = vec![0u8; width * height * 4];
+                for (p, &idx) in bitmap.data.iter().enumerate() {
+                    let (r, g, b) = pal[idx as usize];
+                    let a = if ink36_indexed_key && (r, g, b) == bg { 0 } else { 255 };
+                    let o = p * 4;
+                    out[o] = r;
+                    out[o + 1] = g;
+                    out[o + 2] = b;
+                    out[o + 3] = a;
+                }
+                return out;
+            }
+        }
+
         let mut opaque_count = 0usize;
         let mut transparent_count = 0usize;
 
@@ -4661,7 +4913,11 @@ impl WebGL2Renderer {
     /// Check if ink mode requires matte computation
     /// Matches Canvas2D's should_matte_sprite function
     fn should_matte_sprite(ink: i32) -> bool {
-        ink == 3 || ink == 36 || ink == 33 || ink == 37 || ink == 39 || ink == 41 || ink == 8 || ink == 7  || ink == 32
+        // Only the flood-fill MATTE inks. Inks 3/33/35/36/37/39/40 use a shader
+        // (or baked) COLOR-KEY in bitmap_to_rgba, not the matte, so pre-computing
+        // a flood-fill matte for them was ~2.3ms/sprite of pure waste (g349's
+        // ink-36 tiles). See `should_use_matte` in bitmap_to_rgba.
+        ink == 41 || ink == 8 || ink == 7 || ink == 32
     }
 
     /// Get or create a texture for a bitmap member

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -430,6 +430,24 @@ impl WebGL2Renderer {
     }
 
     /// Draw the current frame
+    /// True if the sprite in `channel_num` is a Shockwave3D member with
+    /// directToStage enabled. Such sprites are composited directly to the screen
+    /// on top of the 2D layer, so they are deferred past the `(the stage).image`
+    /// overlay in draw_frame to keep the live 3D visible under a HUD blit.
+    fn is_direct_to_stage_3d(&self, player: &DirPlayer, channel_num: i16) -> bool {
+        let sprite = match player.movie.score.get_sprite(channel_num) {
+            Some(s) => s,
+            None => return false,
+        };
+        let member_ref = match &sprite.member {
+            Some(m) => m.clone(),
+            None => return false,
+        };
+        player.movie.cast_manager.find_member_by_ref(&member_ref)
+            .map(|m| matches!(&m.member_type, CastMemberType::Shockwave3d(w3d) if w3d.info.direct_to_stage))
+            .unwrap_or(false)
+    }
+
     pub fn draw_frame(&mut self, player: &mut DirPlayer) {
         self.frame_count += 1;
         // Increment sprite debug frame counter
@@ -495,8 +513,24 @@ impl WebGL2Renderer {
             self.draw_trails_texture();
         }
 
-        // Render each sprite
+        // Render each sprite.
+        //
+        // directToStage Shockwave3D sprites are drawn DIRECTLY to the screen, on
+        // top of the 2D layer (Director: directToStage ignores ink/blend and
+        // composites last). When a script has drawn into `(the stage).image`
+        // (`stage_image_dirty`), draw_stage_image_overlay blits that OPAQUE
+        // full-stage bitmap over the sprite output below — which would paste a
+        // frozen snapshot over the live, animating 3D (Splat draws a lives/score
+        // HUD into the stage image, freezing the maze view). Defer such sprites
+        // until after the overlay so the live 3D shows through; the HUD (drawn
+        // into a non-overlapping region) still composites underneath.
+        let overlay_active = player.stage_image_dirty && player.stage_image.is_some();
+        let mut deferred_dts_3d: Vec<i16> = Vec::new();
         for (channel_num, _) in &sorted_channels {
+            if overlay_active && self.is_direct_to_stage_3d(player, *channel_num) {
+                deferred_dts_3d.push(*channel_num);
+                continue;
+            }
             self.render_sprite(player, *channel_num);
         }
 
@@ -553,6 +587,13 @@ impl WebGL2Renderer {
         // for "imaging Lingo" movies that draw into `(the stage).image`
         // (see stage.rs `image` getter). Only once a script has drawn into it.
         self.draw_stage_image_overlay(player);
+
+        // Now draw the deferred directToStage 3D sprites ON TOP of the stage-image
+        // overlay (see the render loop above) so the live, animating 3D is visible
+        // even when a HUD has been blitted into `(the stage).image`.
+        for ch in &deferred_dts_3d {
+            self.render_sprite(player, *ch);
+        }
 
         // Update native CSS cursor (no per-frame draw needed)
         self.update_native_cursor(player);

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -2393,12 +2393,31 @@ impl WebGL2Renderer {
                                         Some(field_member.font.clone())
                                     }
                                 });
+                            // Per-run foreground color from the STXT run
+                            // (QuickDraw u16 channels → 8-bit). A pure-black
+                            // run (0,0,0) is Director's "unset/default" — leave
+                            // it None so it inherits the field's effective color
+                            // (sprite/member override, often navy). An explicit
+                            // non-black run color (e.g. the red "- 50 POINTS -
+                            // Get Stung!" line in SpongeBob's Scoring field)
+                            // overrides per-span. Packed 0xRRGGBB to match
+                            // HtmlStyle::color elsewhere.
+                            let run_color: Option<u32> = {
+                                let r = (run.color_r >> 8) as u32;
+                                let g = (run.color_g >> 8) as u32;
+                                let b = (run.color_b >> 8) as u32;
+                                if r == 0 && g == 0 && b == 0 {
+                                    None
+                                } else {
+                                    Some((r << 16) | (g << 8) | b)
+                                }
+                            };
                             spans.push(StyledSpan {
                                 text: span_text,
                                 style: HtmlStyle {
                                     font_face: span_font_face,
                                     font_size: span_font_size,
-                                    color: None,
+                                    color: run_color,
                                     bg_color: None,
                                     bold,
                                     italic,

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -1087,6 +1087,16 @@ impl WebGL2Renderer {
         if let Some(member) = player.movie.cast_manager.find_member_by_ref(&member_ref) {
             if matches!(member.member_type, CastMemberType::Flash(_)) {
                 blend = 100;
+            } else if matches!(member.member_type, CastMemberType::Shockwave3d(_)) && blend == 0 {
+                // A Shockwave3D member's sprite-level `blend` comes through as 0 when the
+                // score's D6+ "blend enabled" flag (sprite_flags & 0x10) is set over a
+                // junk-default raw byte (255 → convert_raw_blend → 0). blend=0 (fully
+                // transparent) is never intended for the main composited 3D view —
+                // Director renders these opaque (the FinalDrive / HavokCarDemo car movies
+                // came through black). Treat 0 as opaque so the scene shows. Mirrors the
+                // Flash force above (Shockwave's 2D compositor ignores sprite blend on
+                // these special composited members).
+                blend = 100;
             }
         }
 

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -10,6 +10,7 @@ pub mod context;
 mod geometry;
 pub mod mesh3d;
 pub mod scene3d;
+pub mod groove_scene;
 mod shaders;
 mod texture_cache;
 
@@ -106,6 +107,8 @@ pub struct WebGL2Renderer {
     stage_image_texture: Option<web_sys::WebGlTexture>,
     /// Shockwave 3D scene renderer
     scene3d: scene3d::Scene3dRenderer,
+    /// 3D Groove Xtra scene renderer
+    groove: groove_scene::GrooveSceneRenderer,
     native_cursor_cache: crate::cursor::NativeCursorCache,
     /// Off-screen framebuffer for rendering nested `#movie` sub-players via the
     /// full WebGL2 pipeline (so they match the host's fidelity instead of the
@@ -195,6 +198,7 @@ impl WebGL2Renderer {
             trails_size: (0, 0),
             stage_image_texture: None,
             scene3d: scene3d::Scene3dRenderer::new(),
+            groove: groove_scene::GrooveSceneRenderer::new(),
             native_cursor_cache: None,
             nested_fbo: None,
             nested_fbo_texture: None,
@@ -739,6 +743,15 @@ impl WebGL2Renderer {
         // even when a HUD has been blitted into `(the stage).image`.
         for ch in &deferred_dts_3d {
             self.render_sprite(player, *ch);
+        }
+
+        // Draw the active 3D Groove Xtra world onto the stage (RenderToStage),
+        // on top of the 2D layer — like the directToStage 3D above.
+        {
+            let w = player.movie.rect.width() as i32;
+            let h = player.movie.rect.height() as i32;
+            self.groove.draw(&self.context, player, w, h);
+            self.shader_manager.clear_active();
         }
 
         // Update native CSS cursor (no per-frame draw needed)
@@ -1458,8 +1471,14 @@ impl WebGL2Renderer {
                         );
                         if crate::rendering::has_swf_signature(&flash_member.data) {
                             let data = flash_member.data.clone();
-                            let w = sprite_width.max(1) as u32;
-                            let h = sprite_height.max(1) as u32;
+                            // Size the Ruffle capture from the resolved sprite rect
+                            // (which is the member's natural size when the sprite
+                            // isn't stretched — 626x100 for leo3d's "menue"), NOT
+                            // the raw score cell (100x320). Using the cell captured
+                            // the 626x100 SWF into a wrong-aspect canvas that
+                            // resampled to a thin strip in the corrected quad.
+                            let w = sprite_rect.width().max(1) as u32;
+                            let h = sprite_rect.height().max(1) as u32;
                             let paused_at_start = flash_member
                                 .flash_info
                                 .as_ref()

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -2427,7 +2427,7 @@ void main() {
 
         if let Some(gpu_data) = self.member_data.get(member_key) {
             let has_skeleton_data = self.setup_skinning_for_resource(
-                gl, shader, scene, resource, gpu_data, runtime_state,
+                gl, shader, scene, resource, &model_node.name, gpu_data, runtime_state,
             );
 
             let world_matrix = self.accumulate_transform_with_state(scene, model_node, runtime_state);
@@ -3916,12 +3916,15 @@ void main() {
     }
 
     /// Compute and upload bone matrices for skinning. Returns true if skinning data was uploaded.
+    /// `model_name` selects the per-model bonesPlayer state — each skinned model in a member
+    /// animates independently (multiple cloned bots in one G3D scene must not share a clock).
     fn setup_skinning_for_resource(
         &self,
         gl: &WebGl2RenderingContext,
         shader: &Shader3d,
         scene: &W3dScene,
         resource_name: &str,
+        model_name: &str,
         gpu_data: &MemberGpuData,
         runtime_state: Option<&crate::player::cast_member::Shockwave3dRuntimeState>,
     ) -> bool {
@@ -3952,9 +3955,20 @@ void main() {
         };
         let inv_bind = &inv_bind_fresh;
 
-        let current_motion_name = runtime_state.and_then(|rs| rs.current_motion.as_deref());
-        let is_loop = runtime_state.map(|rs| rs.animation_loop).unwrap_or(true);
-        let root_lock = runtime_state.map(|rs| rs.root_lock).unwrap_or(false);
+        // Per-MODEL bonesPlayer state is the source of truth ONCE a motion has been
+        // play()'d on that model. A bare entry created only by a setter (rootLock /
+        // playRate, e.g. the dino) has no motion and a frozen clock — treat it as
+        // absent so we fall back ENTIRELY to the legacy member fields (auto-play +
+        // the advancing legacy clock). Otherwise its frozen time=0 shadowed the
+        // legacy clock and the model rendered stuck on frame 0.
+        let bp = runtime_state.and_then(|rs| rs.bones_player(model_name))
+            .filter(|b| b.current_motion.is_some());
+        let current_motion_name = bp.and_then(|b| b.current_motion.as_deref())
+            .or_else(|| runtime_state.and_then(|rs| rs.current_motion.as_deref()));
+        let is_loop = bp.map(|b| b.animation_loop)
+            .or_else(|| runtime_state.map(|rs| rs.animation_loop)).unwrap_or(true);
+        let root_lock = bp.map(|b| b.root_lock)
+            .or_else(|| runtime_state.map(|rs| rs.root_lock)).unwrap_or(false);
         let motion = if let Some(name) = current_motion_name {
             scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(name))
         } else {
@@ -3965,10 +3979,12 @@ void main() {
         if motion.map(|m| m.tracks.len() < min_tracks).unwrap_or(true) {
             return false;
         }
-        let time = self.animation_time;
+        let time = bp.map(|b| b.animation_time).unwrap_or(self.animation_time);
         let duration = motion.map(|m| m.duration()).unwrap_or(0.0);
-        let end_time = runtime_state.map(|rs| rs.animation_end_time).unwrap_or(-1.0);
-        let start_time = runtime_state.map(|rs| rs.animation_start_time).unwrap_or(0.0);
+        let end_time = bp.map(|b| b.animation_end_time)
+            .or_else(|| runtime_state.map(|rs| rs.animation_end_time)).unwrap_or(-1.0);
+        let start_time = bp.map(|b| b.animation_start_time)
+            .or_else(|| runtime_state.map(|rs| rs.animation_start_time)).unwrap_or(0.0);
         let eff_end = if end_time >= 0.0 { (end_time).min(duration) } else { duration };
         let eff_start = start_time.min(eff_end);
         let range = eff_end - eff_start;
@@ -3983,9 +3999,10 @@ void main() {
             skeleton, motion, t, root_lock,
         );
 
-        // Check for motion blending (crossfade) — use renderer's local blend state
-        let blend_weight = self.blend_weight;
-        let prev_motion_name = runtime_state.and_then(|rs| rs.previous_motion.as_deref());
+        // Check for motion blending (crossfade) — per-model blend state.
+        let blend_weight = bp.map(|b| b.blend_weight).unwrap_or(self.blend_weight);
+        let prev_motion_name = bp.and_then(|b| b.previous_motion.as_deref())
+            .or_else(|| runtime_state.and_then(|rs| rs.previous_motion.as_deref()));
         let blending = blend_weight < 1.0 && prev_motion_name.is_some();
 
         let bone_count = skeleton.bones.len().min(48);

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -4077,9 +4077,28 @@ void main() {
         } else {
             None // Don't apply a motion until the game explicitly calls play()
         };
-        // Skip skinning if motion has too few tracks for the skeleton
+        // Manual per-bone overrides (bonesPlayer.bone[i].transform = t), keyed by
+        // "modelname:boneindex". updateBoneRotation re-sets these each frame to
+        // animate procedurally (the SweeTarts snake's S-wiggle), so we must skin
+        // even when the played motion is sparse or absent.
+        let bone_overrides: std::collections::HashMap<usize, [f32; 16]> = runtime_state
+            .map(|rs| {
+                let prefix = format!("{}:", model_name.to_ascii_lowercase());
+                rs.bone_transform_overrides.iter()
+                    .filter_map(|(k, v)| {
+                        k.strip_prefix(&prefix)
+                            .and_then(|i| i.parse::<usize>().ok())
+                            .map(|i| (i, *v))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        // Skip skinning if motion has too few tracks for the skeleton — unless
+        // manual bone overrides are driving the pose.
         let min_tracks = (skeleton.bones.len() / 2).max(2);
-        if motion.map(|m| m.tracks.len() < min_tracks).unwrap_or(true) {
+        if bone_overrides.is_empty()
+            && motion.map(|m| m.tracks.len() < min_tracks).unwrap_or(true)
+        {
             return false;
         }
         let time = bp.map(|b| b.animation_time).unwrap_or(self.animation_time);
@@ -4100,6 +4119,7 @@ void main() {
         } else { 0.0 };
         let world_matrices = crate::director::chunks::w3d::skeleton::build_bone_matrices_ex(
             skeleton, motion, t, root_lock,
+            if bone_overrides.is_empty() { None } else { Some(&bone_overrides) },
         );
 
         // [root-relativize] Director keeps a 3ds-Max biped's ROOT at identity IN THE SKIN
@@ -4162,6 +4182,7 @@ void main() {
             let prev_motion = prev_motion_name.and_then(|n| scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(n)));
             let prev_matrices = crate::director::chunks::w3d::skeleton::build_bone_matrices_ex(
                 skeleton, prev_motion, t, root_lock,
+                if bone_overrides.is_empty() { None } else { Some(&bone_overrides) },
             );
             for i in 0..bone_count {
                 let cur_rel = mat4_multiply_col_major(&root_relinv, &world_matrices[i]);

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -551,10 +551,13 @@ void main() {
                     float dist = length(light_dir);
                     L = light_dir / dist;
                     atten = 1.0 / (u_light_atten[i].x + u_light_atten[i].y * dist + u_light_atten[i].z * dist * dist);
-                    // Spot light cone attenuation
+                    // Spot light cone attenuation. Director's spotAngle is the
+                    // HALF-cone angle (dict: "corresponds to half the angle; for a
+                    // 90° angle pass 45.0"), so the cone edge is cos(spotAngle) — do
+                    // NOT halve it again.
                     if (u_light_spot_angle[i] > 0.0) {
                         float spot_cos = dot(normalize(-light_dir), u_light_dir[i]);
-                        float cone_cos = cos(u_light_spot_angle[i] * 0.5);
+                        float cone_cos = cos(u_light_spot_angle[i]);
                         if (spot_cos < cone_cos) atten = 0.0;
                         else atten *= smoothstep(cone_cos, cone_cos + 0.1, spot_cos);
                     }
@@ -642,7 +645,14 @@ void main() {
                     vec3 light_dir = u_light_pos[i] - v_position;
                     float dist = length(light_dir);
                     L = light_dir / dist;
-                    atten = 1.0 / (1.0 + 0.01 * dist + 0.0001 * dist * dist);
+                    atten = 1.0 / (u_light_atten[i].x + u_light_atten[i].y * dist + u_light_atten[i].z * dist * dist);
+                    // Spot cone (spotAngle = half-cone angle, per Director dict).
+                    if (u_light_spot_angle[i] > 0.0) {
+                        float spot_cos = dot(normalize(-light_dir), u_light_dir[i]);
+                        float cone_cos = cos(u_light_spot_angle[i]);
+                        if (spot_cos < cone_cos) atten = 0.0;
+                        else atten *= smoothstep(cone_cos, cone_cos + 0.1, spot_cos);
+                    }
                 }
 
                 // Two-sided lighting: use abs(N·L) so back faces also receive light
@@ -4274,20 +4284,16 @@ void main() {
         let mut global_ambient = [0.0f32, 0.0, 0.0];
         let mut num_lights = 0i32;
 
-        // One-time light diagnostic
-        {
-            use std::sync::atomic::{AtomicBool, Ordering};
-            static LOGGED: AtomicBool = AtomicBool::new(false);
-            if !LOGGED.swap(true, Ordering::Relaxed) {
-                let light_info: Vec<String> = scene.lights.iter().map(|l| {
-                    format!("{}({:?}, color=[{:.2},{:.2},{:.2}])", l.name, l.light_type, l.color[0], l.color[1], l.color[2])
-                }).collect();
-                log(&format!(
-                    "[W3D-LIGHTS] {} lights: {:?}",
-                    scene.lights.len(), light_info
-                ));
-            }
-        }
+        // dirplayer injects fallback default lights (Default*/UI*) so an unlit scene
+        // is still visible. When the movie supplies its OWN directional/spot lighting
+        // (e.g. frog01's spot/spot2), those synthetic fallbacks flood the scene and
+        // wash out the intended mood — so suppress them in that case. Baked content
+        // lights (e.g. AmbientLightResource from the .w3d) are kept.
+        let is_fallback_light = |name: &str| matches!(name,
+            "DefaultAmbient" | "DefaultDirectional" | "UIAmbient" | "UIDirectional");
+        let has_movie_light = scene.lights.iter().any(|l|
+            l.enabled && !is_fallback_light(&l.name)
+            && matches!(l.light_type, W3dLightType::Directional | W3dLightType::Spot));
 
         if scene.lights.is_empty() {
             // Default: one directional light from above-right
@@ -4318,6 +4324,10 @@ void main() {
 
             for light in &sorted_lights {
                 if !light.enabled {
+                    continue;
+                }
+                // Suppress dirplayer's synthetic fallback lights when the movie lights itself.
+                if has_movie_light && is_fallback_light(&light.name) {
                     continue;
                 }
                 // Skip lights that have been removed from world

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -386,6 +386,12 @@ void main() {
 
         let fs_source = r#"#version 300 es
 precision mediump float;
+// Fragment shaders default `int` to mediump, but vertex shaders default it to
+// highp. A uniform shared across both stages must match precision or GLSL ES
+// linking fails ("Uniform `u_texcoord2_direct` is not linkable between attached
+// shaders" — Firefox enforces this; Chrome/ANGLE silently tolerates it). Force
+// highp int here so every shared int uniform matches the VS default.
+precision highp int;
 
 in vec3 v_position;
 in vec3 v_normal;

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -1238,7 +1238,7 @@ void main() {
                 } else {
                     None
                 };
-                let buffers = Mesh3dBuffers::new_full(
+                let mut buffers = Mesh3dBuffers::new_full(
                     context,
                     &mesh.positions,
                     &mesh.normals,
@@ -1249,6 +1249,13 @@ void main() {
                     bw_opt,
                     vc_opt,
                 )?;
+                // A file-provided 2nd UV set is a lightmap/shadowmap atlas coord in
+                // [0,1], NOT pre-centered like the base set, so it must bypass the CLOD
+                // (u+0.5, 0.5-v) remap. Without this it shifts to ~[0.5,1.5] and the
+                // forced CLAMP smears the lightmap's edge across the whole surface.
+                if tc2.is_some() {
+                    buffers.texcoord2_direct = true;
+                }
                 group.push(buffers);
             }
             mesh_groups.insert(name.clone(), group);

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -66,6 +66,7 @@ struct Shader3d {
     u_emissive_color: Option<WebGlUniformLocation>,
     u_shininess: Option<WebGlUniformLocation>,
     u_opacity: Option<WebGlUniformLocation>,
+    u_alpha_threshold: Option<WebGlUniformLocation>,
     u_diffuse_tex: Option<WebGlUniformLocation>,
     u_has_texture: Option<WebGlUniformLocation>,
     u_lightmap_tex: Option<WebGlUniformLocation>,
@@ -397,6 +398,10 @@ uniform vec4 u_specular_color;
 uniform vec4 u_emissive_color;
 uniform float u_shininess;
 uniform float u_opacity;
+// Alpha-test threshold for cutout (opaque-but-alpha-textured) models drawn in the
+// opaque pass: discard texels below this so they write neither colour nor depth.
+// 0 disables the test (default / blended-transparent paths).
+uniform float u_alpha_threshold;
 uniform sampler2D u_diffuse_tex;
 uniform int u_has_texture;
 uniform sampler2D u_lightmap_tex;
@@ -505,10 +510,24 @@ vec3 apply_fog(vec3 color) {
 }
 
 void main() {
+    // A fully-transparent material (frog01's `clearS`, blend 0 → opacity 0) is
+    // invisible, but in the opaque/cutout pass (depth_mask ON) it would still write
+    // DEPTH — an invisible depth wall that culls everything behind it. The game-over
+    // `back` wall's clearS face sits ~2.5u in front of the camera and covers the
+    // upper view, so it was depth-hiding the banner / side walls / far logs behind it
+    // (they showed in play because the camera wasn't behind that face). Discard it so
+    // it writes neither colour nor depth. (Genuine translucency like water2 blend=50 →
+    // opacity 0.5 is untouched.)
+    if (u_opacity < 0.004) discard;
     vec3 N = normalize(v_normal);
     vec3 V = normalize(u_camera_pos - v_position);
 
     vec4 tex_sample = texture(u_diffuse_tex, v_texcoord);
+
+    // Alpha-test cutout: opaque models whose texture carries alpha (e.g. frog01's
+    // Flash bark/leaf textures) are drawn in the opaque pass; discard transparent
+    // texels so they don't write depth and aren't sorted as translucent.
+    if (u_alpha_threshold > 0.0 && tex_sample.a < u_alpha_threshold) discard;
 
     // When textured: GL_MODULATE mode = texture * vertex_lighting
     // IFX default: UseDiffuse=OFF → material diffuse forced to white (1,1,1)
@@ -689,6 +708,7 @@ void main() {
             u_emissive_color: u("u_emissive_color"),
             u_shininess: u("u_shininess"),
             u_opacity: u("u_opacity"),
+            u_alpha_threshold: u("u_alpha_threshold"),
             u_diffuse_tex: u("u_diffuse_tex"),
             u_has_texture: u("u_has_texture"),
             u_lightmap_tex: u("u_lightmap_tex"),
@@ -1854,8 +1874,15 @@ void main() {
                 // No model nodes — fallback: draw all meshes with identity transform
                 self.draw_all_meshes_fallback(gl, shader, scene, &member_key);
             } else {
-                // Classify nodes into opaque and transparent for proper rendering order
+                // Classify nodes into opaque, cutout, and transparent for proper order.
+                // - opaque (material opacity ≥ 1, no alpha texture): pass 1, depth write.
+                // - cutout (opacity ≥ 1 but the texture carries alpha, e.g. frog01's
+                //   Flash bark/leaf textures): pass 1b, alpha-tested, depth write — so it
+                //   occludes the translucent water planes instead of being sorted behind
+                //   them (the logs were turning blue when they drifted off-centre).
+                // - transparent (opacity < 1, e.g. water2 blend=50): pass 2, back-to-front.
                 let mut transparent_nodes: Vec<(&W3dNode, f32)> = Vec::new(); // (node, distance_to_camera)
+                let mut cutout_nodes: Vec<&W3dNode> = Vec::new();
 
                 // Sort: skybox nodes first so they render before scene geometry
                 let mut sorted_model_nodes: Vec<&W3dNode> = model_nodes.iter().copied().collect();
@@ -1864,6 +1891,7 @@ void main() {
                 });
 
                 // PASS 1: Render opaque geometry (skybox first, then scene)
+                gl.uniform1f(shader.u_alpha_threshold.as_ref(), 0.0);
                 for model_node in &sorted_model_nodes {
                     if let Some(rs) = runtime_state {
                         if let Some(&vis_mode) = rs.node_visibility.get(&model_node.name) {
@@ -1889,9 +1917,9 @@ void main() {
                             }
                         }
                     }
-                    let has_alpha_tex = self.model_has_alpha_texture(scene, model_node, &member_key, runtime_state);
-                    if opacity < 0.999 || has_alpha_tex {
-                        // Defer to transparent pass — compute distance for sorting
+                    if opacity < 0.999 {
+                        // Genuinely translucent → defer to the transparent pass, sorted
+                        // by camera distance.
                         let world_matrix = self.accumulate_transform_with_state(scene, model_node, runtime_state);
                         let dx = world_matrix[12] - camera_pos[0];
                         let dy = world_matrix[13] - camera_pos[1];
@@ -1899,8 +1927,26 @@ void main() {
                         transparent_nodes.push((model_node, dx*dx + dy*dy + dz*dz));
                         continue;
                     }
+                    if self.model_has_alpha_texture(scene, model_node, &member_key, runtime_state) {
+                        // Opaque material but alpha-keyed texture → cutout (alpha-tested
+                        // opaque draw); keep depth writes so it occludes translucent water.
+                        cutout_nodes.push(model_node);
+                        continue;
+                    }
 
                     self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, false);
+                }
+
+                // PASS 1b: Cutout geometry — opaque pass with alpha-test discard so
+                // transparent texels write neither colour nor depth (hard edges, but
+                // correct occlusion vs. the translucent water planes).
+                if !cutout_nodes.is_empty() {
+                    gl.depth_mask(true);
+                    gl.uniform1f(shader.u_alpha_threshold.as_ref(), 0.5);
+                    for model_node in &cutout_nodes {
+                        self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, false);
+                    }
+                    gl.uniform1f(shader.u_alpha_threshold.as_ref(), 0.0);
                 }
 
                 // PASS 2: Render transparent geometry (back-to-front, no depth writes)
@@ -2325,16 +2371,26 @@ void main() {
         };
 
         let mut chain = vec![node_transform];
-        let mut current_parent = &node.parent_name;
+        let mut current_parent = node.parent_name.as_str();
 
-        // Walk up parent chain
-        while !current_parent.is_empty() && current_parent != "<world>" {
-            if let Some(parent_node) = scene.nodes.iter().find(|n| n.name == *current_parent) {
+        // Walk up parent chain. Director node names are case-insensitive, and
+        // get_runtime_transform already looks them up that way — but the parent
+        // NODE lookup must match it. A case-sensitive `==` here fails to find a
+        // parent whose stored name differs in case from the child's parent_name
+        // (cloneModelFromCastmember preserves the SOURCE member's casing for
+        // re-parented sub-nodes), which silently breaks the chain and renders the
+        // node at its raw local transform — e.g. the frog's deep limb hierarchy
+        // (frog→axe→body→lhip→ll→…→lf) collapsing toward the origin.
+        while !current_parent.is_empty()
+            && !current_parent.eq_ignore_ascii_case("world")
+            && current_parent != "<world>"
+        {
+            if let Some(parent_node) = scene.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(current_parent)) {
                 let parent_t = runtime_state
                     .and_then(|rs| get_runtime_transform(rs, &parent_node.name))
                     .unwrap_or(parent_node.transform);
                 chain.push(parent_t);
-                current_parent = &parent_node.parent_name;
+                current_parent = parent_node.parent_name.as_str();
             } else {
                 break;
             }
@@ -2491,7 +2547,17 @@ void main() {
 
     /// Get the opacity of a model node's material (for transparency sorting).
     /// Look up a per-model shader override.  Returns the first available:
-    /// mesh-specific index → index 0 fallback → None.
+    /// mesh-specific index → index 0 fallback → lowest set index → None.
+    ///
+    /// The lowest-set-index fallback handles Director's 2-sided #plane idiom:
+    /// a plane has a front (mesh 0) and back (mesh 1) face, and movies texture
+    /// only the face that points at the camera after the model's rotation —
+    /// e.g. frog01's water does `model("water").shaderList[2] = waterS` (1-based
+    /// → index 1) and leaves shaderList[1] unset. Because the water is rotated
+    /// -90° about X, the VISIBLE face is mesh 0, which would otherwise resolve to
+    /// no override and render the default checker. Falling back to any set shader
+    /// puts the intended texture on the visible face. Models that set index 0
+    /// (whole-list assignment) or every index are unaffected.
     fn node_shader_override<'a>(
         rs: &'a crate::player::cast_member::Shockwave3dRuntimeState,
         node_name: &str,
@@ -2500,6 +2566,7 @@ void main() {
         rs.node_shaders.get(node_name).and_then(|m| {
             mesh_idx.and_then(|idx| m.get(&idx))
                 .or_else(|| m.get(&0))
+                .or_else(|| m.iter().min_by_key(|(k, _)| **k).map(|(_, v)| v))
         })
     }
 
@@ -3687,6 +3754,24 @@ void main() {
         for binding in &res_info.shader_bindings {
             if mesh_idx < binding.mesh_bindings.len() && !binding.mesh_bindings[mesh_idx].is_empty() {
                 candidate_names.push(binding.mesh_bindings[mesh_idx].clone());
+            }
+        }
+
+        // If this mesh slot has no explicit shader, inherit the lowest-indexed
+        // mesh's shader BEFORE falling back to the resource's auto-generated
+        // "<res>_Shader" default. Director's #plane is 2 meshes; a resource that
+        // carries a single shader (e.g. frog01's cloned wheel: shaderList[1]=wheelS)
+        // puts it on mesh 0 only, leaving mesh 1's binding empty. Director shows the
+        // same shader on both faces ([wheelS, wheelS]); without this, dirplayer's
+        // mesh 1 fell back to the default shader (checker/untextured), so the
+        // camera-facing wheel face rendered with no wheel texture → "no wheels".
+        // Mirrors node_shader_override's lowest-index fallback for the resource path.
+        if candidate_names.is_empty() {
+            for binding in &res_info.shader_bindings {
+                if let Some(first) = binding.mesh_bindings.iter().find(|b| !b.is_empty()) {
+                    candidate_names.push(first.clone());
+                    break;
+                }
             }
         }
 

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -2011,7 +2011,7 @@ void main() {
                         continue;
                     }
 
-                    self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, false);
+                    self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, &view_matrix, &projection_matrix, false);
                 }
 
                 // PASS 1b: Cutout geometry — opaque pass with alpha-test discard so
@@ -2021,7 +2021,7 @@ void main() {
                     gl.depth_mask(true);
                     gl.uniform1f(shader.u_alpha_threshold.as_ref(), 0.5);
                     for model_node in &cutout_nodes {
-                        self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, false);
+                        self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, &view_matrix, &projection_matrix, false);
                     }
                     gl.uniform1f(shader.u_alpha_threshold.as_ref(), 0.0);
                 }
@@ -2034,7 +2034,7 @@ void main() {
                     gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
 
                     for (model_node, _dist) in &transparent_nodes {
-                        self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, true);
+                        self.draw_model_node(gl, shader, scene, model_node, &member_key, runtime_state, &view_matrix, &projection_matrix, true);
                     }
 
                     gl.depth_mask(true);
@@ -2516,6 +2516,8 @@ void main() {
         model_node: &W3dNode,
         member_key: &(i32, i32),
         runtime_state: Option<&crate::player::cast_member::Shockwave3dRuntimeState>,
+        view_matrix: &[f32; 16],
+        projection_matrix: &[f32; 16],
         force_blend: bool,
     ) {
         let resource = if !model_node.model_resource_name.is_empty() {
@@ -2568,6 +2570,24 @@ void main() {
             vis_mode = if is_skybox {
                 gl.disable(WebGl2RenderingContext::CULL_FACE);
                 gl.depth_mask(false);
+                // Rasterwerks draws its skybox through a dedicated sky camera
+                // (rootNode = detached "NodeSkyBox") so it's parallax-free and never
+                // clipped. Approximate that inline: strip the view translation so the
+                // cube is camera-centered (no parallax), and extend the far plane —
+                // the cube is scaled to 32000 (faces at ±16000), far beyond the main
+                // camera's far plane, so it was being clipped to nothing.
+                let mut sky_view = *view_matrix;
+                sky_view[12] = 0.0;
+                sky_view[13] = 0.0;
+                sky_view[14] = 0.0;
+                gl.uniform_matrix4fv_with_f32_array(shader.u_view.as_ref(), false, &sky_view);
+                let near = projection_matrix[14] / (projection_matrix[10] - 1.0);
+                let far = 200000.0f32;
+                let nf = 1.0 / (near - far);
+                let mut sky_proj = *projection_matrix;
+                sky_proj[10] = (far + near) * nf;
+                sky_proj[14] = 2.0 * far * near * nf;
+                gl.uniform_matrix4fv_with_f32_array(shader.u_projection.as_ref(), false, &sky_proj);
                 3u8
             } else {
                 let mode = runtime_state
@@ -2641,6 +2661,9 @@ void main() {
             gl.enable(WebGl2RenderingContext::CULL_FACE);
             gl.cull_face(WebGl2RenderingContext::FRONT); // restore default
             gl.depth_mask(true);
+            // Restore the world view/projection for subsequent (non-skybox) models.
+            gl.uniform_matrix4fv_with_f32_array(shader.u_view.as_ref(), false, view_matrix);
+            gl.uniform_matrix4fv_with_f32_array(shader.u_projection.as_ref(), false, projection_matrix);
         } else if vis_mode >= 2 {
             // Restore default culling after #back or #both
             gl.enable(WebGl2RenderingContext::CULL_FACE);

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -2126,15 +2126,23 @@ void main() {
             let cos_r = rot_rad.cos();
             let sin_r = rot_rad.sin();
 
-            // 2D transform: Scale → Rotate → Translate (with regPoint offset)
+            // 2D transform: Scale → Rotate → Translate (with regPoint offset).
+            // Director's camera.overlay[n].regPoint is in SCALED/destination pixels,
+            // NOT source-texture pixels: e.g. Rasterwerks' rifle scope reticle sets
+            // reg = GetScale(#center) = texCenter × scale (= 256×128 × 3.06 = 783×392)
+            // so the screen rect is `loc - regPoint .. loc - regPoint + texSize×scale`,
+            // centred on loc. The reg term must therefore NOT be multiplied by the
+            // scale again — doing so pushed the scaled reticle far off-screen while
+            // every scale=1 HUD layer (rx*sx == rx) was unaffected, so only the scope
+            // tube vanished. translate = loc − R·regPoint.
             let sw = sx * tex_w;
             let sh = sy * tex_h;
             let model: [f32; 16] = [
                 cos_r * sw, sin_r * sw, 0.0, 0.0,
                -sin_r * sh, cos_r * sh, 0.0, 0.0,
                 0.0,        0.0,        1.0, 0.0,
-                x - rx * sx * cos_r + ry * sy * sin_r,
-                y - rx * sx * sin_r - ry * sy * cos_r,
+                x - rx * cos_r + ry * sin_r,
+                y - rx * sin_r - ry * cos_r,
                 0.0, 1.0,
             ];
             gl.uniform_matrix4fv_with_f32_array(shader.u_model.as_ref(), false, &model);

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -197,6 +197,11 @@ pub struct Scene3dRenderer {
     logged_members: std::collections::HashSet<(i32, i32)>,
     animation_time: f32,
     motion_transforms: HashMap<String, [f32; 16]>,
+    /// Single-track keyframe (object) motions that REPLACE a node's local
+    /// transform — Director keyframePlayer semantics: the keyframe stores the
+    /// node's full local transform, so it overrides the base rather than
+    /// multiplying onto it (motion_transforms). Used by the multi-player path.
+    motion_replace_transforms: HashMap<String, [f32; 16]>,
     pub active_camera: Option<String>,
     /// Set when a non-looping motion reaches its end — caller should advance the queue
     pub motion_ended: bool,
@@ -263,6 +268,7 @@ impl Scene3dRenderer {
             logged_members: std::collections::HashSet::new(),
             animation_time: 0.0,
             motion_transforms: HashMap::new(),
+            motion_replace_transforms: HashMap::new(),
             active_camera: None,
             motion_ended: false,
             last_motion_name: None,
@@ -1155,7 +1161,7 @@ void main() {
                 continue; // Skip light cone/sphere meshes
             }
             let mut group = Vec::new();
-            for (mi, mesh) in decoded_meshes.iter().enumerate() {
+            for mesh in decoded_meshes.iter() {
                 if mesh.positions.is_empty() || mesh.faces.is_empty() {
                     continue;
                 }
@@ -1804,7 +1810,54 @@ void main() {
 
             // Evaluate motion animations each frame
             self.motion_transforms.clear();
-            if !scene.motions.is_empty() {
+            self.motion_replace_transforms.clear();
+            let multi_player = runtime_state.map(|rs| rs.bones_players.len() > 1).unwrap_or(false);
+            if !scene.motions.is_empty() && multi_player {
+                // Multiple per-model keyframe/bones players animating at once
+                // (Splat pac-man: footA plays "footA-Key", footB plays "footB-Key").
+                // The single member-level current_motion can only carry one, so apply
+                // EACH model's own motion at its own clock. A single-track object
+                // keyframe motion is applied to the model the player is on (so
+                // identically-sourced clones with different names still animate);
+                // a multi-track skeletal motion applies each track to its named bone.
+                if let Some(rs) = runtime_state {
+                    for (model_name, bp) in &rs.bones_players {
+                        if !bp.animation_playing { continue; }
+                        let motion_name = match &bp.current_motion { Some(m) => m, None => continue };
+                        let motion = match scene.motions.iter().find(|m| m.name.eq_ignore_ascii_case(motion_name)) {
+                            Some(m) => m, None => continue,
+                        };
+                        let duration = motion.duration();
+                        let eff_end = if bp.animation_end_time >= 0.0 { bp.animation_end_time.min(duration) } else { duration };
+                        let eff_start = bp.animation_start_time.min(eff_end);
+                        let range = eff_end - eff_start;
+                        if range <= 0.0 { continue; }
+                        let t = if bp.animation_loop {
+                            eff_start + ((bp.animation_time - eff_start) % range + range) % range
+                        } else {
+                            bp.animation_time.clamp(eff_start, eff_end)
+                        };
+                        let apply_to_model = motion.tracks.len() == 1;
+                        for track in &motion.tracks {
+                            let mut kf = track.evaluate(t);
+                            if kf.scale_x.abs() < 1e-6 { kf.scale_x = 1.0; }
+                            if kf.scale_y.abs() < 1e-6 { kf.scale_y = 1.0; }
+                            if kf.scale_z.abs() < 1e-6 { kf.scale_z = 1.0; }
+                            let m = keyframe_to_column_major_matrix(&kf);
+                            if apply_to_model {
+                                // Single-track object keyframe → replace the model's local transform.
+                                // Key by lowercase: bones_players keys are lowercased but scene node
+                                // names keep their original case (e.g. "footA"), so the node-draw
+                                // lookup must match case-insensitively or the feet never animate.
+                                self.motion_replace_transforms.insert(model_name.to_ascii_lowercase(), m);
+                            } else {
+                                // Multi-track skeletal → multiply each track onto its bone.
+                                self.motion_transforms.insert(track.bone_name.clone(), m);
+                            }
+                        }
+                    }
+                }
+            } else if !scene.motions.is_empty() {
                 // Determine which motion to play: use runtime current_motion, or fallback to first
                 let is_playing = runtime_state.map(|rs| rs.animation_playing).unwrap_or(true);
                 let play_rate = runtime_state.map(|rs| rs.play_rate).unwrap_or(1.0);
@@ -2374,7 +2427,17 @@ void main() {
 
         // Get this node's transform: motion (combined with base), runtime override, or parsed
         let node_transform = if allow_motion_override {
-            if let Some(motion_t) = self.motion_transforms.get(&node.name) {
+            if let Some(km) = (!self.motion_replace_transforms.is_empty())
+                .then(|| self.motion_replace_transforms.get(&node.name.to_ascii_lowercase()))
+                .flatten()
+            {
+                // Per-model keyframe (Splat pac-man/ghost feet+head): apply the
+                // keyframe ONTO the node's base local transform (motion * base), same
+                // as motion_transforms — the keyframe is relative to the part's rest
+                // pose, so replacing it outright swung the body out of place. Lookup is
+                // case-insensitive (bones_players keys are lowercased; node names aren't).
+                mat4_multiply_col_major(km, &node.transform)
+            } else if let Some(motion_t) = self.motion_transforms.get(&node.name) {
                 // Motion applied to base: motion * base (motion rotates the base orientation)
                 mat4_multiply_col_major(motion_t, &node.transform)
             } else {

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -2431,30 +2431,38 @@ void main() {
             true
         };
 
+        // A model explicitly placed via Lingo `transform.position` (e.g. a cloned
+        // On the Run bonus, repositioned after cloning) has a runtime transform
+        // override. When such a model ALSO runs a keyframePlayer motion, place it
+        // with the runtime transform and apply the keyframe LOCALLY (runtime *
+        // motion) — otherwise the spin would be applied to the stale parsed base
+        // (the template's position) and the model renders nowhere near where
+        // `worldPosition` reports it. Models WITHOUT a runtime override (Splat's
+        // per-part keyframes) keep `motion * base`, relative to the rest pose.
+        let runtime_override: Option<[f32; 16]> =
+            runtime_state.and_then(|rs| get_runtime_transform(rs, &node.name));
         // Get this node's transform: motion (combined with base), runtime override, or parsed
         let node_transform = if allow_motion_override {
             if let Some(km) = (!self.motion_replace_transforms.is_empty())
                 .then(|| self.motion_replace_transforms.get(&node.name.to_ascii_lowercase()))
                 .flatten()
             {
-                // Per-model keyframe (Splat pac-man/ghost feet+head): apply the
-                // keyframe ONTO the node's base local transform (motion * base), same
-                // as motion_transforms — the keyframe is relative to the part's rest
-                // pose, so replacing it outright swung the body out of place. Lookup is
-                // case-insensitive (bones_players keys are lowercased; node names aren't).
-                mat4_multiply_col_major(km, &node.transform)
+                // Lookup is case-insensitive (bones_players keys are lowercased;
+                // node names aren't).
+                match runtime_override {
+                    Some(rt) => mat4_multiply_col_major(&rt, km),
+                    None => mat4_multiply_col_major(km, &node.transform),
+                }
             } else if let Some(motion_t) = self.motion_transforms.get(&node.name) {
-                // Motion applied to base: motion * base (motion rotates the base orientation)
-                mat4_multiply_col_major(motion_t, &node.transform)
+                match runtime_override {
+                    Some(rt) => mat4_multiply_col_major(&rt, motion_t),
+                    None => mat4_multiply_col_major(motion_t, &node.transform),
+                }
             } else {
-                runtime_state
-                    .and_then(|rs| get_runtime_transform(rs, &node.name))
-                    .unwrap_or(node.transform)
+                runtime_override.unwrap_or(node.transform)
             }
         } else {
-            runtime_state
-                .and_then(|rs| get_runtime_transform(rs, &node.name))
-                .unwrap_or(node.transform)
+            runtime_override.unwrap_or(node.transform)
         };
 
         let mut chain = vec![node_transform];
@@ -4538,7 +4546,35 @@ fn decode_and_upload_texture_impl(context: &WebGL2Context, data: &[u8]) -> Optio
         };
         let w = img.width();
         let h = img.height();
-        (w, h, img.into_raw())
+        let mut rgba = img.into_raw();
+        // Director W3D stores rgba4444 / 4444 textures as an RGB JPEG followed by a
+        // separate alpha continuation block: [width u32][height u32][zlibLen u32]
+        // [zlib-compressed 8-bit grayscale alpha]. image::load_from_memory only
+        // decodes the leading JPEG (alpha defaults to 255), so the icon's
+        // transparent background renders black. Recover the alpha here: locate the
+        // JPEG's EOI, parse the trailing block, inflate it, and write it into the
+        // alpha channel (0 = transparent, 255 = opaque).
+        if data[0] == 0xFF && data[1] == 0xD8 {
+            if let Some(eoi) = data.windows(2).position(|b| b[0] == 0xFF && b[1] == 0xD9) {
+                let tail = &data[eoi + 2..];
+                if tail.len() >= 14 {
+                    let aw = u32::from_le_bytes([tail[0], tail[1], tail[2], tail[3]]);
+                    let ah = u32::from_le_bytes([tail[4], tail[5], tail[6], tail[7]]);
+                    let alen = u32::from_le_bytes([tail[8], tail[9], tail[10], tail[11]]) as usize;
+                    if aw == w && ah == h && tail[12] == 0x78 && tail.len() >= 12 + alen {
+                        use std::io::Read;
+                        let mut alpha = Vec::new();
+                        let mut dec = flate2::read::ZlibDecoder::new(&tail[12..12 + alen]);
+                        if dec.read_to_end(&mut alpha).is_ok() && alpha.len() >= (w * h) as usize {
+                            for i in 0..(w * h) as usize {
+                                rgba[i * 4 + 3] = alpha[i];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        (w, h, rgba)
     } else if is_dxt_texture(data) {
         // DXT compressed texture — decode to RGBA
         match decode_dxt_to_rgba(data) {

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -1197,6 +1197,7 @@ void main() {
                 } else {
                     None
                 };
+
                 // Pack bone data (variable-length per-vertex → fixed vec4)
                 let (bone_idx_packed, bone_wgt_packed);
                 let (bi_opt, bw_opt) = if !mesh.bone_indices.is_empty() && !mesh.bone_weights.is_empty()
@@ -1296,8 +1297,14 @@ void main() {
         let mut texture_sizes: HashMap<String, (u32, u32)> = HashMap::new();
         let mut alpha_textures = std::collections::HashSet::new();
         for (tex_name, image_data) in &scene.texture_images {
-            if let Some((tex, w, h, has_alpha)) = self.decode_and_upload_texture(context, image_data) {
-                let lower = tex_name.to_lowercase();
+            let lower = tex_name.to_lowercase();
+            // The SkyLine* textures in this game are authored vertically inverted in
+            // the W3D (the JPEGs are stored upside-down, while houses/buildings/icons
+            // are stored right-side-up). The skyline mesh UVs use the same convention
+            // as everything else, and the texture declarations carry no orientation
+            // flag, so flip these on upload to render the horizon the right way up.
+            let flip_v = lower.contains("skyline");
+            if let Some((tex, w, h, has_alpha)) = self.decode_and_upload_texture(context, image_data, flip_v) {
                 texture_sizes.insert(lower.clone(), (w, h));
                 if has_alpha {
                     alpha_textures.insert(lower.clone());
@@ -1332,8 +1339,8 @@ void main() {
     }
 
     /// Decode JPEG/PNG image data and upload as WebGL texture (delegates to free function)
-    fn decode_and_upload_texture(&self, context: &WebGL2Context, data: &[u8]) -> Option<(WebGlTexture, u32, u32, bool)> {
-        decode_and_upload_texture_impl(context, data)
+    fn decode_and_upload_texture(&self, context: &WebGL2Context, data: &[u8], flip_v: bool) -> Option<(WebGlTexture, u32, u32, bool)> {
+        decode_and_upload_texture_impl(context, data, flip_v)
     }
 
     /// Incrementally re-upload only changed/new textures to GPU
@@ -1348,7 +1355,8 @@ void main() {
                 Some(&old_len) => old_len != data_len,
             };
             if needs_upload {
-                if let Some((tex, w, h, has_alpha)) = decode_and_upload_texture_impl(context, image_data) {
+                let flip_v = lower.contains("skyline");
+                if let Some((tex, w, h, has_alpha)) = decode_and_upload_texture_impl(context, image_data, flip_v) {
                     gpu_data.texture_sizes.insert(lower.clone(), (w, h));
                     if has_alpha {
                         gpu_data.alpha_textures.insert(lower.clone());
@@ -4522,7 +4530,7 @@ void main() {
 
 /// Decode image data (raw RGBA, DXT, JPEG/PNG) and upload as a WebGL2 texture.
 /// Free function to avoid borrow conflicts when called during incremental updates.
-fn decode_and_upload_texture_impl(context: &WebGL2Context, data: &[u8]) -> Option<(WebGlTexture, u32, u32, bool)> {
+fn decode_and_upload_texture_impl(context: &WebGL2Context, data: &[u8], flip_v: bool) -> Option<(WebGlTexture, u32, u32, bool)> {
     if data.len() < 4 { return None; }
 
     // Detection priority: JPEG/PNG magic → DXT header → raw RGBA (our own format)
@@ -4608,6 +4616,23 @@ fn decode_and_upload_texture_impl(context: &WebGL2Context, data: &[u8]) -> Optio
         }
     } else {
         return None;
+    };
+
+    // Vertically flip the decoded image when requested (the caller sets this for
+    // the SkyLine* textures, which are authored upside-down in the W3D asset).
+    let rgba_data = if flip_v && height > 0 {
+        let row = (width as usize) * 4;
+        let mut out = vec![0u8; rgba_data.len()];
+        for y in 0..(height as usize) {
+            let src = y * row;
+            let dst = (height as usize - 1 - y) * row;
+            if src + row <= rgba_data.len() && dst + row <= out.len() {
+                out[dst..dst + row].copy_from_slice(&rgba_data[src..src + row]);
+            }
+        }
+        out
+    } else {
+        rgba_data
     };
 
     let gl = context.gl();

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -3999,6 +3999,44 @@ void main() {
             skeleton, motion, t, root_lock,
         );
 
+        // [root-relativize] Director keeps a 3ds-Max biped's ROOT at identity IN THE SKIN
+        // (the root COM drives the model node, not the deformation). dirplayer's posed
+        // skeleton is instead pre-rotated by the root COM — verified against Director:
+        // dirplayer's bone[i] world == Rz(-122°) × Director's, the SAME factor for every
+        // bone (the root's COM). Strip it by relativizing each posed bone to the posed
+        // ROOT: skin[b] = inverse(root) × world[b] × inv_bind[b]. Algebra cancels to
+        // (b-relative-to-root) × inv_bind[b], so the inv_bind (mesh-consistent dir/quat
+        // T-pose) is untouched — no distortion (changing the bind DOES distort). This is
+        // the bot "aims right, faces ~NW" fix; rigid bodies/non-skinned models are
+        // unaffected (only skinned models reach here).
+        let affine_inv = |m: &[f32; 16]| -> [f32; 16] {
+            let (r00, r01, r02) = (m[0], m[4], m[8]);
+            let (r10, r11, r12) = (m[1], m[5], m[9]);
+            let (r20, r21, r22) = (m[2], m[6], m[10]);
+            let (tx, ty, tz) = (m[12], m[13], m[14]);
+            let itx = -(r00 * tx + r10 * ty + r20 * tz);
+            let ity = -(r01 * tx + r11 * ty + r21 * tz);
+            let itz = -(r02 * tx + r12 * ty + r22 * tz);
+            [r00, r01, r02, 0.0, r10, r11, r12, 0.0, r20, r21, r22, 0.0, itx, ity, itz, 1.0]
+        };
+        // Relativize by a FIXED idle-pose root, NOT the per-frame posed root. The idle
+        // root strips the biped COM convention while KEEPING each frame's run deviation
+        // (the per-frame posed root removed the run's small turn too → bots looked
+        // "slightly off while moving"). The bot mesh is authored at "Idle_Rest", so use
+        // that motion's frame-0 root as the fixed reference; models with no idle motion
+        // (dino/frog) fall back to the per-frame posed root (idle-dominant → no residual).
+        let idle_root_mats = scene.motions.iter()
+            .find(|m| m.name.to_ascii_lowercase().contains("idle_rest"))
+            .or_else(|| scene.motions.iter().find(|m| m.name.to_ascii_lowercase().contains("idle")))
+            .map(|im| crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, Some(im), 0.0));
+        // Only models with an idle-rest motion (the biped actors/bots) are relativized;
+        // everything else (dino, frog01, ClubMarian, …) keeps the original skin — no
+        // relativization — so this can't regress them.
+        let root_relinv = match &idle_root_mats {
+            Some(m) if !m.is_empty() => affine_inv(&m[0]),
+            _ => IDENTITY_4X4,
+        };
+
         // Check for motion blending (crossfade) — per-model blend state.
         let blend_weight = bp.map(|b| b.blend_weight).unwrap_or(self.blend_weight);
         let prev_motion_name = bp.and_then(|b| b.previous_motion.as_deref())
@@ -4023,15 +4061,18 @@ void main() {
                 skeleton, prev_motion, t, root_lock,
             );
             for i in 0..bone_count {
-                let cur = mat4_multiply_col_major(&world_matrices[i], &inv_bind[i]);
-                let prev = mat4_multiply_col_major(&prev_matrices[i], &inv_bind[i]);
+                let cur_rel = mat4_multiply_col_major(&root_relinv, &world_matrices[i]);
+                let prev_rel = mat4_multiply_col_major(&root_relinv, &prev_matrices[i]);
+                let cur = mat4_multiply_col_major(&cur_rel, &inv_bind[i]);
+                let prev = mat4_multiply_col_major(&prev_rel, &inv_bind[i]);
                 for j in 0..16 {
                     skinning_matrices[i * 16 + j] = prev[j] + (cur[j] - prev[j]) * blend_weight;
                 }
             }
         } else {
             for i in 0..bone_count {
-                let final_mat = mat4_multiply_col_major(&world_matrices[i], &inv_bind[i]);
+                let rel = mat4_multiply_col_major(&root_relinv, &world_matrices[i]);
+                let final_mat = mat4_multiply_col_major(&rel, &inv_bind[i]);
                 skinning_matrices[i * 16..i * 16 + 16].copy_from_slice(&final_mat);
             }
         }

--- a/vm-rust/src/rendering_gpu/webgl2/shaders.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/shaders.rs
@@ -56,6 +56,26 @@ impl InkMode {
             40 => InkMode::Lighten,
             41 => InkMode::Darken,
             2 => InkMode::Reverse,
+            // Ink 6 (Not Reverse): like Reverse, the background color is
+            // transparent. dirplayer has no distinct "not reverse" compositing
+            // (the CPU path falls through to a normal blend), so render it as a
+            // background-transparent copy — the visible fix Director users
+            // expect is the transparent background, not a colour inversion.
+            6 => InkMode::BackgroundTransparent,
+            // Ink 38 (Subtract): dst - src with the background color transparent.
+            // Visually identical to Sub Pin (35) on the GPU — both clamp to 0 via
+            // GL_FUNC_REVERSE_SUBTRACT — so reuse it (SubPin already color-keys
+            // the bgColor). Without this, ink 38 fell back to opaque Copy.
+            38 => InkMode::SubPin,
+            // Ink 34 (Add): dst + src with the background transparent. Same GPU
+            // result as Add Pin (33) — both clamp to 255 via additive blend and
+            // color-key the bgColor — so reuse it. (Was opaque Copy.)
+            34 => InkMode::AddPin,
+            // Ink 4 (Not Copy): an inverted copy with the background transparent.
+            // The Reverse shader already does invert-RGB + bgColor color-key,
+            // which matches Not Copy's "inverted source, background out". (Was
+            // opaque Copy — showing the white bounding box.)
+            4 => InkMode::Reverse,
             _ => InkMode::Copy, // Default to copy for unknown inks
         }
     }
@@ -509,7 +529,10 @@ void main() {
         Self::compile_program(context, Self::vertex_shader_source(), frag_source)
     }
 
-    /// Compile Ink 2 (Not Copy / Reverse) shader — inverts RGB, preserves alpha
+    /// Compile Ink 2 (Reverse) shader — inverts RGB, preserves alpha, and
+    /// color-keys the background color (Director's Reverse ink treats the
+    /// bgColor as transparent; the CPU path mattes it via should_matte_sprite).
+    /// Without the color-key the sprite drew an opaque inverted rectangle.
     fn compile_ink_reverse(context: &WebGL2Context) -> Result<ShaderProgram, JsValue> {
         let frag_source = r#"#version 300 es
 precision highp float;
@@ -518,6 +541,8 @@ in vec2 v_texcoord;
 
 uniform sampler2D u_texture;
 uniform float u_blend;
+uniform vec4 u_bg_color;
+uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
@@ -525,6 +550,11 @@ void main() {
     vec4 src = texture(u_texture, v_texcoord);
 
     if (src.a < 0.01) discard;
+
+    // Color-key transparency: discard pixels matching the sprite's bgColor.
+    vec3 diff = abs(src.rgb - u_bg_color.rgb);
+    float dist = max(max(diff.r, diff.g), diff.b);
+    if (dist < u_color_tolerance) discard;
 
     // Invert RGB, keep alpha
     float alpha = src.a * u_blend;

--- a/vm-rust/src/rendering_gpu/webgl2/texture_cache.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/texture_cache.rs
@@ -4,7 +4,7 @@
 //! unchanged bitmaps every frame.
 
 use std::collections::HashMap;
-use web_sys::WebGlTexture;
+use web_sys::{WebGl2RenderingContext, WebGlTexture};
 
 use crate::player::cast_lib::CastMemberRef;
 use crate::player::sprite::ColorRef;
@@ -55,6 +55,17 @@ pub struct CachedTexture {
     pub version: u32,
     /// Last frame this texture was used
     pub last_used_frame: u64,
+    /// GL context, kept so `Drop` can free the GPU texture. Dropping a
+    /// `WebGlTexture` handle does NOT call `gl.deleteTexture`, so without this
+    /// every evicted / replaced / invalidated cache entry would leak its GPU
+    /// texture (memory climbs on animation- or text-heavy movies).
+    gl: WebGl2RenderingContext,
+}
+
+impl Drop for CachedTexture {
+    fn drop(&mut self) {
+        self.gl.delete_texture(Some(&self.texture));
+    }
 }
 
 /// LRU texture cache for bitmap textures
@@ -92,9 +103,11 @@ impl TextureCache {
         }
     }
 
-    /// Insert or update a texture in the cache
+    /// Insert or update a texture in the cache. `gl` is stored so the entry can
+    /// free its GPU texture on eviction/replacement via `Drop`.
     pub fn insert(
         &mut self,
+        gl: &WebGl2RenderingContext,
         key: TextureCacheKey,
         texture: WebGlTexture,
         width: u32,
@@ -106,6 +119,7 @@ impl TextureCache {
             self.evict_lru();
         }
 
+        // A same-key insert replaces (and drops → deletes) the previous entry.
         self.textures.insert(
             key,
             CachedTexture {
@@ -114,6 +128,7 @@ impl TextureCache {
                 height,
                 version,
                 last_used_frame: self.current_frame,
+                gl: gl.clone(),
             },
         );
     }
@@ -414,6 +429,14 @@ pub struct CachedRenderedText {
     pub height: u32,
     /// Last frame this texture was used
     pub last_used_frame: u64,
+    /// GL context, kept so `Drop` frees the GPU texture (see `CachedTexture`).
+    gl: WebGl2RenderingContext,
+}
+
+impl Drop for CachedRenderedText {
+    fn drop(&mut self) {
+        self.gl.delete_texture(Some(&self.texture));
+    }
 }
 
 /// LRU texture cache for rendered text textures
@@ -451,9 +474,11 @@ impl RenderedTextCache {
         }
     }
 
-    /// Insert a texture into the cache
+    /// Insert a texture into the cache. `gl` is stored so the entry frees its
+    /// GPU texture on eviction/replacement via `Drop`.
     pub fn insert(
         &mut self,
+        gl: &WebGl2RenderingContext,
         key: RenderedTextCacheKey,
         texture: WebGlTexture,
         width: u32,
@@ -471,6 +496,7 @@ impl RenderedTextCache {
                 width,
                 height,
                 last_used_frame: self.current_frame,
+                gl: gl.clone(),
             },
         );
     }

--- a/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
@@ -14,7 +14,7 @@
 //! here keyed by `(scene_id, mesh_id)` / `(scene_id, texture_name)`, rebuilt
 //! only when the store's per-item `generation` counter bumps.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlTexture, WebGlUniformLocation};
 
@@ -58,16 +58,23 @@ uniform int u_has_vcolor;
 uniform float u_alpha;
 out vec4 frag;
 void main() {
-    vec3 tex = u_has_tex == 1 ? texture(u_tex, v_uv).rgb : vec3(1.0);
+    vec4 t = u_has_tex == 1 ? texture(u_tex, v_uv) : vec4(1.0);
+    // Groove blit modes (`.t` transparent, `.g` greenscreen, `.s`+`.a` mask) are
+    // decoded CPU-side into the texture's alpha. Drop keyed-out texels entirely
+    // rather than blending them: a discarded fragment writes no depth, so the
+    // scene behind a keyed background stays visible. Sampling only .rgb here (and
+    // emitting u_alpha alone) made every keyed texture render opaque — black skies
+    // and solid blocks where the cut-out should be.
+    if (u_has_tex == 1 && t.a < 0.5) discard;
     // Base lit color (GL fixed-function-style: ambient floor + directional diffuse).
     vec3 n = normalize(v_normal);
     float diff = max(abs(dot(n, normalize(u_light_dir))), 0.0);
     float shade = u_ambient + (1.0 - u_ambient) * diff;
-    vec3 lit = tex * u_color * u_light_color * shade;
+    vec3 lit = t.rgb * u_color * u_light_color * shade;
     // Material emission (self-illumination) is ADDED on top of the lit surface —
     // it does not replace lighting. Zero for non-emissive / non-material faces.
     vec3 emis = u_has_vcolor == 1 ? v_color.rgb : vec3(0.0);
-    frag = vec4(lit + emis, u_alpha);
+    frag = vec4(lit + emis, u_alpha * t.a);
 }
 "#;
 
@@ -325,24 +332,45 @@ impl XtraSceneRenderer {
         }
 
         // (1) Ensure GL meshes for every mesh referenced this frame.
+        //
+        // Both this and the texture pass below key off the UNIQUE mesh ids, not
+        // the draw list. A shape emits one DrawCmd per (part, texture) batch, so
+        // a many-part model has hundreds of draws all naming the same mesh — and
+        // the texture pass walks that mesh's entire batch list. Doing either
+        // per-draw is O(draws × batches): the Hey Arnold level (767 parts, 113
+        // textures, ~800 batches) burned ~640k redundant String clones and
+        // ensure_texture calls *per frame* on that one object.
+        let mut mesh_ids: Vec<u32> = Vec::new();
         for d in &frame.draws {
-            self.ensure_mesh(context, scene_id, d.mesh_id);
-        }
-        // (2) Ensure textures for every name referenced this frame.
-        for d in &frame.draws {
-            if let Some(name) = d.tex_override.as_deref().filter(|n| !n.is_empty()) {
-                self.ensure_texture(context, player, scene_id, name);
+            if !mesh_ids.contains(&d.mesh_id) {
+                mesh_ids.push(d.mesh_id);
             }
-            if let Some((_, batches)) = self.meshes.get(&(scene_id, d.mesh_id)) {
-                let names: Vec<String> = batches
-                    .iter()
-                    .map(|b| b.tex_name.clone())
-                    .filter(|n| !n.is_empty())
-                    .collect();
-                for name in names {
-                    self.ensure_texture(context, player, scene_id, &name);
+        }
+        for &mesh_id in &mesh_ids {
+            self.ensure_mesh(context, scene_id, mesh_id);
+        }
+        // (2) Ensure textures for every name referenced this frame: each unique
+        // mesh's batch names, plus any per-object tex_override. Collected first
+        // (self.meshes is borrowed here, ensure_texture needs &mut self).
+        let mut tex_names: HashSet<String> = HashSet::new();
+        for &mesh_id in &mesh_ids {
+            if let Some((_, batches)) = self.meshes.get(&(scene_id, mesh_id)) {
+                for b in batches {
+                    if !b.tex_name.is_empty() && !tex_names.contains(b.tex_name.as_str()) {
+                        tex_names.insert(b.tex_name.clone());
+                    }
                 }
             }
+        }
+        for d in &frame.draws {
+            if let Some(name) = d.tex_override.as_deref().filter(|n| !n.is_empty()) {
+                if !tex_names.contains(name) {
+                    tex_names.insert(name.to_string());
+                }
+            }
+        }
+        for name in &tex_names {
+            self.ensure_texture(context, player, scene_id, name, false);
         }
 
         let gl = context.gl();
@@ -416,7 +444,11 @@ impl XtraSceneRenderer {
             );
             let alpha = d.alpha.clamp(0.0, 1.0);
             gl.uniform1f(shader.u_alpha.as_ref(), alpha);
-            gl.depth_mask(alpha >= 0.999);
+            // The world background (SetWorldBackground) never occludes and is never
+            // occluded: it writes no depth, so every real surface composites over
+            // it regardless of how near the skydome's own geometry actually is.
+            // The plugin already re-centred it on the camera and submits it first.
+            gl.depth_mask(!d.background && alpha >= 0.999);
             gl.uniform1i(shader.u_tex.as_ref(), 0);
             // Back-face culling per the shape's bfculling flag. Groove models bake
             // double-sided coplanar faces (screen quads wound both ways); culling
@@ -432,7 +464,7 @@ impl XtraSceneRenderer {
             // near-coplanar front object — the 3D logo box over the truss — z-fights
             // into a moiré/hatch). Auto (-1/0) and draw-behind (-2) keep the normal
             // depth test, with a polygon offset to separate coplanar surfaces.
-            if d.depth >= 1 {
+            if d.background || d.depth >= 1 {
                 gl.depth_func(WebGl2RenderingContext::ALWAYS);
                 gl.polygon_offset(0.0, 0.0);
             } else {
@@ -441,10 +473,19 @@ impl XtraSceneRenderer {
                 gl.polygon_offset(poff, poff);
             }
 
-            for (bi, batch) in batches.iter().enumerate() {
-                if d.batch >= 0 && d.batch as usize != bi {
-                    continue;
+            // Select this cmd's batch by index; `batch < 0` means "all batches
+            // of the mesh" (deformed objects submit one cmd for the whole mesh).
+            // Indexing, not scan-and-skip: a shape's per-batch draws each walked
+            // the full batch list, making the pass O(draws × batches) per frame.
+            let selected: &[GlBatch] = if d.batch >= 0 {
+                match batches.get(d.batch as usize) {
+                    Some(b) => std::slice::from_ref(b),
+                    None => &[],
                 }
+            } else {
+                batches.as_slice()
+            };
+            for batch in selected {
                 let tex_name = d
                     .tex_override
                     .as_deref()
@@ -464,7 +505,12 @@ impl XtraSceneRenderer {
                         WebGl2RenderingContext::SRC_ALPHA,
                         WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA,
                     );
-                    gl.depth_mask(alpha >= 0.999);
+                    // Must repeat the background test the outer draw made: a
+                    // background never writes depth. Setting it from `alpha` alone
+                    // let the skydome — drawn with depth_func(ALWAYS) at the camera
+                    // — stamp near depth over the whole screen, so every farther
+                    // surface (the street; the houses, intermittently) failed LEQUAL.
+                    gl.depth_mask(!d.background && alpha >= 0.999);
                 }
                 let tex = self
                     .textures
@@ -542,7 +588,18 @@ impl XtraSceneRenderer {
     /// Ensure a GL texture for `name` in `scene_id`. Prefers a plugin-uploaded
     /// RGBA texture (tracked by store generation); otherwise resolves `name` to a
     /// movie bitmap cast member and uploads it once.
-    fn ensure_texture(&mut self, context: &WebGL2Context, player: &DirPlayer, scene_id: i32, name: &str) {
+    /// `for_overlay`: a 2D overlay sprite rather than a 3D model texture. An
+    /// untagged sprite (the character glyphs) is still a cut-out and needs its
+    /// key colour removed, whereas an untagged 3D texture is Solid and must be
+    /// left opaque — keying a road or wall would punch holes in it.
+    fn ensure_texture(
+        &mut self,
+        context: &WebGL2Context,
+        player: &DirPlayer,
+        scene_id: i32,
+        name: &str,
+        for_overlay: bool,
+    ) {
         // Plugin-uploaded texture? Check the store's generation.
         let uploaded = with_store_mut(|store| {
             store
@@ -564,7 +621,7 @@ impl XtraSceneRenderer {
         if self.textures.contains_key(&key) {
             return;
         }
-        let tex = upload_named_texture(context, player, name);
+        let tex = upload_named_texture(context, player, name, for_overlay);
         self.textures.insert(key, (CAST_TEX_GEN, tex));
     }
 
@@ -610,7 +667,7 @@ impl XtraSceneRenderer {
         // Resolve every overlay's texture + native size first (mutates self).
         for ov in overlays {
             if !ov.tex_name.is_empty() {
-                self.ensure_texture(context, player, scene_id, &ov.tex_name);
+                self.ensure_texture(context, player, scene_id, &ov.tex_name, true);
             }
         }
         let gl = context.gl();
@@ -747,29 +804,69 @@ fn resolve_bitmap_rgba(player: &DirPlayer, name: &str) -> Option<(usize, usize, 
 /// its luminance as the alpha channel. Only when there is no `.a` companion do we
 /// fall back to the corner-color matte (plain sprites like the character glyphs,
 /// which have no mask).
-fn upload_named_texture(context: &WebGL2Context, player: &DirPlayer, name: &str) -> Option<WebGlTexture> {
+fn upload_named_texture(
+    context: &WebGL2Context,
+    player: &DirPlayer,
+    name: &str,
+    for_overlay: bool,
+) -> Option<WebGlTexture> {
     let (w, h, mut rgba) = resolve_bitmap_rgba(player, name)?;
-    // Companion alpha mask name: `foo.s` -> `foo.a`.
-    let alpha_name = name
-        .strip_suffix(".s")
-        .or_else(|| name.strip_suffix(".S"))
-        .map(|base| format!("{}.a", base));
-    let mut used_mask = false;
-    if let Some(an) = alpha_name {
-        if let Some((aw, ah, amask)) = resolve_bitmap_rgba(player, &an) {
-            if aw == w && ah == h {
-                // Grayscale mask → R == G == B; take R as the alpha value.
-                for i in 0..(w * h) {
-                    rgba[i * 4 + 3] = amask[i * 4];
+    // The asset-name extension IS the Groove BlitMode, and dirplayer loads Groove
+    // bitmaps OPAQUE, so reconstruct the transparency it implies:
+    //
+    //   .s  Solid colour image, paired with a `.a` greyscale alpha mask
+    //   .t  Transparent  → colour-key the background
+    //   .g  Greenscreen  → key out green-dominant texels
+    //   .a  Alpha        → the bitmap already carries its own alpha
+    //   none/other       → Solid: key NOTHING
+    //
+    // Keying unconditionally (the old behaviour) is only invisible while the 3D
+    // shader ignores texel alpha; once it honours it, a matte on an untagged
+    // texture punches its border colour out of solid geometry (roads, walls).
+    let ext = name.rsplit_once('.').map(|(_, e)| e.to_ascii_lowercase());
+    match ext.as_deref() {
+        Some("s") => {
+            // Companion mask: `foo.s` -> `foo.a`.
+            let base = &name[..name.len() - 2];
+            let mut used_mask = false;
+            if let Some((aw, ah, amask)) = resolve_bitmap_rgba(player, &format!("{}.a", base)) {
+                if aw == w && ah == h {
+                    // Grayscale mask → R == G == B; take R as the alpha value.
+                    for i in 0..(w * h) {
+                        rgba[i * 4 + 3] = amask[i * 4];
+                    }
+                    used_mask = true;
                 }
-                used_mask = true;
+            }
+            // A `.s` with no authored mask is a plain cut-out sprite.
+            if !used_mask {
+                key_corner_transparent(&mut rgba, w, h);
             }
         }
-    }
-    if !used_mask {
-        matte_edge_transparent(&mut rgba, w, h);
+        Some("t") => key_corner_transparent(&mut rgba, w, h),
+        Some("g") => greenscreen_transparent(&mut rgba, w, h),
+        // Untagged: Solid for a 3D texture, but an overlay sprite (the character
+        // glyphs) is still a cut-out keyed on its background colour.
+        _ if for_overlay => key_corner_transparent(&mut rgba, w, h),
+        _ => {}
     }
     upload_rgba(context, w as u32, h as u32, &rgba)
+}
+
+/// Groove Greenscreen blit mode (`.g`): key out green-dominant texels. Mirrors
+/// the overlay shader's rule (`greenness = g - max(r, b)`) so a texture and an
+/// overlay of the same art cut out identically.
+fn greenscreen_transparent(rgba: &mut [u8], w: usize, h: usize) {
+    if w == 0 || h == 0 || rgba.len() < w * h * 4 {
+        return;
+    }
+    for i in 0..(w * h) {
+        let p = i * 4;
+        let (r, g, b) = (rgba[p] as i32, rgba[p + 1] as i32, rgba[p + 2] as i32);
+        if g - r.max(b) > 40 {
+            rgba[p + 3] = 0;
+        }
+    }
 }
 
 /// Color-key matte for plain Groove overlay sprites that have NO `.a` alpha
@@ -781,31 +878,20 @@ fn upload_named_texture(context: &WebGL2Context, player: &DirPlayer, name: &str)
 /// a flat key background, so keying all key-color pixels is safe. Sprites that
 /// carry a real silhouette (title/buttons) use their `.a` mask and never reach
 /// this path.
-fn matte_edge_transparent(rgba: &mut [u8], w: usize, h: usize) {
+fn key_corner_transparent(rgba: &mut [u8], w: usize, h: usize) {
     if w == 0 || h == 0 || rgba.len() < w * h * 4 {
         return;
     }
-    let px = |x: usize, y: usize| (y * w + x) * 4;
-    // Dominant border color = the background key.
-    let mut counts: std::collections::HashMap<[u8; 3], u32> = std::collections::HashMap::new();
-    let mut tally = |x: usize, y: usize| {
-        let p = px(x, y);
-        if rgba[p + 3] != 0 {
-            *counts.entry([rgba[p], rgba[p + 1], rgba[p + 2]]).or_insert(0) += 1;
-        }
-    };
-    for x in 0..w {
-        tally(x, 0);
-        tally(x, h - 1);
-    }
-    for y in 0..h {
-        tally(0, y);
-        tally(w - 1, y);
-    }
-    let key = match counts.into_iter().max_by_key(|&(_, c)| c) {
-        Some((color, _)) => color,
-        None => return,
-    };
+    // The key is the colour of the TOP-LEFT pixel — Director's transparent-ink
+    // rule (an ink with no explicit bgColor keys on src (0,0)). Every pixel of
+    // that colour is keyed, not just the edge-connected region, so the enclosed
+    // holes of glyphs like O and G become transparent too.
+    //
+    // NOT the dominant border colour: an authored key sits at (0,0) but need not
+    // dominate the border. `busf.t` is keyed green (0,255,0) at (0,0) while its
+    // border is mostly the blue window frame — matting the border cut the frame
+    // and left the windows green.
+    let key = [rgba[0], rgba[1], rgba[2]];
     for i in 0..(w * h) {
         let p = i * 4;
         if rgba[p] == key[0] && rgba[p + 1] == key[1] && rgba[p + 2] == key[2] {

--- a/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+//! Engine-agnostic WebGL2 renderer for the external Xtra 3D scene API.
+//!
+//! Reads the CPU-side [`Scene3dStore`](crate::player::xtra::scene3d) that
+//! external plugins fill through the `scene3d_*` host services and composites
+//! each scene onto the dirplayer stage. Unlike the built-in
+//! `GrooveSceneRenderer`, this holds no engine knowledge: a plugin uploads
+//! flat-shaded triangle batches once (per shape), then each step submits a
+//! [`FrameData`](xtra_sdk::scene3d::FrameData) of draw commands carrying
+//! *final* model matrices + material — the plugin evaluates its own animation.
+//!
+//! GL objects (buffers, textures) can't live in the store, so they're cached
+//! here keyed by `(scene_id, mesh_id)` / `(scene_id, texture_name)`, rebuilt
+//! only when the store's per-item `generation` counter bumps.
+
+use std::collections::HashMap;
+
+use web_sys::{WebGl2RenderingContext, WebGlProgram, WebGlTexture, WebGlUniformLocation};
+
+use crate::player::cast_member::CastMemberType;
+use crate::player::xtra::scene3d::with_store_mut;
+use crate::player::DirPlayer;
+
+use super::{context::WebGL2Context, mesh3d::Mesh3dBuffers};
+
+const VS: &str = r#"#version 300 es
+precision highp float;
+layout(location=0) in vec3 a_pos;
+layout(location=1) in vec3 a_normal;
+layout(location=2) in vec2 a_uv;
+uniform mat4 u_mvp;
+uniform mat4 u_model;
+out vec3 v_normal;
+out vec2 v_uv;
+void main() {
+    gl_Position = u_mvp * vec4(a_pos, 1.0);
+    v_normal = mat3(u_model) * a_normal;
+    v_uv = a_uv;
+}
+"#;
+
+const FS: &str = r#"#version 300 es
+precision highp float;
+in vec3 v_normal;
+in vec2 v_uv;
+uniform vec3 u_light_dir;
+uniform vec3 u_light_color;
+uniform float u_ambient;
+uniform vec3 u_color;
+uniform sampler2D u_tex;
+uniform int u_has_tex;
+uniform float u_alpha;
+out vec4 frag;
+void main() {
+    vec3 n = normalize(v_normal);
+    float diff = max(abs(dot(n, normalize(u_light_dir))), 0.0);
+    float shade = u_ambient + (1.0 - u_ambient) * diff;
+    vec3 tex = u_has_tex == 1 ? texture(u_tex, v_uv).rgb : vec3(1.0);
+    frag = vec4(tex * u_color * u_light_color * shade, u_alpha);
+}
+"#;
+
+struct ShaderProgram {
+    program: WebGlProgram,
+    u_mvp: Option<WebGlUniformLocation>,
+    u_model: Option<WebGlUniformLocation>,
+    u_light_dir: Option<WebGlUniformLocation>,
+    u_light_color: Option<WebGlUniformLocation>,
+    u_ambient: Option<WebGlUniformLocation>,
+    u_color: Option<WebGlUniformLocation>,
+    u_tex: Option<WebGlUniformLocation>,
+    u_has_tex: Option<WebGlUniformLocation>,
+    u_alpha: Option<WebGlUniformLocation>,
+}
+
+/// One GL-uploaded batch: its texture name (empty = untextured) and buffers.
+struct GlBatch {
+    tex_name: String,
+    mesh: Mesh3dBuffers,
+}
+
+/// Only composite while the game is actively driving the scene: it must have
+/// submitted on the current movie frame AND within the last couple of draws.
+const STALE_DRAWS: i32 = 2;
+
+/// GL-side caches + shader. Lazily initialized.
+pub struct XtraSceneRenderer {
+    shader: Option<ShaderProgram>,
+    /// Uploaded mesh buffers keyed by (scene_id, mesh_id): (store generation, batches).
+    meshes: HashMap<(i32, u32), (u64, Vec<GlBatch>)>,
+    /// GL textures keyed by (scene_id, name): (source generation, texture). For a
+    /// plugin-uploaded texture the generation tracks the store entry; for a
+    /// cast-member texture it's `CAST_TEX_GEN` (resolved once, no refresh).
+    textures: HashMap<(i32, String), (u64, Option<WebGlTexture>)>,
+}
+
+/// Sentinel `generation` for cast-member-resolved textures (never auto-refreshed).
+const CAST_TEX_GEN: u64 = u64::MAX;
+
+impl XtraSceneRenderer {
+    pub fn new() -> Self {
+        XtraSceneRenderer { shader: None, meshes: HashMap::new(), textures: HashMap::new() }
+    }
+
+    fn ensure_shader(&mut self, context: &WebGL2Context) -> bool {
+        if self.shader.is_some() {
+            return true;
+        }
+        let gl = context.gl();
+        let vs = match context.compile_shader(WebGl2RenderingContext::VERTEX_SHADER, VS) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let fs = match context.compile_shader(WebGl2RenderingContext::FRAGMENT_SHADER, FS) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let program = match context.link_program(&vs, &fs) {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        let u = |n: &str| gl.get_uniform_location(&program, n);
+        self.shader = Some(ShaderProgram {
+            u_mvp: u("u_mvp"),
+            u_model: u("u_model"),
+            u_light_dir: u("u_light_dir"),
+            u_light_color: u("u_light_color"),
+            u_ambient: u("u_ambient"),
+            u_color: u("u_color"),
+            u_tex: u("u_tex"),
+            u_has_tex: u("u_has_tex"),
+            u_alpha: u("u_alpha"),
+            program,
+        });
+        true
+    }
+
+    /// Composite every active scene in the store.
+    pub fn draw(&mut self, context: &WebGL2Context, player: &DirPlayer, viewport_w: i32, viewport_h: i32) {
+        // Collect the scene ids to draw, gating on staleness. We bump
+        // `draws_since_submit` here (a store write) then release the store
+        // borrow so the GL work below can freely re-borrow it read-only.
+        let current_frame = player.movie.current_frame as i32;
+        let scene_ids: Vec<i32> = with_store_mut(|store| {
+            let mut ids = Vec::new();
+            for (id, scene) in store.scenes.iter_mut() {
+                if scene.frame.is_none() {
+                    continue;
+                }
+                if scene.last_submit_frame != current_frame {
+                    continue;
+                }
+                scene.draws_since_submit += 1;
+                if scene.draws_since_submit > STALE_DRAWS {
+                    continue;
+                }
+                ids.push(*id);
+            }
+            ids
+        });
+        if scene_ids.is_empty() {
+            return;
+        }
+        if !self.ensure_shader(context) {
+            return;
+        }
+        for scene_id in scene_ids {
+            self.draw_scene(context, player, scene_id, viewport_w, viewport_h);
+        }
+    }
+
+    fn draw_scene(
+        &mut self,
+        context: &WebGL2Context,
+        player: &DirPlayer,
+        scene_id: i32,
+        viewport_w: i32,
+        viewport_h: i32,
+    ) {
+        // Snapshot the frame + the mesh/texture upload work needed, all while
+        // holding the store, then drop the borrow before issuing GL draws that
+        // read `self` mutably. Cloning FrameData is cheap (draws are matrices).
+        let frame = match with_store_mut(|store| {
+            store.scenes.get(&scene_id).and_then(|s| s.frame.clone())
+        }) {
+            Some(f) => f,
+            None => return,
+        };
+        if frame.draws.is_empty() {
+            return;
+        }
+
+        // (1) Ensure GL meshes for every mesh referenced this frame.
+        for d in &frame.draws {
+            self.ensure_mesh(context, scene_id, d.mesh_id);
+        }
+        // (2) Ensure textures for every name referenced this frame.
+        for d in &frame.draws {
+            if let Some(name) = d.tex_override.as_deref().filter(|n| !n.is_empty()) {
+                self.ensure_texture(context, player, scene_id, name);
+            }
+            if let Some((_, batches)) = self.meshes.get(&(scene_id, d.mesh_id)) {
+                let names: Vec<String> = batches
+                    .iter()
+                    .map(|b| b.tex_name.clone())
+                    .filter(|n| !n.is_empty())
+                    .collect();
+                for name in names {
+                    self.ensure_texture(context, player, scene_id, &name);
+                }
+            }
+        }
+
+        let gl = context.gl();
+        let (rx1, ry1, rx2, ry2) = frame.render_rect.unwrap_or((0, 0, viewport_w, viewport_h));
+        let rect_w = (rx2 - rx1).max(1);
+        let rect_h = (ry2 - ry1).max(1);
+
+        // Map the render rect (stage px) to framebuffer px (may be HiDPI-scaled);
+        // GL viewport origin is bottom-left so flip Y.
+        let fb_w = gl.drawing_buffer_width();
+        let fb_h = gl.drawing_buffer_height();
+        let sx = fb_w as f32 / viewport_w.max(1) as f32;
+        let sy = fb_h as f32 / viewport_h.max(1) as f32;
+        let vp_x = (rx1 as f32 * sx).round() as i32;
+        let vp_w = (rect_w as f32 * sx).round() as i32;
+        let vp_h = (rect_h as f32 * sy).round() as i32;
+        let vp_y = fb_h - (ry2 as f32 * sy).round() as i32;
+        gl.viewport(vp_x, vp_y, vp_w, vp_h);
+        gl.enable(WebGl2RenderingContext::SCISSOR_TEST);
+        gl.scissor(vp_x, vp_y, vp_w, vp_h);
+
+        gl.enable(WebGl2RenderingContext::DEPTH_TEST);
+        gl.depth_func(WebGl2RenderingContext::LEQUAL);
+        // A windowed view with a background clears opaque; a full-stage view
+        // with no background composites over the 2D layer (depth clear only).
+        match frame.background {
+            Some(bg) => {
+                gl.clear_color(bg[0] as f32 / 255.0, bg[1] as f32 / 255.0, bg[2] as f32 / 255.0, 1.0);
+                gl.clear(WebGl2RenderingContext::COLOR_BUFFER_BIT | WebGl2RenderingContext::DEPTH_BUFFER_BIT);
+            }
+            None => gl.clear(WebGl2RenderingContext::DEPTH_BUFFER_BIT),
+        }
+        gl.enable(WebGl2RenderingContext::BLEND);
+        gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+
+        let shader = self.shader.as_ref().unwrap();
+        gl.use_program(Some(&shader.program));
+        let (ldir, lcolor) = frame
+            .light
+            .map(|l| (l.dir, l.color))
+            .unwrap_or(([0.3, 0.5, 1.0], [1.0, 1.0, 1.0]));
+        gl.uniform3f(shader.u_light_dir.as_ref(), ldir[0], ldir[1], ldir[2]);
+        gl.uniform3f(shader.u_light_color.as_ref(), lcolor[0], lcolor[1], lcolor[2]);
+        gl.uniform1f(shader.u_ambient.as_ref(), frame.ambient.clamp(0.0, 1.0));
+
+        let aspect = if rect_h > 0 { rect_w as f32 / rect_h as f32 } else { 1.0 };
+        let proj = perspective(frame.camera.fov.to_radians().max(0.1), aspect, 1.0, 200_000.0);
+        let view = look_at(frame.camera.pos, frame.camera.look_at, [0.0, 0.0, 1.0]);
+        let view_proj = mat_mul(&proj, &view);
+
+        for d in &frame.draws {
+            let Some((_, batches)) = self.meshes.get(&(scene_id, d.mesh_id)) else { continue };
+            let model = d.model;
+            let mvp = mat_mul(&view_proj, &model);
+            gl.uniform_matrix4fv_with_f32_array(shader.u_mvp.as_ref(), false, &mvp);
+            gl.uniform_matrix4fv_with_f32_array(shader.u_model.as_ref(), false, &model);
+            gl.uniform3f(
+                shader.u_color.as_ref(),
+                d.color[0] as f32 / 255.0,
+                d.color[1] as f32 / 255.0,
+                d.color[2] as f32 / 255.0,
+            );
+            let alpha = d.alpha.clamp(0.0, 1.0);
+            gl.uniform1f(shader.u_alpha.as_ref(), alpha);
+            gl.depth_mask(alpha >= 0.999);
+            gl.uniform1i(shader.u_tex.as_ref(), 0);
+
+            for (bi, batch) in batches.iter().enumerate() {
+                if d.batch >= 0 && d.batch as usize != bi {
+                    continue;
+                }
+                let tex_name = d
+                    .tex_override
+                    .as_deref()
+                    .filter(|n| !n.is_empty())
+                    .unwrap_or(batch.tex_name.as_str());
+                let tex = self
+                    .textures
+                    .get(&(scene_id, tex_name.to_string()))
+                    .and_then(|(_, t)| t.as_ref());
+                if let Some(t) = tex {
+                    gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+                    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(t));
+                    gl.uniform1i(shader.u_has_tex.as_ref(), 1);
+                } else {
+                    gl.uniform1i(shader.u_has_tex.as_ref(), 0);
+                }
+                batch.mesh.bind(gl);
+                batch.mesh.draw(gl);
+                batch.mesh.unbind(gl);
+            }
+        }
+        gl.depth_mask(true);
+        gl.disable(WebGl2RenderingContext::BLEND);
+        gl.disable(WebGl2RenderingContext::DEPTH_TEST);
+        gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
+        gl.viewport(0, 0, fb_w, fb_h);
+    }
+
+    /// Build/refresh the GL buffers for one mesh if the store's generation advanced.
+    fn ensure_mesh(&mut self, context: &WebGL2Context, scene_id: i32, mesh_id: u32) {
+        let store_gen = with_store_mut(|store| {
+            store.scenes.get(&scene_id).and_then(|s| s.meshes.get(&mesh_id)).map(|m| m.generation)
+        });
+        let Some(store_gen) = store_gen else { return };
+        if self.meshes.get(&(scene_id, mesh_id)).map(|(g, _)| *g) == Some(store_gen) {
+            return;
+        }
+        // Rebuild from the store's CPU batches.
+        let batches = with_store_mut(|store| {
+            let mut out: Vec<(String, Vec<[f32; 3]>, Vec<[f32; 3]>, Vec<[f32; 2]>)> = Vec::new();
+            if let Some(m) = store.scenes.get(&scene_id).and_then(|s| s.meshes.get(&mesh_id)) {
+                for b in &m.data.batches {
+                    out.push((
+                        b.tex_name.clone(),
+                        chunk3(&b.positions),
+                        chunk3(&b.normals),
+                        chunk2(&b.uvs),
+                    ));
+                }
+            }
+            out
+        });
+        let mut gl_batches = Vec::new();
+        for (tex_name, positions, normals, uvs) in batches {
+            let n_tris = positions.len() / 3;
+            let faces: Vec<[u32; 3]> =
+                (0..n_tris).map(|i| [(i * 3) as u32, (i * 3 + 1) as u32, (i * 3 + 2) as u32]).collect();
+            let uvs_opt = if uvs.len() == positions.len() { Some(uvs.as_slice()) } else { None };
+            if let Ok(mesh) =
+                Mesh3dBuffers::new(context, &positions, &normals, uvs_opt, None, &faces)
+            {
+                gl_batches.push(GlBatch { tex_name, mesh });
+            }
+        }
+        self.meshes.insert((scene_id, mesh_id), (store_gen, gl_batches));
+    }
+
+    /// Ensure a GL texture for `name` in `scene_id`. Prefers a plugin-uploaded
+    /// RGBA texture (tracked by store generation); otherwise resolves `name` to a
+    /// movie bitmap cast member and uploads it once.
+    fn ensure_texture(&mut self, context: &WebGL2Context, player: &DirPlayer, scene_id: i32, name: &str) {
+        // Plugin-uploaded texture? Check the store's generation.
+        let uploaded = with_store_mut(|store| {
+            store
+                .scenes
+                .get(&scene_id)
+                .and_then(|s| s.textures.get(name))
+                .map(|t| (t.generation, t.w, t.h, t.rgba.clone()))
+        });
+        let key = (scene_id, name.to_string());
+        if let Some((generation, w, h, rgba)) = uploaded {
+            if self.textures.get(&key).map(|(g, _)| *g) == Some(generation) {
+                return; // up to date
+            }
+            let tex = upload_rgba(context, w, h, &rgba);
+            self.textures.insert(key, (generation, tex));
+            return;
+        }
+        // Cast-member texture: resolve once, cache with the sentinel generation.
+        if self.textures.contains_key(&key) {
+            return;
+        }
+        let tex = upload_named_texture(context, player, name);
+        self.textures.insert(key, (CAST_TEX_GEN, tex));
+    }
+}
+
+fn chunk3(v: &[f32]) -> Vec<[f32; 3]> {
+    v.chunks_exact(3).map(|c| [c[0], c[1], c[2]]).collect()
+}
+fn chunk2(v: &[f32]) -> Vec<[f32; 2]> {
+    v.chunks_exact(2).map(|c| [c[0], c[1]]).collect()
+}
+
+fn upload_rgba(context: &WebGL2Context, w: u32, h: u32, rgba: &[u8]) -> Option<WebGlTexture> {
+    if w == 0 || h == 0 || rgba.len() != (w * h * 4) as usize {
+        return None;
+    }
+    let tex = context.create_texture().ok()?;
+    context.upload_texture_rgba(&tex, w, h, rgba).ok()?;
+    Some(tex)
+}
+
+/// Resolve `name` to a movie bitmap cast member and upload it as a GL texture.
+fn upload_named_texture(context: &WebGL2Context, player: &DirPlayer, name: &str) -> Option<WebGlTexture> {
+    let mref = player.movie.cast_manager.find_member_ref_by_name(name)?;
+    let member = player.movie.cast_manager.find_member_by_ref(&mref)?;
+    let bref = match &member.member_type {
+        CastMemberType::Bitmap(b) => b.image_ref,
+        _ => return None,
+    };
+    let bitmap = player.bitmap_manager.get_bitmap(bref)?;
+    upload_rgba(context, bitmap.width as u32, bitmap.height as u32, &bitmap.data)
+}
+
+// ---- minimal column-major mat4 helpers (GL order) ----
+
+fn perspective(fov_y: f32, aspect: f32, near: f32, far: f32) -> [f32; 16] {
+    let f = 1.0 / (fov_y / 2.0).tan();
+    let nf = 1.0 / (near - far);
+    [
+        f / aspect, 0.0, 0.0, 0.0,
+        0.0, f, 0.0, 0.0,
+        0.0, 0.0, (far + near) * nf, -1.0,
+        0.0, 0.0, 2.0 * far * near * nf, 0.0,
+    ]
+}
+
+fn look_at(eye: [f32; 3], center: [f32; 3], up: [f32; 3]) -> [f32; 16] {
+    let f = normalize(sub(center, eye));
+    let s = normalize(cross(f, up));
+    let u = cross(s, f);
+    [
+        s[0], u[0], -f[0], 0.0,
+        s[1], u[1], -f[1], 0.0,
+        s[2], u[2], -f[2], 0.0,
+        -dot(s, eye), -dot(u, eye), dot(f, eye), 1.0,
+    ]
+}
+
+fn mat_mul(a: &[f32; 16], b: &[f32; 16]) -> [f32; 16] {
+    let mut o = [0.0f32; 16];
+    for c in 0..4 {
+        for r in 0..4 {
+            let mut s = 0.0;
+            for k in 0..4 {
+                s += a[k * 4 + r] * b[c * 4 + k];
+            }
+            o[c * 4 + r] = s;
+        }
+    }
+    o
+}
+
+fn sub(a: [f32; 3], b: [f32; 3]) -> [f32; 3] { [a[0] - b[0], a[1] - b[1], a[2] - b[2]] }
+fn cross(a: [f32; 3], b: [f32; 3]) -> [f32; 3] {
+    [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]]
+}
+fn dot(a: [f32; 3], b: [f32; 3]) -> f32 { a[0] * b[0] + a[1] * b[1] + a[2] * b[2] }
+fn normalize(a: [f32; 3]) -> [f32; 3] {
+    let l = dot(a, a).sqrt();
+    if l > 1e-8 { [a[0] / l, a[1] / l, a[2] / l] } else { [0.0, 0.0, 1.0] }
+}

--- a/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
@@ -89,39 +89,43 @@ precision highp float;
 in vec2 v_uv;
 uniform sampler2D u_tex;
 uniform float u_alpha;
-uniform int u_greenkey;
+uniform int u_mode; // OverlayCmd.blit_mode: 0=Normal, 1=Greenscreen, 2=Chroma
 out vec4 frag;
 void main() {
     vec4 t = texture(u_tex, v_uv);
-    if (u_greenkey == 1) {
-        // Groove `.g` sprites bake transparency as a green color key (dirplayer
-        // loads them opaque). Key out green-dominant texels; soft edge kills halo.
+    if (u_mode == 1) {
+        // Greenscreen (`.g`): key out green-dominant texels; soft edge kills halo.
         float greenness = t.g - max(t.r, t.b);
         float key = 1.0 - smoothstep(0.15, 0.35, greenness);
         frag = vec4(t.rgb, t.a * u_alpha * key);
-    } else if (u_alpha < 0.999) {
-        // Translucent `.c` sprite (leo3d's glas.c lens) — active ONLY when a
-        // `DefineMaterials` translucent material scoped u_alpha below 1 (strict, so
-        // it can't affect movies without one). The lens tint is a vivid (high-chroma)
-        // blue, while the frame (black), the reflection highlight (white) and the dark
-        // rim are all low-chroma — so opacity tracks CHROMA (max-min): vivid blue →
-        // the transparent window (world shows); black vignette, white highlight AND
-        // the dark edge stay opaque, giving a smooth rim instead of a jagged one.
+    } else if (u_mode == 2) {
+        // Chroma (`.c`, leo3d's glas.c lens): opacity tracks CHROMA (max-min) —
+        // vivid blue tint → the transparent window (world shows through); the black
+        // vignette, the white highlight AND the dark rim are low-chroma so they stay
+        // opaque, giving a smooth rim instead of a jagged one.
         float mx = max(t.r, max(t.g, t.b));
         float mn = min(t.r, min(t.g, t.b));
         frag = vec4(t.rgb, 1.0 - (mx - mn));
     } else {
-        frag = vec4(t.rgb, t.a);
+        // Normal: straight alpha (a `.s`/`.a` mask, the corner matte, or an opaque
+        // bitmap) scaled by the overlay's blend.
+        frag = vec4(t.rgb, t.a * u_alpha);
     }
 }
 "#;
+
+/// Grace period (in stage draws) a Groove scene keeps compositing after its last
+/// `submit_frame`. Continuously-driven scenes reset the counter every frame, so
+/// this only bounds how long a scene the game has NAVIGATED AWAY FROM lingers
+/// before it fades out (e.g. BioBoxing's title arena when you open Instructions).
+const STALE_DRAWS: i32 = 125;
 
 struct OverlayShader {
     program: WebGlProgram,
     u_rect: Option<WebGlUniformLocation>,
     u_tex: Option<WebGlUniformLocation>,
     u_alpha: Option<WebGlUniformLocation>,
-    u_greenkey: Option<WebGlUniformLocation>,
+    u_mode: Option<WebGlUniformLocation>,
     vao: web_sys::WebGlVertexArrayObject,
 }
 
@@ -144,10 +148,6 @@ struct GlBatch {
     tex_name: String,
     mesh: Mesh3dBuffers,
 }
-
-/// Only composite while the game is actively driving the scene: it must have
-/// submitted on the current movie frame AND within the last couple of draws.
-const STALE_DRAWS: i32 = 2;
 
 /// GL-side caches + shader. Lazily initialized.
 pub struct XtraSceneRenderer {
@@ -213,7 +213,7 @@ impl XtraSceneRenderer {
             u_rect: gl.get_uniform_location(&program, "u_rect"),
             u_tex: gl.get_uniform_location(&program, "u_tex"),
             u_alpha: gl.get_uniform_location(&program, "u_alpha"),
-            u_greenkey: gl.get_uniform_location(&program, "u_greenkey"),
+            u_mode: gl.get_uniform_location(&program, "u_mode"),
             vao,
             program,
         });
@@ -259,14 +259,23 @@ impl XtraSceneRenderer {
         // Collect the scene ids to draw, gating on staleness. We bump
         // `draws_since_submit` here (a store write) then release the store
         // borrow so the GL work below can freely re-borrow it read-only.
-        let current_frame = player.movie.current_frame as i32;
         let scene_ids: Vec<i32> = with_store_mut(|store| {
             let mut ids = Vec::new();
             for (id, scene) in store.scenes.iter_mut() {
+                // Composite the last submitted frame, and keep compositing it for a
+                // short GRACE period after the game stops submitting. Two failure
+                // modes to avoid:
+                //  - The old strict gate (`last_submit_frame == current_frame`) cut
+                //    the scene the instant the movie changed frame → hard-cut
+                //    transitions, and it blacked out a menu that submits once then
+                //    holds while the movie plays on.
+                //  - Persisting FOREVER left a stale scene (e.g. BioBoxing's title
+                //    arena) composited over a later Director-only screen
+                //    (Instructions), hiding it.
+                // The grace (draws_since_submit) smooths transitions yet lets a scene
+                // the game has navigated away from fade out. A continuously-driven
+                // scene resets the counter every submit and always renders.
                 if scene.frame.is_none() {
-                    continue;
-                }
-                if scene.last_submit_frame != current_frame {
                     continue;
                 }
                 scene.draws_since_submit += 1;
@@ -305,7 +314,13 @@ impl XtraSceneRenderer {
             Some(f) => f,
             None => return,
         };
-        if frame.draws.is_empty() {
+        // Bail only when there's nothing to composite at all. A menu / title
+        // screen is 2D overlays over a background with NO 3D models, so
+        // `frame.draws` is empty while `frame.overlays` is not — returning here
+        // would skip the overlay pass (draw_overlays, below) and leave the menu
+        // blank. The 3D mesh/texture/draw loops that follow all iterate
+        // `frame.draws`, so they naturally no-op when it's empty.
+        if frame.draws.is_empty() && frame.overlays.is_empty() {
             return;
         }
 
@@ -630,20 +645,15 @@ impl XtraSceneRenderer {
             let vh = viewport_h.max(1) as f32;
             let ndc_x = |x: f32| x / vw * 2.0 - 1.0;
             let ndc_y = |y: f32| 1.0 - y / vh * 2.0;
-            // `.c` sprites (leo3d's glas.c lens) draw ADDITIVE — a translucent tint
-            // you see the world through; `.g` sprites (BioBoxing logo) are green-keyed
-            // alpha. Groove picks this per the sprite's texture format; the extension
-            // is our proxy.
-            // `.c` sprites are translucent (alpha blend at the material-defined
-            // opacity carried in `ov.blend`, no color key); `.g` sprites are
-            // green-keyed. Both use normal alpha blending.
-            let translucent = ov.tex_name.len() >= 2
-                && ov.tex_name[ov.tex_name.len() - 2..].eq_ignore_ascii_case(".c");
+            // Transparency mode comes from the PLUGIN (OverlayCmd.blit_mode):
+            // 0 = Normal alpha, 1 = Greenscreen (`.g`), 2 = Chroma (`.c`). The host
+            // no longer sniffs `tex_name` — the plugin owns the extension decision.
+            // All modes use standard SRC_ALPHA over-blending.
             gl.blend_func(
                 WebGl2RenderingContext::SRC_ALPHA,
                 WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA,
             );
-            gl.uniform1i(ov_shader.u_greenkey.as_ref(), if translucent { 0 } else { 1 });
+            gl.uniform1i(ov_shader.u_mode.as_ref(), ov.blit_mode as i32);
             // u_rect = (left,bottom)→(right,top) so corner (0,0)=bottom-left.
             gl.uniform4f(ov_shader.u_rect.as_ref(), ndc_x(left), ndc_y(bottom), ndc_x(right), ndc_y(top));
             gl.uniform1f(ov_shader.u_alpha.as_ref(), (ov.blend / 100.0).clamp(0.0, 1.0));
@@ -713,8 +723,9 @@ fn upload_rgba(context: &WebGL2Context, w: u32, h: u32, rgba: &[u8]) -> Option<W
     Some(tex)
 }
 
-/// Resolve `name` to a movie bitmap cast member and upload it as a GL texture.
-fn upload_named_texture(context: &WebGL2Context, player: &DirPlayer, name: &str) -> Option<WebGlTexture> {
+/// Resolve a movie bitmap cast member by name and expand it to opaque RGBA
+/// (native-depth `bitmap.data` — 8-bit indexed / 16 / 32 — via the cast palette).
+fn resolve_bitmap_rgba(player: &DirPlayer, name: &str) -> Option<(usize, usize, Vec<u8>)> {
     let mref = player.movie.cast_manager.find_member_ref_by_name(name)?;
     let member = player.movie.cast_manager.find_member_by_ref(&mref)?;
     let bref = match &member.member_type {
@@ -722,7 +733,85 @@ fn upload_named_texture(context: &WebGL2Context, player: &DirPlayer, name: &str)
         _ => return None,
     };
     let bitmap = player.bitmap_manager.get_bitmap(bref)?;
-    upload_rgba(context, bitmap.width as u32, bitmap.height as u32, &bitmap.data)
+    let palettes = player.movie.cast_manager.palettes();
+    let rgba = super::WebGL2Renderer::bitmap_to_rgba(bitmap, &palettes, 0, None, None, None, false);
+    Some((bitmap.width as usize, bitmap.height as usize, rgba))
+}
+
+/// Resolve `name` to a movie bitmap cast member and upload it as a GL texture.
+///
+/// Groove sprites carry transparency as a SEPARATE companion bitmap: `<base>.s`
+/// is the 32-bit color image and `<base>.a` is an 8-bit **grayscale alpha mask**
+/// (white = opaque, black = transparent — the sprite silhouette). The two are
+/// authored as a pair. So load the `.s` color, then load the `.a` mask and use
+/// its luminance as the alpha channel. Only when there is no `.a` companion do we
+/// fall back to the corner-color matte (plain sprites like the character glyphs,
+/// which have no mask).
+fn upload_named_texture(context: &WebGL2Context, player: &DirPlayer, name: &str) -> Option<WebGlTexture> {
+    let (w, h, mut rgba) = resolve_bitmap_rgba(player, name)?;
+    // Companion alpha mask name: `foo.s` -> `foo.a`.
+    let alpha_name = name
+        .strip_suffix(".s")
+        .or_else(|| name.strip_suffix(".S"))
+        .map(|base| format!("{}.a", base));
+    let mut used_mask = false;
+    if let Some(an) = alpha_name {
+        if let Some((aw, ah, amask)) = resolve_bitmap_rgba(player, &an) {
+            if aw == w && ah == h {
+                // Grayscale mask → R == G == B; take R as the alpha value.
+                for i in 0..(w * h) {
+                    rgba[i * 4 + 3] = amask[i * 4];
+                }
+                used_mask = true;
+            }
+        }
+    }
+    if !used_mask {
+        matte_edge_transparent(&mut rgba, w, h);
+    }
+    upload_rgba(context, w as u32, h as u32, &rgba)
+}
+
+/// Color-key matte for plain Groove overlay sprites that have NO `.a` alpha
+/// companion (the character glyphs). The key color is the most common color
+/// along the border (the sprite's background). EVERY pixel of that color is
+/// keyed to alpha 0 — not just the edge-connected region — so the enclosed
+/// holes of letters like O/G also become transparent and reveal the button
+/// behind, instead of showing the key color. Glyphs are single-color letters on
+/// a flat key background, so keying all key-color pixels is safe. Sprites that
+/// carry a real silhouette (title/buttons) use their `.a` mask and never reach
+/// this path.
+fn matte_edge_transparent(rgba: &mut [u8], w: usize, h: usize) {
+    if w == 0 || h == 0 || rgba.len() < w * h * 4 {
+        return;
+    }
+    let px = |x: usize, y: usize| (y * w + x) * 4;
+    // Dominant border color = the background key.
+    let mut counts: std::collections::HashMap<[u8; 3], u32> = std::collections::HashMap::new();
+    let mut tally = |x: usize, y: usize| {
+        let p = px(x, y);
+        if rgba[p + 3] != 0 {
+            *counts.entry([rgba[p], rgba[p + 1], rgba[p + 2]]).or_insert(0) += 1;
+        }
+    };
+    for x in 0..w {
+        tally(x, 0);
+        tally(x, h - 1);
+    }
+    for y in 0..h {
+        tally(0, y);
+        tally(w - 1, y);
+    }
+    let key = match counts.into_iter().max_by_key(|&(_, c)| c) {
+        Some((color, _)) => color,
+        None => return,
+    };
+    for i in 0..(w * h) {
+        let p = i * 4;
+        if rgba[p] == key[0] && rgba[p + 1] == key[1] && rgba[p + 2] == key[2] {
+            rgba[p + 3] = 0;
+        }
+    }
 }
 
 // ---- minimal column-major mat4 helpers (GL order) ----

--- a/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/xtra_scene.rs
@@ -29,14 +29,17 @@ precision highp float;
 layout(location=0) in vec3 a_pos;
 layout(location=1) in vec3 a_normal;
 layout(location=2) in vec2 a_uv;
+layout(location=6) in vec4 a_color;
 uniform mat4 u_mvp;
 uniform mat4 u_model;
 out vec3 v_normal;
 out vec2 v_uv;
+out vec4 v_color;
 void main() {
     gl_Position = u_mvp * vec4(a_pos, 1.0);
     v_normal = mat3(u_model) * a_normal;
     v_uv = a_uv;
+    v_color = a_color;
 }
 "#;
 
@@ -44,22 +47,83 @@ const FS: &str = r#"#version 300 es
 precision highp float;
 in vec3 v_normal;
 in vec2 v_uv;
+in vec4 v_color;
 uniform vec3 u_light_dir;
 uniform vec3 u_light_color;
 uniform float u_ambient;
 uniform vec3 u_color;
 uniform sampler2D u_tex;
 uniform int u_has_tex;
+uniform int u_has_vcolor;
 uniform float u_alpha;
 out vec4 frag;
 void main() {
+    vec3 tex = u_has_tex == 1 ? texture(u_tex, v_uv).rgb : vec3(1.0);
+    // Base lit color (GL fixed-function-style: ambient floor + directional diffuse).
     vec3 n = normalize(v_normal);
     float diff = max(abs(dot(n, normalize(u_light_dir))), 0.0);
     float shade = u_ambient + (1.0 - u_ambient) * diff;
-    vec3 tex = u_has_tex == 1 ? texture(u_tex, v_uv).rgb : vec3(1.0);
-    frag = vec4(tex * u_color * u_light_color * shade, u_alpha);
+    vec3 lit = tex * u_color * u_light_color * shade;
+    // Material emission (self-illumination) is ADDED on top of the lit surface —
+    // it does not replace lighting. Zero for non-emissive / non-material faces.
+    vec3 emis = u_has_vcolor == 1 ? v_color.rgb : vec3(0.0);
+    frag = vec4(lit + emis, u_alpha);
 }
 "#;
+
+/// 2D overlay shader: a unit-quad corner (loc 0) mapped into an NDC rect, textured.
+const OVERLAY_VS: &str = r#"#version 300 es
+precision highp float;
+layout(location=0) in vec2 a_corner;
+uniform vec4 u_rect;   // (x0,y0, x1,y1) in NDC: (left,bottom)→(right,top)
+out vec2 v_uv;
+void main() {
+    vec2 p = mix(u_rect.xy, u_rect.zw, a_corner);
+    gl_Position = vec4(p, 0.0, 1.0);
+    v_uv = vec2(a_corner.x, 1.0 - a_corner.y); // texture origin top-left
+}
+"#;
+
+const OVERLAY_FS: &str = r#"#version 300 es
+precision highp float;
+in vec2 v_uv;
+uniform sampler2D u_tex;
+uniform float u_alpha;
+uniform int u_greenkey;
+out vec4 frag;
+void main() {
+    vec4 t = texture(u_tex, v_uv);
+    if (u_greenkey == 1) {
+        // Groove `.g` sprites bake transparency as a green color key (dirplayer
+        // loads them opaque). Key out green-dominant texels; soft edge kills halo.
+        float greenness = t.g - max(t.r, t.b);
+        float key = 1.0 - smoothstep(0.15, 0.35, greenness);
+        frag = vec4(t.rgb, t.a * u_alpha * key);
+    } else if (u_alpha < 0.999) {
+        // Translucent `.c` sprite (leo3d's glas.c lens) — active ONLY when a
+        // `DefineMaterials` translucent material scoped u_alpha below 1 (strict, so
+        // it can't affect movies without one). The lens tint is a vivid (high-chroma)
+        // blue, while the frame (black), the reflection highlight (white) and the dark
+        // rim are all low-chroma — so opacity tracks CHROMA (max-min): vivid blue →
+        // the transparent window (world shows); black vignette, white highlight AND
+        // the dark edge stay opaque, giving a smooth rim instead of a jagged one.
+        float mx = max(t.r, max(t.g, t.b));
+        float mn = min(t.r, min(t.g, t.b));
+        frag = vec4(t.rgb, 1.0 - (mx - mn));
+    } else {
+        frag = vec4(t.rgb, t.a);
+    }
+}
+"#;
+
+struct OverlayShader {
+    program: WebGlProgram,
+    u_rect: Option<WebGlUniformLocation>,
+    u_tex: Option<WebGlUniformLocation>,
+    u_alpha: Option<WebGlUniformLocation>,
+    u_greenkey: Option<WebGlUniformLocation>,
+    vao: web_sys::WebGlVertexArrayObject,
+}
 
 struct ShaderProgram {
     program: WebGlProgram,
@@ -71,6 +135,7 @@ struct ShaderProgram {
     u_color: Option<WebGlUniformLocation>,
     u_tex: Option<WebGlUniformLocation>,
     u_has_tex: Option<WebGlUniformLocation>,
+    u_has_vcolor: Option<WebGlUniformLocation>,
     u_alpha: Option<WebGlUniformLocation>,
 }
 
@@ -87,6 +152,7 @@ const STALE_DRAWS: i32 = 2;
 /// GL-side caches + shader. Lazily initialized.
 pub struct XtraSceneRenderer {
     shader: Option<ShaderProgram>,
+    overlay: Option<OverlayShader>,
     /// Uploaded mesh buffers keyed by (scene_id, mesh_id): (store generation, batches).
     meshes: HashMap<(i32, u32), (u64, Vec<GlBatch>)>,
     /// GL textures keyed by (scene_id, name): (source generation, texture). For a
@@ -100,7 +166,58 @@ const CAST_TEX_GEN: u64 = u64::MAX;
 
 impl XtraSceneRenderer {
     pub fn new() -> Self {
-        XtraSceneRenderer { shader: None, meshes: HashMap::new(), textures: HashMap::new() }
+        XtraSceneRenderer {
+            shader: None,
+            overlay: None,
+            meshes: HashMap::new(),
+            textures: HashMap::new(),
+        }
+    }
+
+    /// Lazily build the 2D overlay shader + its unit-quad VAO.
+    fn ensure_overlay(&mut self, context: &WebGL2Context) -> bool {
+        if self.overlay.is_some() {
+            return true;
+        }
+        let gl = context.gl();
+        let vs = match context.compile_shader(WebGl2RenderingContext::VERTEX_SHADER, OVERLAY_VS) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let fs = match context.compile_shader(WebGl2RenderingContext::FRAGMENT_SHADER, OVERLAY_FS) {
+            Ok(s) => s,
+            Err(_) => return false,
+        };
+        let program = match context.link_program(&vs, &fs) {
+            Ok(p) => p,
+            Err(_) => return false,
+        };
+        let Some(vao) = gl.create_vertex_array() else { return false };
+        let Some(vbo) = gl.create_buffer() else { return false };
+        gl.bind_vertex_array(Some(&vao));
+        gl.bind_buffer(WebGl2RenderingContext::ARRAY_BUFFER, Some(&vbo));
+        // Two triangles of the unit quad: corners (0,0)(1,0)(0,1)(1,1).
+        let corners: [f32; 12] = [0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0, 1.0, 0.0, 1.0, 1.0];
+        unsafe {
+            let view = js_sys::Float32Array::view(&corners);
+            gl.buffer_data_with_array_buffer_view(
+                WebGl2RenderingContext::ARRAY_BUFFER,
+                &view,
+                WebGl2RenderingContext::STATIC_DRAW,
+            );
+        }
+        gl.enable_vertex_attrib_array(0);
+        gl.vertex_attrib_pointer_with_i32(0, 2, WebGl2RenderingContext::FLOAT, false, 0, 0);
+        gl.bind_vertex_array(None);
+        self.overlay = Some(OverlayShader {
+            u_rect: gl.get_uniform_location(&program, "u_rect"),
+            u_tex: gl.get_uniform_location(&program, "u_tex"),
+            u_alpha: gl.get_uniform_location(&program, "u_alpha"),
+            u_greenkey: gl.get_uniform_location(&program, "u_greenkey"),
+            vao,
+            program,
+        });
+        true
     }
 
     fn ensure_shader(&mut self, context: &WebGL2Context) -> bool {
@@ -130,6 +247,7 @@ impl XtraSceneRenderer {
             u_color: u("u_color"),
             u_tex: u("u_tex"),
             u_has_tex: u("u_has_tex"),
+            u_has_vcolor: u("u_has_vcolor"),
             u_alpha: u("u_alpha"),
             program,
         });
@@ -244,6 +362,11 @@ impl XtraSceneRenderer {
         }
         gl.enable(WebGl2RenderingContext::BLEND);
         gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+        // Per-object depth priority (SetObjectDepth) uses polygon offset so coplanar
+        // surfaces (a TV screen + its scanline overlay) don't z-fight/flicker.
+        gl.enable(WebGl2RenderingContext::POLYGON_OFFSET_FILL);
+        // Back-face culling is per-draw (bfculling); front faces are CCW.
+        gl.front_face(WebGl2RenderingContext::CCW);
 
         let shader = self.shader.as_ref().unwrap();
         gl.use_program(Some(&shader.program));
@@ -256,6 +379,10 @@ impl XtraSceneRenderer {
         gl.uniform1f(shader.u_ambient.as_ref(), frame.ambient.clamp(0.0, 1.0));
 
         let aspect = if rect_h > 0 { rect_w as f32 / rect_h as f32 } else { 1.0 };
+        // Large far plane: Groove worlds are big and some views (leo3d's fernglas
+        // dolly-zoom) look at very distant features. A tighter far clips them —
+        // the TV-screen moiré that prompted a tighter far was actually back-face
+        // culling, not depth precision, so keep the original generous range.
         let proj = perspective(frame.camera.fov.to_radians().max(0.1), aspect, 1.0, 200_000.0);
         let view = look_at(frame.camera.pos, frame.camera.look_at, [0.0, 0.0, 1.0]);
         let view_proj = mat_mul(&proj, &view);
@@ -276,6 +403,28 @@ impl XtraSceneRenderer {
             gl.uniform1f(shader.u_alpha.as_ref(), alpha);
             gl.depth_mask(alpha >= 0.999);
             gl.uniform1i(shader.u_tex.as_ref(), 0);
+            // Back-face culling per the shape's bfculling flag. Groove models bake
+            // double-sided coplanar faces (screen quads wound both ways); culling
+            // the back-facing copy stops the two from z-fighting into a moiré.
+            if d.cull {
+                gl.enable(WebGl2RenderingContext::CULL_FACE);
+                gl.cull_face(WebGl2RenderingContext::BACK);
+            } else {
+                gl.disable(WebGl2RenderingContext::CULL_FACE);
+            }
+            // SetObjectDepth priority. A fixed value >= 1 is a FRONT LAYER: Groove
+            // composites it on top of the scene, so we skip the depth test (else a
+            // near-coplanar front object — the 3D logo box over the truss — z-fights
+            // into a moiré/hatch). Auto (-1/0) and draw-behind (-2) keep the normal
+            // depth test, with a polygon offset to separate coplanar surfaces.
+            if d.depth >= 1 {
+                gl.depth_func(WebGl2RenderingContext::ALWAYS);
+                gl.polygon_offset(0.0, 0.0);
+            } else {
+                gl.depth_func(WebGl2RenderingContext::LEQUAL);
+                let poff = if d.depth == -2 { 2.0 } else { 0.0 };
+                gl.polygon_offset(poff, poff);
+            }
 
             for (bi, batch) in batches.iter().enumerate() {
                 if d.batch >= 0 && d.batch as usize != bi {
@@ -286,6 +435,22 @@ impl XtraSceneRenderer {
                     .as_deref()
                     .filter(|n| !n.is_empty())
                     .unwrap_or(batch.tex_name.as_str());
+                // Groove `.add` textures are drawn with ADDITIVE blending (engine
+                // blend mode 2 = SRC_ALPHA, ONE): black areas add nothing (read as
+                // transparent), bright areas glow over the scene. Everything else
+                // uses the standard alpha blend.
+                let additive = tex_name.len() >= 4
+                    && tex_name[tex_name.len() - 4..].eq_ignore_ascii_case(".add");
+                if additive {
+                    gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE);
+                    gl.depth_mask(false);
+                } else {
+                    gl.blend_func(
+                        WebGl2RenderingContext::SRC_ALPHA,
+                        WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA,
+                    );
+                    gl.depth_mask(alpha >= 0.999);
+                }
                 let tex = self
                     .textures
                     .get(&(scene_id, tex_name.to_string()))
@@ -297,16 +462,24 @@ impl XtraSceneRenderer {
                 } else {
                     gl.uniform1i(shader.u_has_tex.as_ref(), 0);
                 }
+                // Batches with baked material colors render unlit (self-illuminated).
+                gl.uniform1i(shader.u_has_vcolor.as_ref(), batch.mesh.has_vertex_colors as i32);
                 batch.mesh.bind(gl);
                 batch.mesh.draw(gl);
                 batch.mesh.unbind(gl);
             }
         }
         gl.depth_mask(true);
+        gl.polygon_offset(0.0, 0.0);
+        gl.disable(WebGl2RenderingContext::POLYGON_OFFSET_FILL);
+        gl.disable(WebGl2RenderingContext::CULL_FACE);
         gl.disable(WebGl2RenderingContext::BLEND);
         gl.disable(WebGl2RenderingContext::DEPTH_TEST);
         gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
         gl.viewport(0, 0, fb_w, fb_h);
+
+        // 2D bitmap overlays over the full stage, composited after the 3D scene.
+        self.draw_overlays(context, player, scene_id, &frame.overlays, viewport_w, viewport_h);
     }
 
     /// Build/refresh the GL buffers for one mesh if the store's generation advanced.
@@ -320,7 +493,8 @@ impl XtraSceneRenderer {
         }
         // Rebuild from the store's CPU batches.
         let batches = with_store_mut(|store| {
-            let mut out: Vec<(String, Vec<[f32; 3]>, Vec<[f32; 3]>, Vec<[f32; 2]>)> = Vec::new();
+            let mut out: Vec<(String, Vec<[f32; 3]>, Vec<[f32; 3]>, Vec<[f32; 2]>, Vec<[f32; 4]>)> =
+                Vec::new();
             if let Some(m) = store.scenes.get(&scene_id).and_then(|s| s.meshes.get(&mesh_id)) {
                 for b in &m.data.batches {
                     out.push((
@@ -328,20 +502,22 @@ impl XtraSceneRenderer {
                         chunk3(&b.positions),
                         chunk3(&b.normals),
                         chunk2(&b.uvs),
+                        chunk4(&b.colors),
                     ));
                 }
             }
             out
         });
         let mut gl_batches = Vec::new();
-        for (tex_name, positions, normals, uvs) in batches {
+        for (tex_name, positions, normals, uvs, colors) in batches {
             let n_tris = positions.len() / 3;
             let faces: Vec<[u32; 3]> =
                 (0..n_tris).map(|i| [(i * 3) as u32, (i * 3 + 1) as u32, (i * 3 + 2) as u32]).collect();
             let uvs_opt = if uvs.len() == positions.len() { Some(uvs.as_slice()) } else { None };
-            if let Ok(mesh) =
-                Mesh3dBuffers::new(context, &positions, &normals, uvs_opt, None, &faces)
-            {
+            let colors_opt = if colors.len() == positions.len() { Some(colors.as_slice()) } else { None };
+            if let Ok(mesh) = Mesh3dBuffers::new_full(
+                context, &positions, &normals, uvs_opt, None, &faces, None, None, colors_opt,
+            ) {
                 gl_batches.push(GlBatch { tex_name, mesh });
             }
         }
@@ -376,6 +552,108 @@ impl XtraSceneRenderer {
         let tex = upload_named_texture(context, player, name);
         self.textures.insert(key, (CAST_TEX_GEN, tex));
     }
+
+    /// Native pixel size of an overlay's texture — a plugin-uploaded sprite
+    /// (store) or a movie bitmap cast member resolved by name.
+    fn overlay_texture_size(&self, player: &DirPlayer, scene_id: i32, name: &str) -> Option<(i32, i32)> {
+        let store_size = with_store_mut(|store| {
+            store
+                .scenes
+                .get(&scene_id)
+                .and_then(|s| s.textures.get(name))
+                .map(|t| (t.w as i32, t.h as i32))
+        });
+        if let Some((w, h)) = store_size {
+            if w > 0 && h > 0 {
+                return Some((w, h));
+            }
+        }
+        let mref = player.movie.cast_manager.find_member_ref_by_name(name)?;
+        let member = player.movie.cast_manager.find_member_by_ref(&mref)?;
+        let bref = match &member.member_type {
+            CastMemberType::Bitmap(b) => b.image_ref,
+            _ => return None,
+        };
+        let bitmap = player.bitmap_manager.get_bitmap(bref)?;
+        Some((bitmap.width as i32, bitmap.height as i32))
+    }
+
+    /// Composite the frame's 2D bitmap overlays over the full stage (Groove
+    /// `AddOverlay`). Center-anchored at `loc` in stage px; blend → alpha.
+    fn draw_overlays(
+        &mut self,
+        context: &WebGL2Context,
+        player: &DirPlayer,
+        scene_id: i32,
+        overlays: &[xtra_sdk::scene3d::OverlayCmd],
+        viewport_w: i32,
+        viewport_h: i32,
+    ) {
+        if overlays.is_empty() || !self.ensure_overlay(context) {
+            return;
+        }
+        // Resolve every overlay's texture + native size first (mutates self).
+        for ov in overlays {
+            if !ov.tex_name.is_empty() {
+                self.ensure_texture(context, player, scene_id, &ov.tex_name);
+            }
+        }
+        let gl = context.gl();
+        let fb_w = gl.drawing_buffer_width();
+        let fb_h = gl.drawing_buffer_height();
+        gl.viewport(0, 0, fb_w, fb_h);
+        gl.disable(WebGl2RenderingContext::DEPTH_TEST);
+        gl.disable(WebGl2RenderingContext::SCISSOR_TEST);
+        gl.enable(WebGl2RenderingContext::BLEND);
+        gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+        let ov_shader = self.overlay.as_ref().unwrap();
+        gl.use_program(Some(&ov_shader.program));
+        gl.bind_vertex_array(Some(&ov_shader.vao));
+        gl.uniform1i(ov_shader.u_tex.as_ref(), 0);
+        for ov in overlays {
+            let tex = self
+                .textures
+                .get(&(scene_id, ov.tex_name.clone()))
+                .and_then(|(_, t)| t.as_ref());
+            let Some(tex) = tex else { continue };
+            let (nw, nh) = self.overlay_texture_size(player, scene_id, &ov.tex_name).unwrap_or((0, 0));
+            let w = if ov.size[0] > 0 { ov.size[0] } else { nw };
+            let h = if ov.size[1] > 0 { ov.size[1] } else { nh };
+            if w <= 0 || h <= 0 {
+                continue;
+            }
+            // Center-anchored stage-pixel rect → NDC (y flipped, top-left origin).
+            let (cx, cy) = (ov.loc[0] as f32, ov.loc[1] as f32);
+            let (left, right) = (cx - w as f32 / 2.0, cx + w as f32 / 2.0);
+            let (top, bottom) = (cy - h as f32 / 2.0, cy + h as f32 / 2.0);
+            let vw = viewport_w.max(1) as f32;
+            let vh = viewport_h.max(1) as f32;
+            let ndc_x = |x: f32| x / vw * 2.0 - 1.0;
+            let ndc_y = |y: f32| 1.0 - y / vh * 2.0;
+            // `.c` sprites (leo3d's glas.c lens) draw ADDITIVE — a translucent tint
+            // you see the world through; `.g` sprites (BioBoxing logo) are green-keyed
+            // alpha. Groove picks this per the sprite's texture format; the extension
+            // is our proxy.
+            // `.c` sprites are translucent (alpha blend at the material-defined
+            // opacity carried in `ov.blend`, no color key); `.g` sprites are
+            // green-keyed. Both use normal alpha blending.
+            let translucent = ov.tex_name.len() >= 2
+                && ov.tex_name[ov.tex_name.len() - 2..].eq_ignore_ascii_case(".c");
+            gl.blend_func(
+                WebGl2RenderingContext::SRC_ALPHA,
+                WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA,
+            );
+            gl.uniform1i(ov_shader.u_greenkey.as_ref(), if translucent { 0 } else { 1 });
+            // u_rect = (left,bottom)→(right,top) so corner (0,0)=bottom-left.
+            gl.uniform4f(ov_shader.u_rect.as_ref(), ndc_x(left), ndc_y(bottom), ndc_x(right), ndc_y(top));
+            gl.uniform1f(ov_shader.u_alpha.as_ref(), (ov.blend / 100.0).clamp(0.0, 1.0));
+            gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+            gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(tex));
+            gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 6);
+        }
+        gl.bind_vertex_array(None);
+        gl.disable(WebGl2RenderingContext::BLEND);
+    }
 }
 
 fn chunk3(v: &[f32]) -> Vec<[f32; 3]> {
@@ -384,6 +662,9 @@ fn chunk3(v: &[f32]) -> Vec<[f32; 3]> {
 fn chunk2(v: &[f32]) -> Vec<[f32; 2]> {
     v.chunks_exact(2).map(|c| [c[0], c[1]]).collect()
 }
+fn chunk4(v: &[f32]) -> Vec<[f32; 4]> {
+    v.chunks_exact(4).map(|c| [c[0], c[1], c[2], c[3]]).collect()
+}
 
 fn upload_rgba(context: &WebGL2Context, w: u32, h: u32, rgba: &[u8]) -> Option<WebGlTexture> {
     if w == 0 || h == 0 || rgba.len() != (w * h * 4) as usize {
@@ -391,6 +672,44 @@ fn upload_rgba(context: &WebGL2Context, w: u32, h: u32, rgba: &[u8]) -> Option<W
     }
     let tex = context.create_texture().ok()?;
     context.upload_texture_rgba(&tex, w, h, rgba).ok()?;
+    // Groove 3D surfaces tile textures via UVs > 1 (e.g. the stands repeat a
+    // spectator strip 4× across each row). The shared uploader sets CLAMP_TO_EDGE,
+    // which would fill only the first tile — override to REPEAT. WebGL2 allows
+    // REPEAT on NPOT textures; for 0..1 UVs (overlays) it's identical to clamp.
+    let gl = context.gl();
+    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(&tex));
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D,
+        WebGl2RenderingContext::TEXTURE_WRAP_S,
+        WebGl2RenderingContext::REPEAT as i32,
+    );
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D,
+        WebGl2RenderingContext::TEXTURE_WRAP_T,
+        WebGl2RenderingContext::REPEAT as i32,
+    );
+    // Trilinear + mipmaps. The shared uploader sets NEAREST, which aliases badly
+    // when high-frequency 3D textures (the stands' net/grid, distant screens) are
+    // minified — producing a shimmering moiré that flickers as the camera orbits.
+    // Mipmapped LINEAR resolves it (WebGL2 allows mipmaps on NPOT textures).
+    gl.generate_mipmap(WebGl2RenderingContext::TEXTURE_2D);
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D,
+        WebGl2RenderingContext::TEXTURE_MIN_FILTER,
+        WebGl2RenderingContext::LINEAR_MIPMAP_LINEAR as i32,
+    );
+    gl.tex_parameteri(
+        WebGl2RenderingContext::TEXTURE_2D,
+        WebGl2RenderingContext::TEXTURE_MAG_FILTER,
+        WebGl2RenderingContext::LINEAR as i32,
+    );
+    // Anisotropic filtering. The TV screens sit on arena walls viewed at steep
+    // angles, where plain trilinear mipmapping still aliases the fine screen/LED
+    // pattern into a moiré "net". EXT_texture_filter_anisotropic resolves it.
+    // TEXTURE_MAX_ANISOTROPY_EXT = 0x84FE.
+    if matches!(gl.get_extension("EXT_texture_filter_anisotropic"), Ok(Some(_))) {
+        gl.tex_parameterf(WebGl2RenderingContext::TEXTURE_2D, 0x84FE, 16.0);
+    }
     Some(tex)
 }
 

--- a/vm-rust/tests/browser_templates/dirplayer-js-api.js
+++ b/vm-rust/tests/browser_templates/dirplayer-js-api.js
@@ -63,7 +63,16 @@ function flashManager() {
   if (_flashManager) return Promise.resolve(_flashManager);
   if (!_flashManagerPromise) {
     _flashManagerPromise = import('./flashPlayerManager.bundle.js')
-      .then(mod => (_flashManager = mod))
+      .then(mod => {
+        // Install the window.dirplayer_ruffle* globals the WASM frame loop
+        // calls into (setSize / isPlaying / getCurrentFrame / gotoFrameAndStop /
+        // getVariable / …). The dev app does this from callbacks.ts at startup;
+        // the test stub must do it here or those frame-loop externs reference
+        // undefined globals. (The Rust side also `catch`es them, so a failure
+        // here degrades to a no-op rather than killing the frame loop.)
+        try { mod.initFlashBridge?.(); } catch (e) { console.warn('[flash] initFlashBridge failed:', e); }
+        return (_flashManager = mod);
+      })
       .catch(err => {
         console.warn('[flash] bundle not available:', err?.message || err);
         return (_flashManager = { createFlashInstance: () => {}, destroyFlashInstance: () => {} });
@@ -71,15 +80,21 @@ function flashManager() {
   }
   return _flashManagerPromise;
 }
-export function onFlashMemberLoaded(castLib, castMember, swfData, width, height) {
+export function onFlashMemberLoaded(spriteNum, castLib, castMember, swfData, width, height, pausedAtStart, assertedFrame) {
   const copy = new Uint8Array(swfData);
   flashManager().then(m => {
-    m.createFlashInstance?.(castLib, castMember, copy, width, height)
+    m.createFlashInstance?.(spriteNum, castLib, castMember, copy, width, height, pausedAtStart, assertedFrame)
       ?.catch?.(e => console.error('createFlashInstance failed:', e));
   });
 }
-export function onFlashMemberUnloaded(castLib, castMember) {
-  flashManager().then(m => m.destroyFlashInstance?.(castLib, castMember));
+export function onFlashMemberUnloaded(spriteNum) {
+  flashManager().then(m => m.destroyFlashInstance?.(spriteNum));
+}
+export function onFlashResetAll() {
+  // Only tear down if the Flash bundle was actually loaded by a prior movie;
+  // don't import it just to reset nothing on a pure non-Flash test run.
+  if (_flashManager) _flashManager.destroyAllFlashInstances?.();
+  else if (_flashManagerPromise) _flashManagerPromise.then(m => m.destroyAllFlashInstances?.());
 }
 export function onStageSizeChanged() {}
 

--- a/vm-rust/tests/browser_templates/index.template.html
+++ b/vm-rust/tests/browser_templates/index.template.html
@@ -81,6 +81,8 @@
     window.__testResults = null;
     window.__testEnv = $TEST_ENV_JSON;
     window.__testDebug = $DEBUG_MODE;
+    // Optional substring filter (E2E_FILTER env var) — run only matching test_* fns.
+    window.__testFilter = "$TEST_FILTER";
 
     // Ruffle + DirPlayer Flash bridge — mirrors public/index.html setup.
     // dirplayer-rs ships a fork of Ruffle namespaced under
@@ -89,7 +91,10 @@
     // Ruffle if both are loaded on the same page.
     window.dirplayer_RufflePlayer = window.dirplayer_RufflePlayer || {};
     window.dirplayer_RufflePlayer.config = { allowNetworking: "all" };
-    window.__dirplayerFlashConfig = { renderer: "canvas", logLevel: "warn" };
+    // logLevel 'error': Ruffle logs to console, and the browser retains every
+    // console entry — at 'info'/'warn' a busy SWF floods it every frame and RAM
+    // climbs over a long test run. Keep only hard errors.
+    window.__dirplayerFlashConfig = { renderer: "canvas", logLevel: "error" };
   </script>
   <script src="./ruffle/dirplayer_ruffle.js"></script>
   <script type="importmap">
@@ -205,8 +210,11 @@
       api.setVmModule(wasm);
       statusLine('Module loaded. Running tests...');
 
+      const testFilter = (window.__testFilter || '').trim().toLowerCase();
+      const filterParts = testFilter ? testFilter.split(',').map(s => s.trim()).filter(Boolean) : [];
       const testFns = Object.keys(wasm)
-        .filter(k => k.startsWith('test_') && typeof wasm[k] === 'function');
+        .filter(k => k.startsWith('test_') && typeof wasm[k] === 'function')
+        .filter(k => filterParts.length === 0 || filterParts.some(f => k.toLowerCase().includes(f)));
 
       for (const name of testFns) {
         const group = startTest(name);

--- a/vm-rust/tests/e2e/lego/supersonic.rs
+++ b/vm-rust/tests/e2e/lego/supersonic.rs
@@ -33,15 +33,15 @@ browser_e2e_test!(test_supersonic_load, |player| async move {
 
     player.step_until(datum("_movie.frame").equals(StaticDatum::Int(95))).timeout(15.0).await?;
 
-    player.step_frames(100).await;
+    player.step_frames(200).await;
 
     snapshots.verify("game_control", player.snapshot_stage())?;
 
-    player.click_sprite(sprite().number(67)).await?;
+    player.click_sprite(sprite().number(61)).await?;
 
     player.step_until(datum("_movie.frame").equals(StaticDatum::Int(70))).timeout(15.0).await?;
 
-    player.step_frames(100).await;
+    player.step_frames(200).await;
 
     snapshots.verify("in_game", player.snapshot_stage())?;
 

--- a/vm-rust/tests/e2e/nintendo/melon.rs
+++ b/vm-rust/tests/e2e/nintendo/melon.rs
@@ -17,15 +17,15 @@ browser_e2e_test!(test_nintendo_melon_load, |player| async move {
 
     player.step_until(datum("_movie.frame").equals(StaticDatum::Int(1))).timeout(10.0).await?;
 
-    player.step_frames(1).await;
+    player.step_frames(250).await;
 
     snapshots.verify("start_game", player.snapshot_stage())?;
 
-    player.step_frames(15).await;
+    player.step_frames(250).await;
 
     player.click_sprite(sprite().member("play_button")).await?;
 
-    player.step_frames(5).await;
+    player.step_frames(250).await;
 
     snapshots.verify("in_match", player.snapshot_stage())?;
 

--- a/xtra-sdk/Cargo.lock
+++ b/xtra-sdk/Cargo.lock
@@ -64,6 +64,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,4 +136,5 @@ version = "0.1.0"
 dependencies = [
  "postcard",
  "serde",
+ "serde_bytes",
 ]

--- a/xtra-sdk/src/host_env.rs
+++ b/xtra-sdk/src/host_env.rs
@@ -76,6 +76,58 @@ enum HostOp {
     /// Args: `[Datum::String(xtra_name), Datum::Int(instance_id)]`.
     /// Returns void.
     DestroyXtraInstance = 7,
+
+    // ── 3D scene rendering (see `crate::scene3d`) ─────────────────────────
+
+    /// Args: `[Datum::String(tag)]`. Returns `Datum::Int(scene_id)`.
+    /// Idempotent per tag — the same tag always maps to the same scene.
+    Scene3dCreate = 8,
+
+    /// Args: `[Datum::Int(scene_id), Datum::Int(mesh_id),
+    /// Datum::ByteArray(postcard MeshData)]`. Returns void. Re-uploading the
+    /// same `mesh_id` replaces its geometry (the deform path).
+    Scene3dUploadMesh = 9,
+
+    /// Args: `[Datum::Int(scene_id), Datum::Int(mesh_id)]`. Returns void.
+    Scene3dDropMesh = 10,
+
+    /// Args: `[Datum::Int(scene_id), Datum::String(name), Datum::Int(w),
+    /// Datum::Int(h), Datum::ByteArray(rgba)]`. Returns void. For
+    /// CPU-composed textures; cast-member textures resolve host-side by name.
+    Scene3dUploadTexture = 11,
+
+    /// Args: `[Datum::Int(scene_id), Datum::ByteArray(postcard FrameData)]`.
+    /// Returns void. The host stores the frame and composites it in its next
+    /// draw pass.
+    Scene3dSubmitFrame = 12,
+
+    /// Args: `[Datum::Int(scene_id)]`. Returns void. Frees the scene's meshes
+    /// and textures.
+    Scene3dDestroy = 13,
+
+    // ── Host state a compute-only plugin reads ────────────────────────────
+
+    /// Args: `[Datum::String(member_name), Datum::String(kind)]`. Returns the
+    /// raw bytes of the named cast member as `Datum::ByteArray`, or
+    /// `Datum::Void` if there's no such member of that `kind`. `kind` gates the
+    /// member type (e.g. `"groove3gm"`), so a plugin can't read arbitrary
+    /// member data.
+    CastMemberBytes = 14,
+
+    /// Args: `[]`. Returns `Datum::List[Int(stage_w), Int(stage_h),
+    /// Int(current_frame)]`.
+    StageInfo = 15,
+
+    /// Args: `[]`. Returns `Datum::Point(mouseH, mouseV)`.
+    MouseLoc = 16,
+
+    /// Args: `[Datum::String(key_name)]`. Returns `Datum::Bool(is_down)`.
+    KeyDown = 17,
+
+    /// Args: `[Datum::String(name), Datum::<any>(value)]`. Sets a Lingo global
+    /// so scripts can read it (e.g. Groove's `collideX`…`collideTexture`).
+    /// Returns void.
+    SetLingoGlobal = 18,
 }
 
 // ── Low-level glue: call dx_host_call and decode ────────────────────────
@@ -204,6 +256,120 @@ pub fn destroy_xtra_instance(xtra_name: &str, instance_id: InstanceId) {
             Datum::String(String::from(xtra_name)),
             Datum::Int(instance_id as i32),
         ],
+    );
+}
+
+// ── 3D scene rendering wrappers ──────────────────────────────────────────
+
+use crate::scene3d::{FrameData, MeshData};
+
+/// Create (or look up) a host-side 3D scene keyed by `tag`. Idempotent — the
+/// same tag returns the same scene id for the plugin's whole lifetime. The
+/// returned id addresses the scene in every other `scene3d_*` call.
+pub fn scene3d_create(tag: &str) -> Result<i32, String> {
+    match invoke_for_datum(HostOp::Scene3dCreate, &[Datum::String(String::from(tag))])? {
+        Datum::Int(id) => Ok(id),
+        other => Err(alloc::format!("scene3d_create: expected Int, got {:?}", other)),
+    }
+}
+
+/// Upload (or replace) the geometry of mesh `mesh_id` in `scene_id`. Cheap to
+/// call once per shape; re-call with the same id to replace after a deform.
+pub fn scene3d_upload_mesh(scene_id: i32, mesh_id: u32, mesh: &MeshData) {
+    invoke(
+        HostOp::Scene3dUploadMesh,
+        &[
+            Datum::Int(scene_id),
+            Datum::Int(mesh_id as i32),
+            Datum::ByteArray(mesh.to_bytes()),
+        ],
+    );
+}
+
+/// Drop mesh `mesh_id` from `scene_id` (releases its host GL buffers lazily).
+pub fn scene3d_drop_mesh(scene_id: i32, mesh_id: u32) {
+    invoke(
+        HostOp::Scene3dDropMesh,
+        &[Datum::Int(scene_id), Datum::Int(mesh_id as i32)],
+    );
+}
+
+/// Upload a CPU-composed RGBA texture under `name`. `rgba` must be
+/// `w * h * 4` bytes. Only needed for textures the plugin composes itself;
+/// textures that live as movie bitmap cast members resolve host-side by name.
+pub fn scene3d_upload_texture(scene_id: i32, name: &str, w: i32, h: i32, rgba: Vec<u8>) {
+    invoke(
+        HostOp::Scene3dUploadTexture,
+        &[
+            Datum::Int(scene_id),
+            Datum::String(String::from(name)),
+            Datum::Int(w),
+            Datum::Int(h),
+            Datum::ByteArray(rgba),
+        ],
+    );
+}
+
+/// Submit the frame to composite for `scene_id`. Call once per engine step;
+/// the host stores it and draws it on its next paint.
+pub fn scene3d_submit_frame(scene_id: i32, frame: &FrameData) {
+    invoke(
+        HostOp::Scene3dSubmitFrame,
+        &[Datum::Int(scene_id), Datum::ByteArray(frame.to_bytes())],
+    );
+}
+
+/// Destroy `scene_id`, freeing its meshes and textures.
+pub fn scene3d_destroy(scene_id: i32) {
+    invoke(HostOp::Scene3dDestroy, &[Datum::Int(scene_id)]);
+}
+
+// ── Host-state wrappers ──────────────────────────────────────────────────
+
+/// Fetch the raw bytes of the cast member named `name`, gated to `kind` (e.g.
+/// `"groove3gm"`). Returns `None` if there's no such member of that kind.
+pub fn cast_member_bytes(name: &str, kind: &str) -> Option<Vec<u8>> {
+    match invoke_for_datum(
+        HostOp::CastMemberBytes,
+        &[Datum::String(String::from(name)), Datum::String(String::from(kind))],
+    ) {
+        Ok(Datum::ByteArray(b)) => Some(b),
+        _ => None,
+    }
+}
+
+/// Stage size and current movie frame: `(width, height, current_frame)`.
+pub fn stage_info() -> (i32, i32, i32) {
+    match invoke_for_datum(HostOp::StageInfo, &[]) {
+        Ok(Datum::List(items)) => {
+            let g = |i: usize| items.get(i).and_then(|d| d.as_int()).unwrap_or(0);
+            (g(0), g(1), g(2))
+        }
+        _ => (0, 0, 0),
+    }
+}
+
+/// Current mouse position in stage pixels: `(mouseH, mouseV)`.
+pub fn mouse_loc() -> (i32, i32) {
+    match invoke_for_datum(HostOp::MouseLoc, &[]) {
+        Ok(Datum::Point(x, y)) => (x as i32, y as i32),
+        _ => (0, 0),
+    }
+}
+
+/// Whether the named key is currently held (Director key names / chars).
+pub fn key_down(key: &str) -> bool {
+    invoke_for_datum(HostOp::KeyDown, &[Datum::String(String::from(key))])
+        .ok()
+        .and_then(|d| d.as_bool())
+        .unwrap_or(false)
+}
+
+/// Set a Lingo global `name` to `value` so movie scripts can read it.
+pub fn set_lingo_global(name: &str, value: Datum) {
+    invoke(
+        HostOp::SetLingoGlobal,
+        &[Datum::String(String::from(name)), value],
     );
 }
 

--- a/xtra-sdk/src/host_env.rs
+++ b/xtra-sdk/src/host_env.rs
@@ -128,6 +128,13 @@ enum HostOp {
     /// so scripts can read it (e.g. Groove's `collideX`…`collideTexture`).
     /// Returns void.
     SetLingoGlobal = 18,
+
+    /// Args: `[Datum::String(member_name)]`. Returns `Datum::List[Int(w),
+    /// Int(h)]` — the natural pixel size of the named bitmap cast member — or
+    /// `Datum::Void` if it isn't a bitmap. A plugin that positions art by name
+    /// (Groove's sprites/overlays) needs the authored size to hit-test it; only
+    /// the host can resolve a member.
+    MemberSize = 19,
 }
 
 // ── Low-level glue: call dx_host_call and decode ────────────────────────
@@ -163,7 +170,7 @@ fn invoke_for_datum(op: HostOp, args: &[Datum]) -> Result<Datum, String> {
 
 // ── Ergonomic wrappers ───────────────────────────────────────────────────
 
-/// Write a debug-level log line. Visible in the host's developer console.
+/// Write a log line to the host's developer console.
 #[inline]
 pub fn log(msg: &str) {
     invoke(HostOp::Log, &[Datum::String(String::from(msg))]);
@@ -350,6 +357,17 @@ pub fn stage_info() -> (i32, i32, i32) {
 }
 
 /// Current mouse position in stage pixels: `(mouseH, mouseV)`.
+/// Natural pixel size of a bitmap cast member, or `None` if it isn't one.
+pub fn member_size(name: &str) -> Option<(i32, i32)> {
+    match invoke_for_datum(HostOp::MemberSize, &[Datum::String(String::from(name))]) {
+        Ok(Datum::List(v)) if v.len() >= 2 => match (&v[0], &v[1]) {
+            (Datum::Int(w), Datum::Int(h)) => Some((*w, *h)),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 pub fn mouse_loc() -> (i32, i32) {
     match invoke_for_datum(HostOp::MouseLoc, &[]) {
         Ok(Datum::Point(x, y)) => (x as i32, y as i32),

--- a/xtra-sdk/src/lib.rs
+++ b/xtra-sdk/src/lib.rs
@@ -48,6 +48,7 @@ pub mod abi;
 pub mod datum;
 pub mod host_env;
 pub mod plugin;
+pub mod scene3d;
 pub mod wire;
 
 pub use datum::{Datum, InstanceId};

--- a/xtra-sdk/src/scene3d.rs
+++ b/xtra-sdk/src/scene3d.rs
@@ -106,6 +106,11 @@ pub struct OverlayCmd {
     pub size: [i32; 2],
     pub blend: f32,
     pub channel: i32,
+    /// Transparency/blit mode, decided by the PLUGIN from the sprite's Groove
+    /// extension (the host must not re-parse `tex_name`): 0 = Normal (straight
+    /// alpha — a `.s`/`.a` color+mask pair or an opaque sprite), 1 = Greenscreen
+    /// (`.g`, green color key), 2 = Chroma (`.c`, translucent-lens chroma alpha).
+    pub blit_mode: u8,
 }
 
 /// A full frame to composite. `render_rect` (stage pixels, l/t/r/b) bounds the

--- a/xtra-sdk/src/scene3d.rs
+++ b/xtra-sdk/src/scene3d.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-only
+//
+//! Typed 3D scene frames crossing the host↔plugin boundary.
+//!
+//! The base [`Datum`](crate::Datum) wire only carries scalar/list values, which
+//! is a poor fit for the dense f32 buffers a 3D engine plugin (e.g. the Groove
+//! Xtra) needs to push at the host renderer. Rather than widen `Datum` with
+//! geometry variants, these structs are postcard-encoded into a
+//! [`Datum::ByteArray`](crate::Datum::ByteArray) — the SDK's binary channel — so
+//! host and plugin share one source of truth and cannot drift.
+//!
+//! ## Split of responsibility
+//!
+//! - **Meshes** ([`MeshData`]) cross **once**, when the plugin creates a shape,
+//!   and again only when that shape's geometry is edited (deform). They are
+//!   non-indexed, flat-shaded, per-material triangle batches.
+//! - **Frames** ([`FrameData`]) cross **every step** and carry only draw
+//!   commands — a per-batch model matrix + material, *not* geometry. The plugin
+//!   evaluates its own animation and ships the resulting matrices, so per-frame
+//!   traffic stays small (a few KB of f32s even for a busy scene).
+//!
+//! See `docs/Groove-Xtra-Plugin-Plan.md` for the full rationale.
+
+use alloc::{string::String, vec::Vec};
+use serde::{Deserialize, Serialize};
+
+/// One non-indexed, flat-shaded triangle batch of a single material.
+///
+/// `positions`/`normals` are `3 * vertex_count` long, `uvs` is
+/// `2 * vertex_count`; vertices are consumed three-at-a-time as triangles
+/// (index `0,1,2, 3,4,5, …`). `tex_name` is the host-resolved texture name
+/// (a movie bitmap cast member, or a name uploaded via `Scene3dUploadTexture`);
+/// empty means untextured.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MeshBatch {
+    pub tex_name: String,
+    pub positions: Vec<f32>,
+    pub normals: Vec<f32>,
+    pub uvs: Vec<f32>,
+}
+
+/// A complete uploadable mesh — the batch set for one shape or one deformed
+/// object. Re-uploading under the same mesh id replaces the previous data.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MeshData {
+    pub batches: Vec<MeshBatch>,
+}
+
+/// Camera for a frame. `pos`/`look_at` are world-space; `fov` is the vertical
+/// field of view in degrees. Up is +Z (the engine's world up).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Camera {
+    pub pos: [f32; 3],
+    pub look_at: [f32; 3],
+    pub fov: f32,
+}
+
+/// A single directional light. `dir` is the direction the light travels;
+/// `color` is linear 0..1 RGB.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct Light {
+    pub dir: [f32; 3],
+    pub color: [f32; 3],
+}
+
+/// One draw call: place batch(es) of an uploaded mesh with a model matrix and
+/// material. `batch = -1` draws every batch of the mesh; `>= 0` selects one.
+/// `model` is a column-major (GL order) 4×4. `tex_override`, when set, replaces
+/// every batch's own texture name for this draw.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DrawCmd {
+    pub mesh_id: u32,
+    pub batch: i32,
+    pub model: [f32; 16],
+    pub color: [u8; 3],
+    pub alpha: f32,
+    pub tex_override: Option<String>,
+}
+
+/// A full frame to composite. `render_rect` (stage pixels, l/t/r/b) bounds the
+/// 3D view; `None` means the whole stage. `background`, when set, clears the
+/// rect to that color (an opaque windowed view); `None` composites over the 2D
+/// layer without a color clear.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FrameData {
+    pub render_rect: Option<(i32, i32, i32, i32)>,
+    pub background: Option<[u8; 3]>,
+    pub camera: Camera,
+    /// Ambient floor, 0..1 (already mapped from any engine-specific percent).
+    pub ambient: f32,
+    pub light: Option<Light>,
+    pub draws: Vec<DrawCmd>,
+}
+
+impl MeshData {
+    /// Postcard-encode for transport inside a `Datum::ByteArray`.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).unwrap_or_default()
+    }
+    /// Decode a payload produced by [`MeshData::to_bytes`].
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}
+
+impl FrameData {
+    /// Postcard-encode for transport inside a `Datum::ByteArray`.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        postcard::to_allocvec(self).unwrap_or_default()
+    }
+    /// Decode a payload produced by [`FrameData::to_bytes`].
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+}

--- a/xtra-sdk/src/scene3d.rs
+++ b/xtra-sdk/src/scene3d.rs
@@ -93,6 +93,14 @@ pub struct DrawCmd {
     /// moiré. When true the host culls back faces (front = CCW).
     #[serde(default)]
     pub cull: bool,
+    /// Groove `SetWorldBackground`: this draw is the world's BACKGROUND (skydome),
+    /// not world geometry. The engine hides the source object and re-draws it from
+    /// a dedicated per-viewport slot with its position zeroed, so it can never be
+    /// left behind however small it is (the engine's own default is a radius-10000
+    /// sphere). The host draws it first, centred on the camera, with the depth test
+    /// and depth writes off so all real geometry composites over it.
+    #[serde(default)]
+    pub background: bool,
 }
 
 /// A 2D screen-space bitmap overlay composited over (or under) the 3D scene

--- a/xtra-sdk/src/scene3d.rs
+++ b/xtra-sdk/src/scene3d.rs
@@ -37,6 +37,13 @@ pub struct MeshBatch {
     pub positions: Vec<f32>,
     pub normals: Vec<f32>,
     pub uvs: Vec<f32>,
+    /// Optional per-vertex color, `4 * vertex_count` (RGBA, 0..1) or empty. When
+    /// non-empty the host renders this batch **unlit** (the color is the final
+    /// fragment color, mirroring an engine that bakes material emission/diffuse
+    /// into flat vertex colors — e.g. Groove's `glColorPointer`); empty keeps the
+    /// batch on the lit/textured path.
+    #[serde(default)]
+    pub colors: Vec<f32>,
 }
 
 /// A complete uploadable mesh — the batch set for one shape or one deformed
@@ -75,6 +82,30 @@ pub struct DrawCmd {
     pub color: [u8; 3],
     pub alpha: f32,
     pub tex_override: Option<String>,
+    /// Groove `SetObjectDepth` priority: `-1` auto, `-2` draw-behind, `>= 0` fixed
+    /// (higher = closer to camera). The host applies a matching polygon-offset so
+    /// coplanar surfaces (e.g. a screen + its scanline overlay) don't z-fight.
+    #[serde(default)]
+    pub depth: i32,
+    /// Back-face culling (the shape's `Atr2` bfculling flag). Groove models are
+    /// authored with double-sided coplanar faces (e.g. a screen quad wound both
+    /// ways); without culling the two opposite-wound triangles z-fight into a
+    /// moiré. When true the host culls back faces (front = CCW).
+    #[serde(default)]
+    pub cull: bool,
+}
+
+/// A 2D screen-space bitmap overlay composited over (or under) the 3D scene
+/// (Groove `AddOverlay`). Center-anchored at `loc` in stage pixels; `size` `[0,0]`
+/// means use the texture's native size. `blend` is 0..100 (→ alpha). `channel`
+/// is z-order: negative draws below the 3D scene, `>= 0` above it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OverlayCmd {
+    pub tex_name: String,
+    pub loc: [i32; 2],
+    pub size: [i32; 2],
+    pub blend: f32,
+    pub channel: i32,
 }
 
 /// A full frame to composite. `render_rect` (stage pixels, l/t/r/b) bounds the
@@ -90,6 +121,10 @@ pub struct FrameData {
     pub ambient: f32,
     pub light: Option<Light>,
     pub draws: Vec<DrawCmd>,
+    /// 2D bitmap overlays (Groove `AddOverlay`), composited in stage space after
+    /// the 3D scene, ordered by `channel`.
+    #[serde(default)]
+    pub overlays: Vec<OverlayCmd>,
 }
 
 impl MeshData {


### PR DESCRIPTION
# PR: Broad runtime compatibility pass

A broad compatibility pass across the Director runtime, bringing a large batch of
real Shockwave-era titles to a playable state. Headline additions: a
**3D Groove Playback Xtra** port — shipped as an **external wasm plugin** on a new
`scene3d` SDK — plus a new `.3GM` member type, **nested `#movie` (Linked Movie)**
playback, and an **MV3 browser-extension** path for cross-origin Flash content.
The rest are targeted correctness fixes across Shockwave 3D, Havok physics,
Flash/Ruffle interop, text/PFR rendering, sound, score/sprites, and core Lingo.

**Scope:** 142 commits · 119 files · +16,114 / −2,314 (vs `upstream/main`)

## Highlights

- **3D Groove Playback Xtra** — a full port of the Groove engine (keyframe
  animation, per-part hierarchy, collision, camera, overlays) plus the `.3GM`
  (type-15 XMED) member type. The engine lives in a **standalone wasm plugin**
  (`xtras/groove-xtra`) built against the Xtra SDK; the host keeps only an
  engine-agnostic `scene3d` bridge and composites the plugin's draw data with its
  own WebGL2 renderer. Two real Groove games (*Leo's Great Day II*, *Hey Arnold!
  Runaway Bus*) are playable end-to-end.
- **Xtra SDK `scene3d` API** — the first *rendering* plugin surface: retained
  geometry + per-frame draw commands pushed from a plugin to the host. Groove is
  its reference consumer.
- **Nested `#movie` playback** — Linked Movie members run via a de-globalized
  child player.
- **MV3 extension** — cross-origin CORS through a service-worker proxy + DNR,
  and a bridge exposing the full Flash player API to the main world.
- **Flash/Ruffle interop maturity** — per-sprite instances, member-swap
  reconcile, reg-point/flip anchoring, LocalConnection receivers (Neopets DGS),
  `getVariable`→`FlashObjectRef`, AS-ready gating, `mouseOverButton`/`hitTest`.

## Changes by area

### Xtra plugins / SDK
- `scene3d` host API + auto-load: a plugin declares 3D scene data, the host
  buffers it and draws it in the normal pass (materials, translucent overlays,
  culling, depth).
- Groove engine extracted from `vm-rust` into the `xtras/groove-xtra` submodule
  (this is why the diff nets ~8.4k lines *out* of the host).
- SDK: visible plugin logs, `MemberSize`, `DrawCmd.background`.
- Xtra scene renderer: two O(N²) passes dropped, decoded blit modes, background
  draw.
- Groove overlays: 2D menus, `.s`/`.a` alpha masks, palette expand, `blit_mode`.
- `.3GM` (`Groove3gm`) cast member type + `#g3d` shape type.

### Shockwave 3D (W3D)
- Per-model `keyframePlayer`/`bonesPlayer` state (fixes cloned/multiple skinned
  models sharing one motion); biped skin relativized to idle-pose root.
- Contour-based `extrude3D` pipeline (caps with holes, bevel), higher trace
  resolution, extrusion-resolution cap.
- CLOD: geometric normal recompute; lightmap 2nd-UV kept out of the +0.5 remap.
- Rendering: skybox camera-centering + extended far plane, spot-cone/fallback-
  light fixes, rgba4444 alpha, SkyLine texture flip, `GL_BLEND` for 2D after 3D,
  Firefox `highp int` shader fix.
- API: `modelsUnderRay` optionsList + front-face culling, `bone[]`/`bone.count`,
  `pointAt` parent-local, `transform` axis/slerp fixes, `#collision`
  modifier/callback, `newMesh`/`meshDeform`, `cloneMotionFromCastmember`,
  texture-clone renaming, `randomVector()`.

### Havok physics
- "On the Run" drivable; chassis inertia in spawn-rotated frame + authored
  displacement-COM.
- HKE metadata parsing (displacement-COM / collisions-disabled / casts-shadows),
  polyhedron mass properties, body initial orientation.
- Auto-sleep/wake, edge-resting, `attemptMoveTo` rejects blocked targets,
  `havok.reset()`, angular-path (worldScale²) fixes.

### Flash / Ruffle
- Member geometry (SWF frameCount, QuickDraw regPoint/rect), per-sprite frame
  intent, dynamic resize, un-stretched sprites at natural size + click rebase.
- LocalConnection Director-owned receivers, `newObject`/linked-SWF/event
  dispatch, fscommand bridge, loop=false stop-at-end, external-cast reload,
  Ruffle submodule bumps.

### Text / PFR / fonts
- Habbo PFR rendering (anchoring, `#adjust` auto-size, underline), Volter
  strike-vs-outline sizing, XMED Section-2 byte-exact concatenation.
- RTE text members + member-attached/parent scripts; fields render per-run STXT
  colors (and size/face) instead of one flat color.

### Core Lingo / VM
- Case-insensitive globals, VOID leniency (VOID list index, `length()`→0),
  `birth()`, `setAt` growth, `member(N)` empty-slot ref, busy-wait/keyDown loop
  yielding, list×scalar recursion (any length), `preload`, `set the timer`,
  marker nav, compare operators for chunk/point/symbol/list.
- `findPosNear` global form, 2-arg `atan` (atan2), `netAbort`/`netStatus`,
  prop-list key ops, sound-verb `do()`, `new()` returning the instance when
  `on new` omits `return me`, `setProp` on an invalid reference ignored rather
  than raising.

### Sound
- SWA/MP3 playback + dev-UI preview, MP3 detection fix, synchronous `soundBusy`
  after `puppetSound`.

### Score / sprites / behaviors
- `puppetSprite(N,FALSE)` deferred revert, behavior re-apply after `on new me`,
  exitFrame on forward advance, empty-channel last-rect retention, rolling-buffer
  frame parse.
- D6/D7 sprite-span parsing (52+ byte spans, filmloop length underflow), D6 blend
  flag, stretch-flag sprite dims, D6-only per-frame member swap, frame-script
  instance recreated on span change.

### Bitmap / rendering / tooling
- 1-bit getPixel, same-palette copyPixels fast path, `importFileInto` regPoint
  centering; WebGL texture eviction, context-loss pause; per-movie CORS proxy
  opt-in, quieter logging, `E2E_FILTER`.
- Dev UI: chunk tree no longer collapses to ILS/KEY* (owner id 1024 collision).

---


fixes #158 
fixes #118 
fixes #207 
fixes #176
fixes #175
fixes #162
fixes #160
fixes #157
fixes #156
fixes #155 
fixes #154
fixes #18
fixes #17 
fixes #16 
fixes #15
fixes #47
fixes #187 

improves #121
improves #82 
improves #45 
improves #13 
improves #171 


<details>
<summary>All 142 commits (newest first)</summary>

- Bump groove-xtra to the README link fixes
- Bump groove-xtra to the legacy Dot2/Dots/Pos parse
- Bump groove-xtra to the n-gon parser + camera/collision fixes
- Xtra scene: drop two O(N^2) passes, decode blit modes, draw the background
- Xtra SDK: make plugin logs visible, add MemberSize, DrawCmd.background
- Cast member: ignore setProp on an invalid reference instead of erroring
- Lingo: scalar * list multiplication for any list length
- Lingo: findPosNear global function form for lists/prop-lists
- Groove overlays: 2D menus, .s/.a alpha masks, palette expand, blit_mode
- Lingo/VM: netAbort, prop-list key ops, sound-verb do(), .3GM #g3d type
- Lingo: 2-arg atan (atan2) + Flash getVariable member-swap guard
- vm: Groove scene3d renderer + SDK — materials, translucent overlays, culling, depth
- Groove: external wasm plugin (scene3d host API + auto-load)
- Flash: render un-stretched sprites at member natural size + fix click rebase
- Lingo/VM: case-insensitive globals, VOID list index, and leo3d props
- Groove: add .3GM (Groove3gm) cast member type
- Fish: animate during keyDown loops; guard sendSprite re-entrancy
- Lingo: member(N) yields a by-number ref for an empty slot
- keyboard: deliver browser key-repeats to on keyDown
- bitmap: 1-bit getPixel + index-preserving copyPixels
- bitmap: image.draw()/fill() accept a bare color or leading color
- bitmap: importFileInto centers the imported member's regPoint
- Lingo: yield busy-wait loops that poll a clock
- Lingo: birth() constructs a fresh per-instance object
- webgl2: background-transparent inks 2/4/6/34/38
- Lingo: setAt grows a linear list past its end
- Movie: add enableFlashLingo property (stored, non-gating)
- DEV UI: make CORS proxy opt-in per movie
- ruffle: bump submodule (fscommand alias + LocalConnection.send hook)
- MV3 extension: cross-origin CORS via service-worker proxy + DNR
- MV3 extension: bridge the full Flash player API to the main world
- Flash LocalConnection: Director-owned receivers (Neopets DGS score/protocol)
- vm: getVariable(path, 0) returns a FlashObjectRef for AS object handles
- Behavior init: re-apply Score params after `on new me`
- LoadMovie: Shockwave loader-mode UI + per-load CORS proxy field
- puppetSprite(N,FALSE): defer the revert to the next frame tick
- Flash interop: block per-sprite calls until the SWF is AS-ready
- ruffle: bump submodule to avm1 prototype-chain cap fix
- flashPlayerManager: outstanding-fetch + active-flash-count signals for the frame-loop yield
- Nested #movie (Linked Movie) playback via a de-globalized player
- lingo: match Director's VOID leniency instead of raising
- bitmap: same-palette 8-bit copyPixels fast path
- cors-proxy: preserve upstream Content-Length for accurate getStreamStatus
- Loader mode: dev CORS proxy + Flash fscommand bridge
- length() coerces VOID to 0
- Flash Asset interop: newObject, path rooting, linked SWF, event dispatch
- Flash: default Ruffle logLevel to error instead of hardcoded info
- Tests: E2E_FILTER to run a subset of browser tests; quieter harness
- Logging: quiet benign per-frame/load diagnostics; sound decoder uses the log crate
- Player: free the outgoing movie's resources on reset; tolerate a missing Flash bridge
- Renderer: free per-frame and evicted WebGL textures
- W3D: cap 3D-text extrusion resolution
- Score: parse frames with a rolling buffer, drop the retained dense grid
- File: recognise SWA compression GUIDs (both byte orders)
- Shape: decode shape type 4 as line
- Lingo: implement preload (returns the last frame loaded)
- Compare: support string-chunk/sprite/symbol/list/instance in < and >
- Movie/net: go/next marker navigation + graceful net-status handlers
- Movie: support `set the timer`
- Flash: stop loop=false members at end of timeline
- Flash: render anchoring — reg-point placement, flipH/flipV, frame get/set
- Flash: member geometry — SWF-header frameCount + QuickDraw regPoint/rect
- Flash: member-swap reconcile, per-sprite frame intent, dynamic resize
- Flash/sprite fixes for bogey_nights (D8)
- Flash/text/behavior fixes for pengapop
- Sprite: index a prop-list sprite property by key in getPropRef
- Sprite: stamp spriteNum on behaviors added via scriptInstanceList.add()
- Compare: support Point vs scalar for > and <
- value(): evaluate only the first complete list expression
- Field: grow word-wrapped #scroll/#fixed fields to fit small overflow
- Movie: fix puppetSound arg order + puppetSprite unpuppet clobber
- Player: dispatch sprite-behavior exitFrame on forward frame advance
- Havok: build chassis inertia in the spawn-rotated frame + keep authored DISPLACEMENT COM
- Havok: drop orphaned manifold/faithful-step state from HavokPhysicsState
- Havok: faithful angular-path fixes — worldScale² on torque/momentum + chassis COM
- Havok: attemptMoveTo rejects a blocked target (body_blocked_at), returns 0 on failure
- Sound: dev-UI sound preview + Shockwave Audio (SWA/MP3) playback fixes
- Havok: parse HKE rigid-body metadata (displacement-COM / collisions-disabled / casts-shadows) + polyhedron mass-properties + Lingo body props
- W3D: keep a file-provided 2nd UV set (lightmap) out of the CLOD +0.5 remap
- W3D: rename colliding cloned-model textures to -clone<N> (match Director)
- W3D: render skybox models camera-centered with an extended far plane
- W3D: sync runtime textureTransform to renderer + procedural bone-override wiggle
- W3D: SweeTarts raycast/scale/primitive/parent fixes
- Score: retain a sprite's last rect for empty-channel reads (Director keeps it after a span ends)
- W3D: transform interpolate/interpolateTo slerp rotation (was element-wise matrix lerp)
- Lingo: add randomVector() returning a uniform unit vector
- W3D: synthesize the implicit default motion at member.motion[1]
- Havok: apply the HKE body's initial orientation to mesh-derived bodies
- Havok: rest a body on a triangle edge, not just its face (road box seams)
- W3D: flip the upside-down SkyLine textures on upload
- W3D: keyframe motion uses a positioned clone's transform; rgba4444 alpha
- W3D: fire #collideAny events and size mesh collision from geometry
- W3D: cloneMotionFromCastmember clones the named source motion
- Havok: havok.reset() reverts the scene to its initial (.hke) state
- Havok: auto-sleep settled bodies (velocity-based deactivation)
- Havok: wake sleeping bodies on all disturbances + initial angular velocity
- Havok/Lingo: make "On the Run" drivable
- W3D/webgl2: force highp int in scene fragment shader (fix Firefox link error)
- sound: don't let placeholder sampleCount=1 suppress MP3 detection (Rasterwerks SFX)
- W3D: per-model keyframePlayer animation + clone motions (Splat feet/body); defaultRect setter
- W3D Shockwave3D object: #collision callback, count(#face), #sphere resolution, meshDeform, newMesh texCoords/UV
- Lingo: list * scalar multiply recurses into nested list/point/rect/vector elements
- Splat: fix directToStage 3D frozen behind (the stage).image HUD; size from defaultRect
- Flash: implement sprite.mouseOverButton + faithful sprite.hitTest
- 3D/text: raise native-font trace resolution (6..10) so extruded side walls don't gap
- 3D/lighting: fix spot cones + stop fallback lights flooding movie-lit scenes
- 3D text: contour-based extrude3D pipeline (caps with holes, bevel, no-PFR vectorizer)
- fps/mouse-look: fix click camera-jolt, Esc view-tilt, and inverted horizontal look
- 3D/overlay: camera overlay regPoint is in scaled pixels, not texture pixels
- fps/input: rightMouseDown() function returns the tracked right-button state
- 3D/skin: relativize biped skin by the idle-pose root (fix actor body facing)
- 3D/bonesPlayer: per-MODEL animation state (fix multiple skinned models sharing one motion)
- 3D: bone[] / bone.count resolve the model's own skeleton (fix cloned skinned models)
- 3D: pointAt stores a parent-LOCAL transform (fix aim on parented nodes)
- fps: skip setPointerCapture during Pointer Lock (fix shoot-click error)
- 3D/bonesPlayer: playList includes current motion + playNext advances
- 3D: transform.xAxis/yAxis/zAxis return unit basis vectors (strip scale)
- 3D/CLOD: recompute mesh normals geometrically (fix garbage decoded normals)
- text: concatenate XMED Section-2 chunks byte-for-byte (no phantom line breaks)
- 3D: meshDeform read API — face[] / face.count / normalList
- 3D: modelsUnderRay matches Director — optionsList arg + front-face culling
- movie: support `play movie <current>` in-place restart
- 3D: native #collision modifier, Flash-as-texture, and model/transform fixes
- bitmap: default image.draw() #shapeType to #line; drop dead arms
- score: only the main movie drives the channel-0 frame-script instance
- render: pause stage draw on WebGL context loss / hidden tab
- timeout: support the read/write `period` property
- 3D: enable GL_BLEND for 2D sprites after a 3D scene; insertOverlay
- sound: mark channel busy synchronously after puppetSound
- flash: reload Ruffle instances when an external cast is swapped in place
- text: Habbo PFR text rendering - anchoring, #adjust auto-size, underline
- pfr1: Volter strike-vs-outline sizing, bold-glyph drop, metrics
- score: don't honor stretch flag for <=1px reg-centering rounding
- score: recreate frame-script instance on span change (re-apply params)
- score: restrict per-frame member swap to D6 only
- cast: RTE text members + member-attached/parent scripts
- script: new() returns the instance when 'on new' omits 'return me'
- field: render per-run STXT colors (and size/face) instead of one color
- score: D6 blend flag, stretch-flag sprite dims, per-frame member swap
- vwsc: fix D6/D7 sprite span parsing (52+ byte spans, filmloop length underflow)
- dev-ui: fix chunk tree showing only ILS/KEY* (owner id 1024 collision)
- net: implement netStatus handler (no-op, VOID return)

</details>