### PR TITLE
shockwave3d clod parser and havok physics improvements

### DIFF
--- a/vm-rust/src/director/chunks/w3d/clod_decoder.rs
+++ b/vm-rust/src/director/chunks/w3d/clod_decoder.rs
@@ -33,6 +33,9 @@ pub struct ClodMeshDecoder {
     // Global resolution counter (persists across CLOD blocks)
     global_update_counter: u32,
 
+    // Global resolution of the update currently being decoded (for the corner-history boundary).
+    current_global_resolution: u32,
+
     // Per-mesh cursors (persist across CLOD blocks for multi-mesh)
     mesh_cursors: Option<Vec<usize>>,
 }
@@ -53,6 +56,7 @@ impl ClodMeshDecoder {
             sync_table: None,
             distal_edge_merges: None,
             global_update_counter: 0,
+            current_global_resolution: 0,
             mesh_cursors: None,
         }
     }
@@ -118,6 +122,9 @@ impl ClodMeshDecoder {
         if self.meshes.len() <= 1 {
             // Single mesh path
             for u in 0..update_count {
+                // +1 to match the multi-mesh SyncTable convention (global_res = counter + u + 1),
+                // so the corner-history boundary is consistent across single/multi mesh.
+                self.current_global_resolution = self.global_update_counter + u + 1;
                 if let Err(e) = self.decode_mesh_update(&mut bs, 0) {
                     debug!(
                         "[W3D CLOD] decode failed \"{}\" update {}/{}: {} ({} verts, {} faces so far)",
@@ -141,6 +148,7 @@ impl ClodMeshDecoder {
 
             for u in 0..update_count {
                 let global_res = self.global_update_counter + u + 1;
+                self.current_global_resolution = global_res;
 
                 // Apply distal edge merges at this resolution
                 self.apply_distal_edge_merges_at_resolution(global_res);
@@ -240,21 +248,20 @@ impl ClodMeshDecoder {
         self.meshes[mesh_idx].pending_face_record_surplus +=
             num_patch_records as i32 - num_face_corner_updates as i32;
 
-        // v11.X-style: snapshot AFTER loops but BEFORE batch.
-        // Predictions and split corners read from face_basis_snapshot (patches 0..N-2).
-        // Confirmed correct by Director 12 Lingo queries on both MA and MB models.
-        self.meshes[mesh_idx].face_basis_snapshot = self.meshes[mesh_idx].faces.clone();
-
-        // Apply this update's patch records (batch, after snapshot)
+        // Apply this update's patch records (batch), recording each into the per-corner resolution
+        // history so later predictions can read the corner at the SetResolution(resCounter-1) boundary.
+        let gres = self.current_global_resolution;
         let mesh = &mut self.meshes[mesh_idx];
         let patch_end = mesh.patch_records.len();
         let patch_start = patch_end - num_patch_records as usize;
         for pi in patch_start..patch_end {
-            let fi = mesh.patch_records[pi].face_index as usize;
-            let ci = mesh.patch_records[pi].corner_index as usize;
+            let fi = mesh.patch_records[pi].face_index;
+            let ci = mesh.patch_records[pi].corner_index as u8;
             let nvi = mesh.patch_records[pi].new_vertex_index;
-            if fi < mesh.faces.len() && ci < 3 {
-                mesh.faces[fi][ci] = nvi;
+            if (fi as usize) < mesh.faces.len() && (ci as usize) < 3 {
+                let old_val = mesh.faces[fi as usize][ci as usize];
+                mesh.faces[fi as usize][ci as usize] = nvi;
+                mesh.corner_history.entry((fi, ci)).or_insert_with(|| vec![(0u32, old_val)]).push((gres, nvi));
             }
         }
 
@@ -272,23 +279,18 @@ impl ClodMeshDecoder {
 
         if pred_mode != 4 {
             let pred_idx = bs.read_compressed_u32(5) as usize;
+            let boundary = self.current_global_resolution as i64 - 2;
             let mesh = &self.meshes[mesh_idx];
-            if pred_idx < mesh.sorted_faces.len() {
-                let face_idx = mesh.sorted_faces[pred_idx] as usize;
-                // Use face_basis_snapshot (pre-batch, patches 0..N-2) for predictions.
-                let face_source = if face_idx < mesh.face_basis_snapshot.len() {
-                    &mesh.face_basis_snapshot
-                } else {
-                    &mesh.faces
-                };
-                if face_idx < face_source.len() && (pred_mode as usize) < 3 {
-                    let corner_vert = face_source[face_idx][pred_mode as usize] as usize;
-                    if corner_vert < mesh.positions.len() {
-                        let p = mesh.positions[corner_vert];
-                        pred_x = p[0];
-                        pred_y = p[1];
-                        pred_z = p[2];
-                    }
+            if pred_idx < mesh.sorted_faces.len() && (pred_mode as usize) < 3 {
+                let face_idx = mesh.sorted_faces[pred_idx];
+                // Read the reference corner at the encoder's collapsed-resolution boundary
+                // (SetResolution(resCounter-1) => global_res <= global_res_N - 2), not the live mesh.
+                let corner_vert = mesh.corner_value_as_of(face_idx, pred_mode, boundary) as usize;
+                if corner_vert < mesh.positions.len() {
+                    let p = mesh.positions[corner_vert];
+                    pred_x = p[0];
+                    pred_y = p[1];
+                    pred_z = p[2];
                 }
             }
         }
@@ -314,22 +316,16 @@ impl ClodMeshDecoder {
 
         if norm_pred_mode != 4 {
             let norm_pred_idx = bs.read_compressed_u32(9) as usize;
+            let boundary = self.current_global_resolution as i64 - 2;
             let mesh = &self.meshes[mesh_idx];
-            if norm_pred_idx < mesh.sorted_faces.len() {
-                let face_idx = mesh.sorted_faces[norm_pred_idx] as usize;
-                let face_source = if face_idx < mesh.face_basis_snapshot.len() {
-                    &mesh.face_basis_snapshot
-                } else {
-                    &mesh.faces
-                };
-                if face_idx < face_source.len() && (norm_pred_mode as usize) < 3 {
-                    let corner_vert = face_source[face_idx][norm_pred_mode as usize] as usize;
-                    if corner_vert < mesh.normals.len() {
-                        let n = mesh.normals[corner_vert];
-                        pred_nx = n[0];
-                        pred_ny = n[1];
-                        pred_nz = n[2];
-                    }
+            if norm_pred_idx < mesh.sorted_faces.len() && (norm_pred_mode as usize) < 3 {
+                let face_idx = mesh.sorted_faces[norm_pred_idx];
+                let corner_vert = mesh.corner_value_as_of(face_idx, norm_pred_mode, boundary) as usize;
+                if corner_vert < mesh.normals.len() {
+                    let n = mesh.normals[corner_vert];
+                    pred_nx = n[0];
+                    pred_ny = n[1];
+                    pred_nz = n[2];
                 }
             }
         }
@@ -407,21 +403,15 @@ impl ClodMeshDecoder {
 
             if tc_pred_mode != 4 {
                 let tc_pred_idx = bs.read_compressed_u32(15) as usize;
+                let boundary = self.current_global_resolution as i64 - 2;
                 let mesh = &self.meshes[mesh_idx];
-                if tc_pred_idx < mesh.sorted_faces.len() {
-                    let face_idx = mesh.sorted_faces[tc_pred_idx] as usize;
-                    let face_source = if face_idx < mesh.face_basis_snapshot.len() {
-                        &mesh.face_basis_snapshot
-                    } else {
-                        &mesh.faces
-                    };
-                    if face_idx < face_source.len() && (tc_pred_mode as usize) < 3 {
-                        let corner_vert = face_source[face_idx][tc_pred_mode as usize] as usize;
-                        if layer < mesh.tex_coords.len() && corner_vert < mesh.tex_coords[layer].len() {
-                            let tc = mesh.tex_coords[layer][corner_vert];
-                            pred_u = tc[0];
-                            pred_v = tc[1];
-                        }
+                if tc_pred_idx < mesh.sorted_faces.len() && (tc_pred_mode as usize) < 3 {
+                    let face_idx = mesh.sorted_faces[tc_pred_idx];
+                    let corner_vert = mesh.corner_value_as_of(face_idx, tc_pred_mode, boundary) as usize;
+                    if layer < mesh.tex_coords.len() && corner_vert < mesh.tex_coords[layer].len() {
+                        let tc = mesh.tex_coords[layer][corner_vert];
+                        pred_u = tc[0];
+                        pred_v = tc[1];
                     }
                 }
             }
@@ -537,30 +527,34 @@ impl ClodMeshDecoder {
                     corners[c] = rel_idx + mesh.vertex_count - mesh.new_vert_count;
                 }
                 2 | 3 | 4 => {
-                    // Split from existing face corner
+                    // Split from existing face corner. Same collapsed-resolution boundary as the
+                    // position base (global_res <= global_res_N - 2) — base and connectivity reads
+                    // must share it (they are coupled through the decode cascade).
                     let split_idx = bs.read_compressed_u32(27) as usize;
                     let offset = bs.read_compressed_u32(28);
+                    let boundary = self.current_global_resolution as i64 - 2;
                     let mesh = &self.meshes[mesh_idx];
                     if split_idx < mesh.sorted_faces.len() {
-                        let face_idx = mesh.sorted_faces[split_idx] as usize;
-                        let corner = (corner_type - 2) as usize;
-                        // Use face_basis_snapshot for split corners (patches 0..N-2).
-                        let face_source = if face_idx < mesh.face_basis_snapshot.len() {
-                            &mesh.face_basis_snapshot
-                        } else {
-                            &mesh.faces
-                        };
-                        if face_idx < face_source.len() && corner < 3 {
-                            let base_vertex = face_source[face_idx][corner];
-                            corners[c] = offset + base_vertex;
-                        }
+                        let face_idx = mesh.sorted_faces[split_idx];
+                        let corner = (corner_type - 2) as u8;
+                        let base_vertex = mesh.corner_value_as_of(face_idx, corner, boundary);
+                        corners[c] = offset + base_vertex;
                     }
                 }
                 _ => {}
             }
         }
 
-        self.meshes[mesh_idx].faces.push(corners);
+        // Seed per-corner history at this face's creation resolution (face index = face_count).
+        let new_face_idx = self.meshes[mesh_idx].face_count;
+        let gres = self.current_global_resolution;
+        {
+            let mesh = &mut self.meshes[mesh_idx];
+            mesh.faces.push(corners);
+            for ci in 0u8..3 {
+                mesh.corner_history.insert((new_face_idx, ci), vec![(gres, corners[ci as usize])]);
+            }
+        }
 
         // Update face_write_cursor immediately after writing face (before neighbor mesh reads).
         // The C# does this at CLODMeshDecoder.cs:3043 — critical because neighbor mesh

--- a/vm-rust/src/director/chunks/w3d/clod_types.rs
+++ b/vm-rust/src/director/chunks/w3d/clod_types.rs
@@ -1,5 +1,7 @@
 /// Internal state types for CLOD (Continuous Level of Detail) mesh decoder.
 
+use std::collections::HashMap;
+
 #[derive(Clone, Debug)]
 pub struct UpdateHeader {
     pub num_new_verts: u32,
@@ -70,10 +72,11 @@ pub struct MeshState {
     pub step_records: Vec<StepRecord>,
     pub patch_records: Vec<PatchRecord>,
 
-    // v11.X-style face snapshot: captures mesh.faces AFTER loops but BEFORE batch.
-    // Predictions and split corners read from this snapshot (patches 0..N-2 at step N).
-    // Confirmed correct by Director 12 Lingo queries.
-    pub face_basis_snapshot: Vec<[u32; 3]>,
+    // Per-(face, corner) value history vs global resolution: list of (global_res, value).
+    // Lets a prediction read a reference corner at the encoder's SetResolution(resCounter-1)
+    // collapsed state (global_res <= global_res_N - 2) instead of the live mesh — the general
+    // fix that resolves the warehouse "broken left wall" with no oracle. See clod-director-decoder-trace.
+    pub corner_history: HashMap<(u32, u8), Vec<(u32, u32)>>,
 
     // Sorted faces for current update
     pub sorted_faces: Vec<u32>,
@@ -113,8 +116,28 @@ impl MeshState {
             neighbor_faces: Vec::new(),
             step_records: Vec::with_capacity(max_updates as usize),
             patch_records: Vec::with_capacity(update_data_count as usize),
-            face_basis_snapshot: Vec::new(),
+            corner_history: HashMap::new(),
             sorted_faces: Vec::new(),
+        }
+    }
+
+    /// Read reference corner `(face, corner)` as of resolution boundary `max_gres`
+    /// (all patches with global_res <= max_gres applied). Falls back to the live face value.
+    pub fn corner_value_as_of(&self, face: u32, corner: u8, max_gres: i64) -> u32 {
+        if let Some(hist) = self.corner_history.get(&(face, corner)) {
+            if !hist.is_empty() {
+                let mut val = hist[0].1;
+                for &(g, v) in hist {
+                    if (g as i64) <= max_gres { val = v; } else { break; }
+                }
+                return val;
+            }
+        }
+        let fi = face as usize;
+        if fi < self.faces.len() && (corner as usize) < 3 {
+            self.faces[fi][corner as usize]
+        } else {
+            0
         }
     }
 

--- a/vm-rust/src/director/chunks/w3d/parser.rs
+++ b/vm-rust/src/director/chunks/w3d/parser.rs
@@ -163,6 +163,46 @@ impl W3dFileParser {
             });
         }
 
+        // Director adds a default white directional key light ("UIDirectional") only
+        // when the scene has no "aimed" key light of its own — i.e. no directional
+        // AND no spot light. Point and ambient lights do NOT count (a scene of only
+        // point + ambient still gets the default). Verified against Director:
+        //   - estate (point+point+ambient)        → UIDirectional ADDED
+        //   - movie with "Default MAX Light" (dir) → not added
+        //   - movie with Fspot01 (spot)+point      → not added
+        // Without it, a point/ambient-only scene (the estate explore) loses its key
+        // light and faces the points don't reach fall to the ambient floor and render
+        // near-black — the dark "shadows" Shockwave doesn't show. Orientation matches
+        // Director's reported default: color rgb(255,255,255), zAxis (0.8543,-0.0015,0.5198).
+        let has_aimed_key_light = self.scene.lights.iter().any(|l| matches!(
+            l.light_type,
+            W3dLightType::Directional | W3dLightType::Spot
+        ));
+        if !has_aimed_key_light {
+            self.scene.lights.push(W3dLight {
+                name: "UIDirectional".to_string(),
+                light_type: W3dLightType::Directional,
+                color: [1.0, 1.0, 1.0],
+                enabled: true,
+                spot_angle: 90.0,
+                attenuation: [1.0, 0.0, 0.0],
+            });
+            // Only the Z axis (columns 8/9/10) is read for a directional light's
+            // orientation; X/Y axes and position are unused but kept sane.
+            let mut t = [0.0f32; 16];
+            t[0] = 1.0; t[5] = 1.0;
+            t[8] = 0.8543; t[9] = -0.0015; t[10] = 0.5198;
+            t[12] = -397.3754; t[13] = 714.7632; t[14] = -538.8293;
+            t[15] = 1.0;
+            self.scene.nodes.push(W3dNode {
+                name: "UIDirectional".to_string(),
+                node_type: W3dNodeType::Light,
+                parent_name: "World".to_string(),
+                transform: t,
+                ..Default::default()
+            });
+        }
+
         log(&format!("Parse complete: {} materials, {} shaders, {} nodes, {} lights, {} textures, {} skeletons, {} motions, {} mesh resources",
             self.scene.materials.len(), self.scene.shaders.len(), self.scene.nodes.len(),
             self.scene.lights.len(), self.scene.texture_images.len(),

--- a/vm-rust/src/director/chunks/w3d/primitives.rs
+++ b/vm-rust/src/director/chunks/w3d/primitives.rs
@@ -585,6 +585,130 @@ fn flatten_bezier_recursive(
     flatten_bezier_recursive(mx0123,my0123, mx123,my123, mx23,my23, x3,y3, tolerance, depth+1, out);
 }
 
+/// Extrude a rasterised text alpha mask into a SMOOTH 3D glyph mesh via
+/// marching squares. Each grid cell of the alpha image emits the filled
+/// sub-polygon with its boundary placed at the sub-pixel alpha crossing
+/// (smooth, diagonal/curved edges) instead of axis-aligned pixel boxes — so the
+/// silhouette matches Director's vector-outline look rather than stair-stepping.
+/// Letter counters/holes fall out naturally (empty cells emit nothing) and the
+/// mesh is far lighter than the per-pixel voxel version. Flat extrusion:
+/// front (+Z), back (-Z), and straight side walls along the contour (no bevel).
+pub fn extrude_alpha_mask_smooth(
+    width: u32,
+    height: u32,
+    rgba: &[u8],
+    world_width: f32,
+    world_height: f32,
+    tunnel_depth: f32,
+) -> super::types::ClodDecodedMesh {
+    let mut mesh = super::types::ClodDecodedMesh::default();
+    mesh.name = "Text".to_string();
+    if width < 2 || height < 2 || rgba.len() < (width as usize) * (height as usize) * 4 {
+        return mesh;
+    }
+    let depth = tunnel_depth.max(1.0);
+    let ww = world_width.max(1.0);
+    let wh = world_height.max(1.0);
+    let pw = ww / width as f32;
+    let ph = wh / height as f32;
+    let thr = 24.0f32;
+    let z_front = 0.0f32;
+    let z_back = -depth;
+
+    let alpha = |x: i32, y: i32| -> f32 {
+        rgba[((y as usize) * (width as usize) + x as usize) * 4 + 3] as f32
+    };
+    // grid (gx,gy in pixels) -> (world XY [y flipped to Y-up], uv)
+    let to_world = |gx: f32, gy: f32| -> ([f32; 2], [f32; 2]) {
+        (
+            [gx * pw, wh - gy * ph],
+            [(gx / width as f32).clamp(0.0, 1.0), (gy / height as f32).clamp(0.0, 1.0)],
+        )
+    };
+
+    // Oblique skew: the back face + tunnel are shifted by a uniform up-right
+    // offset (not extruded straight back) so the gray depth reads as one CLEAN
+    // directional edge peeking out of the white front — the way Director's
+    // #topCenter-lit extrusion looks at the gameplay camera — instead of a
+    // straight wall that is edge-on (invisible) head-on.
+    let skew_x = depth * 0.55;
+    let skew_y = depth * 0.85;
+    let g_back = 0.5f32; // back face / shadow gray
+
+    let mut positions: Vec<[f32; 3]> = Vec::new();
+    let mut normals: Vec<[f32; 3]> = Vec::new();
+    let mut tex: Vec<[f32; 2]> = Vec::new();
+    let mut colors: Vec<[f32; 4]> = Vec::new();
+    let mut faces: Vec<[u32; 3]> = Vec::new();
+
+    for cy in 0..(height as i32 - 1) {
+        for cx in 0..(width as i32 - 1) {
+            // CCW-in-grid corners: bl, br, tr, tl.
+            let corners = [
+                (cx as f32, cy as f32, alpha(cx, cy)),
+                ((cx + 1) as f32, cy as f32, alpha(cx + 1, cy)),
+                ((cx + 1) as f32, (cy + 1) as f32, alpha(cx + 1, cy + 1)),
+                (cx as f32, (cy + 1) as f32, alpha(cx, cy + 1)),
+            ];
+            // Edge-walk the cell, collecting the filled sub-polygon. Inside corners
+            // are added as-is; inside↔outside transitions add the interpolated
+            // (sub-pixel) crossing point. `is_crossing` flags boundary verts.
+            let mut poly: Vec<(f32, f32, bool)> = Vec::new();
+            for i in 0..4 {
+                let (ax, ay, aa) = corners[i];
+                let (bx, by, ab) = corners[(i + 1) % 4];
+                let a_in = aa >= thr;
+                let b_in = ab >= thr;
+                if a_in {
+                    poly.push((ax, ay, false));
+                }
+                if a_in != b_in {
+                    let t = ((aa - thr) / (aa - ab)).clamp(0.0, 1.0);
+                    poly.push((ax + t * (bx - ax), ay + t * (by - ay), true));
+                }
+            }
+            let n = poly.len();
+            if n < 3 {
+                continue;
+            }
+            // Front + back vertices. The world poly is CW (the y flip reverses the
+            // CCW grid order), so the reverse fan below yields CCW (+Z) front faces.
+            let fbase = positions.len() as u32;
+            for &(gx, gy, _) in &poly {
+                let (p, uv) = to_world(gx, gy);
+                positions.push([p[0], p[1], z_front]);
+                normals.push([0.0, 0.0, 1.0]);
+                tex.push(uv);
+                colors.push([1.0, 1.0, 1.0, 1.0]); // front face: full white
+            }
+            // Back face = a gray copy of the glyph, shifted up-right and pushed
+            // behind (z_back), FACING THE CAMERA (+Z) so it renders as a flat gray
+            // drop-shadow. The white front (z=0, closer) occludes most of it; the
+            // part that peeks out on the upper-right is the clean gray depth edge.
+            // No tunnel walls — those produced the diagonal streaks across the face.
+            let bbase = positions.len() as u32;
+            for &(gx, gy, _) in &poly {
+                let (p, uv) = to_world(gx, gy);
+                positions.push([p[0] + skew_x, p[1] + skew_y, z_back]);
+                normals.push([0.0, 0.0, 1.0]);
+                tex.push(uv);
+                colors.push([g_back, g_back, g_back, 1.0]);
+            }
+            for i in 1..(n as u32 - 1) {
+                faces.push([fbase, fbase + i + 1, fbase + i]);
+                // Back face: same camera-facing winding as the front.
+                faces.push([bbase, bbase + i + 1, bbase + i]);
+            }
+        }
+    }
+    mesh.positions = positions;
+    mesh.normals = normals;
+    mesh.tex_coords = vec![tex];
+    mesh.diffuse_colors = colors;
+    mesh.faces = faces;
+    mesh
+}
+
 /// Extrude text string into a 3D mesh using PFR glyph outlines.
 pub fn extrude_text_to_mesh(
     text: &str,

--- a/vm-rust/src/director/chunks/w3d/types.rs
+++ b/vm-rust/src/director/chunks/w3d/types.rs
@@ -387,6 +387,21 @@ pub struct ModelResourceInfo {
     pub primitive_length: f32,
     pub primitive_height: f32,
     pub primitive_radius: f32,
+    /// #cylinder taper + tessellation. primitive_radius is the bottom radius;
+    /// primitive_top_radius the top. primitive_resolution is the radial segment
+    /// count (0 = use a sensible default).
+    pub primitive_top_radius: f32,
+    pub primitive_resolution: u32,
+    /// #sphere/#cylinder partial sweep around the Y axis, in degrees. Default
+    /// 0..360 = full. The Pacman mouth uses startAngle 25 / endAngle 335.
+    pub primitive_start_angle: f32,
+    pub primitive_end_angle: f32,
+    /// #cylinder end caps. Per the Director spec the defaults are asymmetric:
+    /// topCap FALSE (open), bottomCap TRUE (sealed). Ghosts set both to 0.
+    /// These are initialised at newModelResource time (derive(Default) gives
+    /// false, which is wrong for bottom_cap, so the creation site sets them).
+    pub primitive_top_cap: bool,
+    pub primitive_bottom_cap: bool,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -992,6 +992,10 @@ pub struct Shockwave3dRuntimeState {
     /// Per-shader persistent textureModeList DatumRefs: shader_name -> DatumRef to list of mode symbols.
     /// Synced into shader.texture_layers[].tex_mode by sync_shader_texture_lists before render.
     pub shader_texture_mode_lists: std::collections::HashMap<String, crate::player::DatumRef>,
+    /// Per-shader persistent blendConstantList DatumRefs: shader_name -> DatumRef to list of 0..100 floats.
+    /// Synced into shader.texture_layers[].blend_const by sync_shader_texture_lists before render.
+    /// Needed so `shader.blendConstantList[i] = N` (e.g. reflectionMap's 30% blend) persists.
+    pub shader_blend_constant_lists: std::collections::HashMap<String, crate::player::DatumRef>,
 
     // ─── MeshDeform state ───
     /// Per-model mesh deform data: model_name -> list of mesh texture layers
@@ -1236,6 +1240,11 @@ impl Shockwave3dRuntimeState {
             animation_scale: 1.0,
             animation_end_time: -1.0,
             directional_preset: 2, // Director default: #topCenter
+            // IFX default fog decay is #exponential (IFXRenderFog: m_eMode = IFX_FOG_EXP),
+            // NOT #linear. Movies that enable fog without setting decayMode (e.g. the
+            // estate explore) rely on this; a linear default left distant geometry
+            // unfogged because linear ignores everything closer than fog.near.
+            fog_mode: 1, // 0=linear, 1=exp, 2=exp2
             ..Default::default()
         };
         // Seed camera transform from 3DPR camera position/rotation.

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1185,6 +1185,7 @@ pub struct EmitterState {
     pub is_loop: bool,
     pub direction: [f64; 3],
     pub region: [f64; 3],
+    pub has_region: bool, // true once a script assigns emitter.region (emit there, not at the model node)
     pub distribution: String, // "linear", "gaussian"
     pub angle: f64,
     pub min_speed: f64,
@@ -1195,11 +1196,12 @@ pub struct EmitterState {
 impl Default for EmitterState {
     fn default() -> Self {
         Self {
-            num_particles: 100,
+            num_particles: 1000, // Director #particle default
             mode: "burst".to_string(),
             is_loop: true,
             direction: [0.0, 1.0, 0.0],
             region: [0.0, 0.0, 0.0],
+            has_region: false,
             distribution: "linear".to_string(),
             angle: 180.0,
             min_speed: 1.0,
@@ -1229,6 +1231,18 @@ pub struct ParticleSystemState {
     pub emitter_size: [f32; 3], // dimensions of emitter shape
     pub angle_range: f32,       // emission cone angle (0 = parallel, PI = hemisphere)
     pub particle_size: f32,
+    pub max_speed: f32,         // upper bound of the emitter speed range
+    pub stream: bool,           // #stream = continuous recycle, #burst = emit once
+    // Per-particle appearance interpolated from birth (start) to death (end), per
+    // the Director #particle colorRange/sizeRange/blendRange properties.
+    pub color_start: [f32; 3],  // RGB 0..1 at birth
+    pub color_end: [f32; 3],    // RGB 0..1 at death
+    pub size_start: f32,
+    pub size_end: f32,
+    pub blend_start: f32,       // opacity 0..1 at birth
+    pub blend_end: f32,         // opacity 0..1 at death
+    pub texture_name: String,   // particle billboard texture (lowercased gpu key)
+    pub seed: u32,              // evolving RNG so respawns aren't a fixed per-index pattern
 }
 
 impl Shockwave3dRuntimeState {
@@ -1322,6 +1336,16 @@ impl Default for ParticleSystemState {
             emitter_size: [1.0; 3],
             angle_range: 0.3,
             particle_size: 1.0,
+            max_speed: 1.0,
+            stream: true,
+            color_start: [1.0, 1.0, 1.0],
+            color_end: [1.0, 1.0, 1.0],
+            size_start: 1.0,
+            size_end: 1.0,
+            blend_start: 1.0,
+            blend_end: 1.0,
+            texture_name: String::new(),
+            seed: 0x9E3779B9,
         }
     }
 }
@@ -1334,9 +1358,13 @@ impl ParticleSystemState {
         self.ages = vec![0.0; count];
         self.alive = vec![false; count];
 
-        // Stagger initial ages
+        // Randomize initial ages across the lifetime so particles are at varied
+        // distances down the stream from the start — a uniform stagger plus the
+        // constant emit speed left them at regular intervals (visible banding).
         for i in 0..count {
-            self.ages[i] = (i as f32 / count as f32) * self.lifetime;
+            self.seed = self.seed.wrapping_mul(1664525).wrapping_add(1013904223);
+            let r = (self.seed >> 8) as f32 / 16_777_216.0; // 0..1
+            self.ages[i] = r * self.lifetime;
             self.alive[i] = false;
         }
     }
@@ -1351,8 +1379,10 @@ impl ParticleSystemState {
                 // Recycle
                 self.ages[i] -= self.lifetime;
                 self.alive[i] = true;
-                // Emitter shape offset
-                let hash = (i as u32).wrapping_mul(2654435761); // Knuth hash for pseudo-random
+                // Evolve the RNG each respawn so particles don't all return to the
+                // same fixed per-index offset/velocity (that produced regular bands).
+                self.seed = self.seed.wrapping_mul(1664525).wrapping_add(1013904223);
+                let hash = self.seed;
                 let r1 = (hash & 0xFF) as f32 / 255.0 - 0.5;
                 let r2 = ((hash >> 8) & 0xFF) as f32 / 255.0 - 0.5;
                 let r3 = ((hash >> 16) & 0xFF) as f32 / 255.0 - 0.5;

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -955,6 +955,11 @@ pub struct Shockwave3dRuntimeState {
     /// Shader overrides for nodes: model_name → (mesh_index → shader_name)
     /// mesh_index is 0-based; index 0 is also the whole-model fallback
     pub node_shaders: std::collections::HashMap<String, std::collections::HashMap<usize, String>>,
+    /// Text3D model resources created by `someTextMember.extrude3d(thisScene)`,
+    /// keyed by the resource name in this member's scene. Retains the source
+    /// glyphs + extrude state so the resource's tunnelDepth/bevelType/bevelDepth/
+    /// smoothness setters can re-extrude the mesh into this scene.
+    pub text3d_resources: std::collections::HashMap<String, (Text3dSource, Text3dState)>,
 
     // ─── World state ───
     pub background_color: Option<(u8, u8, u8)>,

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -1480,6 +1480,15 @@ pub struct HavokRigidBody {
     pub is_convex: bool,
     /// Half-extents of the mesh bounding box, for box inertia computation.
     pub inertia_half_extents: [f64; 3],
+    /// True once the body has received a hover/drive force (applyForce /
+    /// applyForceAtPoint). Such bodies (e.g. the SuperSonic car) keep the
+    /// original collision path; force-free objects use the box-stacking path.
+    pub driven: bool,
+    /// Authored per-axis model scale from the W3D transform, preserved so the
+    /// rendered model keeps its size when physics writes back its transform
+    /// (the finaldrive car is authored at 0.296×; losing it makes the RaycastCar
+    /// compute wheel/hover points at the wrong scale and tumble).
+    pub sync_scale: [f64; 3],
     // --- Full Havok engine state (ported from C# reference) ---
     /// Orientation quaternion [w, x, y, z]. Internal physics state.
     pub orientation: [f64; 4],
@@ -1538,6 +1547,8 @@ impl HavokRigidBody {
             is_fixed: false,
             is_convex,
             inertia_half_extents: [10.0; 3],
+            driven: false,
+            sync_scale: [1.0; 3],
             orientation: [1.0, 0.0, 0.0, 0.0],
             inverse_mass: if mass > 0.0 { 1.0 / mass } else { 0.0 },
             inertia_tensor: i_tensor,
@@ -1573,6 +1584,8 @@ impl HavokRigidBody {
             is_fixed: true,
             is_convex,
             inertia_half_extents: [10.0; 3],
+            driven: false,
+            sync_scale: [1.0; 3],
             orientation: [1.0, 0.0, 0.0, 0.0],
             inverse_mass: 0.0,
             inertia_tensor: [0.0; 9],
@@ -1585,6 +1598,20 @@ impl HavokRigidBody {
             resting_normal: None,
         }
     }
+}
+
+/// Cable / point-to-point distance constraint: keeps `body_index`'s attach
+/// point at `length` from a fixed world `anchor` (a pendulum), so e.g. the
+/// lamp hangs and swings instead of falling.
+#[derive(Clone, Debug)]
+pub struct HavokCable {
+    pub body_index: usize,
+    /// Fixed world anchor (Director units).
+    pub anchor: [f64; 3],
+    /// Attachment point on the body, body-local (Director units).
+    pub attach_local: [f64; 3],
+    /// Constraint distance (Director units).
+    pub length: f64,
 }
 
 #[derive(Clone, Debug)]
@@ -1703,6 +1730,10 @@ pub struct HavokPhysicsState {
     pub springs: Vec<HavokSpring>,
     pub linear_dashpots: Vec<HavokLinearDashpot>,
     pub angular_dashpots: Vec<HavokAngularDashpot>,
+    /// Cable / point-to-point constraints (e.g. the hanging lamp). Distinct
+    /// from `springs` so they don't flip the scene out of the passive
+    /// collision path.
+    pub cable_constraints: Vec<HavokCable>,
     pub collision_interests: Vec<HavokCollisionInterest>,
     pub step_callbacks: Vec<(String, crate::player::DatumRef)>,  // (handler_name, script_instance)
     pub disabled_collision_pairs: Vec<(String, String)>,
@@ -1737,6 +1768,7 @@ impl Clone for HavokPhysicsState {
             drag_params: self.drag_params,
             rigid_bodies: self.rigid_bodies.clone(),
             springs: self.springs.clone(),
+            cable_constraints: self.cable_constraints.clone(),
             linear_dashpots: self.linear_dashpots.clone(),
             angular_dashpots: self.angular_dashpots.clone(),
             collision_interests: self.collision_interests.clone(),
@@ -1777,6 +1809,7 @@ impl Default for HavokPhysicsState {
             drag_params: [0.0, 0.0],
             rigid_bodies: Vec::new(),
             springs: Vec::new(),
+            cable_constraints: Vec::new(),
             linear_dashpots: Vec::new(),
             angular_dashpots: Vec::new(),
             collision_interests: Vec::new(),

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -4635,7 +4635,12 @@ impl CastMember {
                         name: chunk.member_info.as_ref().map(|x| x.name.to_owned()).unwrap_or_default(),
                         comments: chunk.member_info.as_ref().map(|x| x.comments.to_owned()).unwrap_or_default(),
                         member_type: CastMemberType::Shockwave3d(Shockwave3dMember {
-                        source_scene: None,
+                        // Capture the load-time scene (even when it's the empty scene
+                        // for Lingo-built content like Pacman's "BlankScene") so
+                        // resetWorld() can restore it. Without this, resetWorld was a
+                        // no-op for these members and runtime models (the whole maze,
+                        // ghosts, etc.) leaked across a game-over restart.
+                        source_scene: parsed_scene.clone(),
                         parsed_scene,
                         runtime_state,
                         info: info.clone(),

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -583,6 +583,87 @@ pub async fn tick_w3d_animations() {
     });
 }
 
+/// Advance every W3D member's #particle systems once per frame. Separate from
+/// tick_w3d_animations because particles run regardless of animation_playing
+/// (that tick early-returns for members with no playing motion). For each
+/// particle model resource we sync the emitter parameters (set via
+/// `resource.emitter.*` into runtime_state.emitters) and the world emit position
+/// (from the model node that references the resource) into the sim, then step it.
+pub async fn tick_w3d_particles() {
+    use crate::player::cast_member::CastMemberType;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static LAST_TICK_MS: AtomicU64 = AtomicU64::new(0);
+    let now_ms = crate::player::testing_shared::now_ms() as u64;
+    let last = LAST_TICK_MS.swap(now_ms, Ordering::Relaxed);
+    let dt = if last == 0 {
+        1.0_f32 / 30.0
+    } else {
+        ((now_ms.saturating_sub(last)) as f32 / 1000.0).min(0.1)
+    };
+    reserve_player_mut(|player| {
+        for cast in player.movie.cast_manager.casts.iter_mut() {
+            for (_, member) in cast.members.iter_mut() {
+                if let CastMemberType::Shockwave3d(w3d) = &mut member.member_type {
+                    if w3d.runtime_state.particles.is_empty() { continue; }
+                    let scene = w3d.parsed_scene.clone();
+                    let names: Vec<String> = w3d.runtime_state.particles.keys().cloned().collect();
+                    for name in names {
+                        // Emitter params (cloned) and the emit position from the model
+                        // node that references this resource — gathered before the
+                        // mutable particle borrow to avoid overlapping borrows.
+                        let em = w3d.runtime_state.emitters.get(&name).cloned();
+                        let world_pos = scene.as_ref().and_then(|sc| {
+                            sc.nodes.iter()
+                                .find(|n| n.model_resource_name.eq_ignore_ascii_case(&name)
+                                    || n.resource_name.eq_ignore_ascii_case(&name))
+                                .map(|n| {
+                                    let t = w3d.runtime_state.node_transforms.get(&n.name)
+                                        .copied()
+                                        .unwrap_or(n.transform);
+                                    [t[12], t[13], t[14]]
+                                })
+                        }).unwrap_or([0.0, 0.0, 0.0]);
+
+                        if let Some(ps) = w3d.runtime_state.particles.get_mut(&name) {
+                            // Emit from emitter.region when a script set it (e.g. the car demos
+                            // track the exhaust pipe via `emitter.region = [exhaust.worldPosition]`),
+                            // otherwise from the model node's world position (the faucet translates
+                            // its ColdWater model). Without this the car smoke emitted at the origin
+                            // and whited out the camera, blanking the whole 3D scene.
+                            ps.emitter_position = match &em {
+                                Some(e) if e.has_region =>
+                                    [e.region[0] as f32, e.region[1] as f32, e.region[2] as f32],
+                                _ => world_pos,
+                            };
+                            if let Some(em) = &em {
+                                let d = em.direction;
+                                let len = (d[0]*d[0] + d[1]*d[1] + d[2]*d[2]).sqrt();
+                                if len > 1e-6 {
+                                    ps.direction = [(d[0]/len) as f32, (d[1]/len) as f32, (d[2]/len) as f32];
+                                }
+                                ps.initial_speed = em.min_speed as f32;
+                                ps.max_speed = em.max_speed.max(em.min_speed) as f32;
+                                ps.speed_range = (em.max_speed - em.min_speed).max(0.0) as f32;
+                                // emitter.angle is the cone half-angle in degrees.
+                                ps.angle_range = (em.angle as f32).to_radians();
+                                ps.stream = em.mode.eq_ignore_ascii_case("stream");
+                                let n = (em.num_particles.max(0) as usize).min(10000);
+                                if n > 0 && ps.max_particles != n {
+                                    ps.initialize(n);
+                                }
+                            }
+                            if ps.positions.is_empty() && ps.max_particles > 0 {
+                                ps.initialize(ps.max_particles);
+                            }
+                            ps.update(dt);
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
 /// Drain queued PhysX collision reports across all PhysX members and
 /// dispatch them to the script's registered `collisionCallback` handler.
 ///

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok.rs
@@ -13,6 +13,41 @@ use crate::{
     },
 };
 
+/// Build a large static quad collision mesh for an (infinite) Havok plane
+/// primitive, centred at `center` with surface normal `n_world` (both in
+/// Director world units). Two triangles, wound so their geometric normal
+/// matches `n_world` (pointing toward the bodies that rest on it).
+fn build_plane_quad(
+    name: &str,
+    center: [f64; 3],
+    n_world: [f64; 3],
+) -> Option<super::havok_physics::CollisionMesh> {
+    use super::havok_physics::{v3_add, v3_cross, v3_normalized, v3_scale, v3_sub};
+    let n = v3_normalized(n_world);
+    if n[0] == 0.0 && n[1] == 0.0 && n[2] == 0.0 { return None; }
+    // Half-size large enough to act as floor/wall for any reasonable room.
+    const S: f64 = 5000.0;
+    let helper = if n[2].abs() < 0.9 { [0.0, 0.0, 1.0] } else { [1.0, 0.0, 0.0] };
+    let t1 = v3_normalized(v3_cross(n, helper));
+    let t2 = v3_normalized(v3_cross(n, t1)); // cross(t1, t2) == n
+    let a = v3_scale(t1, S);
+    let b = v3_scale(t2, S);
+    let v0 = v3_sub(v3_sub(center, a), b);
+    let v1 = v3_sub(v3_add(center, a), b);
+    let v2 = v3_add(v3_add(center, a), b);
+    let v3 = v3_add(v3_sub(center, a), b);
+    let mut cmesh = super::havok_physics::CollisionMesh {
+        name: name.to_string(),
+        vertices: vec![v0, v1, v2, v3],
+        triangles: vec![[0, 1, 2], [0, 2, 3]],
+        aabb_min: [0.0; 3],
+        aabb_max: [0.0; 3],
+        body_index: None, // static scenery
+    };
+    cmesh.compute_aabb();
+    Some(cmesh)
+}
+
 pub struct HavokPhysicsMemberHandlers {}
 
 impl HavokPhysicsMemberHandlers {
@@ -554,15 +589,27 @@ impl HavokPhysicsMemberHandlers {
             for mesh in &hke.meshes {
                 if mesh.vertices.is_empty() || mesh.triangles.is_empty() { continue; }
                 let model_xform = model_transforms.get(&mesh.name.to_lowercase());
+                let xform_rt: Option<[f64; 12]> = model_xform.map(|t| {
+                    let mut c0 = [t[0] as f64, t[1] as f64, t[2] as f64];
+                    let mut c1 = [t[4] as f64, t[5] as f64, t[6] as f64];
+                    let mut c2 = [t[8] as f64, t[9] as f64, t[10] as f64];
+                    let n0 = (c0[0]*c0[0]+c0[1]*c0[1]+c0[2]*c0[2]).sqrt();
+                    let n1 = (c1[0]*c1[0]+c1[1]*c1[1]+c1[2]*c1[2]).sqrt();
+                    let n2 = (c2[0]*c2[0]+c2[1]*c2[1]+c2[2]*c2[2]).sqrt();
+                    if n0 > 1e-9 { for k in 0..3 { c0[k] /= n0; } }
+                    if n1 > 1e-9 { for k in 0..3 { c1[k] /= n1; } }
+                    if n2 > 1e-9 { for k in 0..3 { c2[k] /= n2; } }
+                    [c0[0],c0[1],c0[2], c1[0],c1[1],c1[2], c2[0],c2[1],c2[2], t[12] as f64, t[13] as f64, t[14] as f64]
+                });
                 let vertices: Vec<[f64; 3]> = mesh.vertices.iter()
                     .map(|v| {
                         let lx = v[0] as f64 * inv_scale;
                         let ly = v[1] as f64 * inv_scale;
                         let lz = v[2] as f64 * inv_scale;
-                        if let Some(t) = model_xform {
-                            let wx = t[0] as f64*lx + t[4] as f64*ly + t[8] as f64*lz + t[12] as f64;
-                            let wy = t[1] as f64*lx + t[5] as f64*ly + t[9] as f64*lz + t[13] as f64;
-                            let wz = t[2] as f64*lx + t[6] as f64*ly + t[10] as f64*lz + t[14] as f64;
+                        if let Some(r) = &xform_rt {
+                            let wx = r[0]*lx + r[3]*ly + r[6]*lz + r[9];
+                            let wy = r[1]*lx + r[4]*ly + r[7]*lz + r[10];
+                            let wz = r[2]*lx + r[5]*ly + r[8]*lz + r[11];
                             [wx, wy, wz]
                         } else {
                             [lx, ly, lz]
@@ -584,11 +631,27 @@ impl HavokPhysicsMemberHandlers {
                 if let Some(p) = props {
                     if let Some(r) = p.restitution { rb.restitution = r as f64; }
                     if let Some(f) = p.static_friction { rb.friction = f as f64; }
+                    // Honour the HKE active flag: bodies authored at rest start
+                    // asleep (frozen) and only simulate once disturbed. This is
+                    // why the warehouse stack stays put until the lone active
+                    // crate slides into it.
+                    if mass > 0.0 { if let Some(act) = p.active { rb.active = act; } }
+                    if let Some(v) = p.linear_velocity {
+                        rb.linear_velocity = [v[0] as f64*inv_scale, v[1] as f64*inv_scale, v[2] as f64*inv_scale];
+                    }
                 }
 
-                // Set position from W3D model transform
+                // Set position + authored model scale from the W3D transform.
                 if let Some(t) = model_xform {
                     rb.position = [t[12] as f64, t[13] as f64, t[14] as f64];
+                    let s0 = ((t[0]as f64).powi(2)+(t[1]as f64).powi(2)+(t[2]as f64).powi(2)).sqrt();
+                    let s1 = ((t[4]as f64).powi(2)+(t[5]as f64).powi(2)+(t[6]as f64).powi(2)).sqrt();
+                    let s2 = ((t[8]as f64).powi(2)+(t[9]as f64).powi(2)+(t[10]as f64).powi(2)).sqrt();
+                    rb.sync_scale = [
+                        if s0 > 1e-9 { s0 } else { 1.0 },
+                        if s1 > 1e-9 { s1 } else { 1.0 },
+                        if s2 > 1e-9 { s2 } else { 1.0 },
+                    ];
                 }
                 let rb_index = havok.state.rigid_bodies.len();
                 havok.state.rigid_bodies.push(rb);
@@ -606,10 +669,62 @@ impl HavokPhysicsMemberHandlers {
                     body_index: mesh_body_index,
                 };
                 cmesh.compute_aabb();
+
+                if mass > 0.0 {
+                    let (mut lmn, mut lmx) = ([f64::MAX; 3], [f64::MIN; 3]);
+                    for v in &mesh.vertices {
+                        for i in 0..3 {
+                            let c = v[i] as f64 * inv_scale;
+                            if c < lmn[i] { lmn[i] = c; }
+                            if c > lmx[i] { lmx[i] = c; }
+                        }
+                    }
+                    let he = [0.5*(lmx[0]-lmn[0]).abs(), 0.5*(lmx[1]-lmn[1]).abs(), 0.5*(lmx[2]-lmn[2]).abs()];
+                    // COM = local box centre = body-frame offset from the node
+                    // origin (model base) to the collision-box centre.
+                    let com = [0.5*(lmn[0]+lmx[0]), 0.5*(lmn[1]+lmx[1]), 0.5*(lmn[2]+lmx[2])];
+                    let unit_i = super::havok_physics::box_unit_inertia(he);
+                    let (mut it, mut inv_it, mut inv_m) = ([0.0; 9], [0.0; 9], 0.0);
+                    super::havok_physics::recompute_body_inertia(mass, unit_i, &mut it, &mut inv_it, &mut inv_m);
+                    let rb = &mut havok.state.rigid_bodies[rb_index];
+                    rb.inertia_half_extents = he;
+                    rb.center_of_mass = com;
+                    rb.unit_inertia_tensor = unit_i;
+                    rb.inertia_tensor = it;
+                    rb.inverse_inertia_tensor = inv_it;
+                    rb.inverse_mass = inv_m;
+                }
+
                 havok.state.collision_meshes.push(cmesh);
             }
 
-            // Create rigid bodies for HKE tail entries that have no collision mesh
+            // Per-ENTRY-mesh half-extents in Director units, plus a shared
+            // fallback box (the first mesh) for bodies whose mesh primitive
+            // references geometry that is only stored once (e.g. the warehouse
+            // crates all reuse the single "Crate01" box).
+            // mesh name -> (half-extents, local centre), both Director units.
+            let mut mesh_geo: std::collections::HashMap<String, ([f64; 3], [f64; 3])> = std::collections::HashMap::new();
+            let mut fallback_geo: Option<([f64; 3], [f64; 3])> = None;
+            for mesh in &hke.meshes {
+                if mesh.vertices.is_empty() { continue; }
+                let (mut mn, mut mx) = ([f64::MAX; 3], [f64::MIN; 3]);
+                for v in &mesh.vertices {
+                    for i in 0..3 {
+                        let c = v[i] as f64 * inv_scale;
+                        if c < mn[i] { mn[i] = c; }
+                        if c > mx[i] { mx[i] = c; }
+                    }
+                }
+                let he = [0.5*(mx[0]-mn[0]).abs(), 0.5*(mx[1]-mn[1]).abs(), 0.5*(mx[2]-mn[2]).abs()];
+                let center = [0.5*(mn[0]+mx[0]), 0.5*(mn[1]+mx[1]), 0.5*(mn[2]+mx[2])];
+                mesh_geo.insert(mesh.name.to_lowercase(), (he, center));
+                if fallback_geo.is_none() { fallback_geo = Some((he, center)); }
+            }
+
+            // Create rigid bodies for HKE tail entries that have no ENTRY mesh.
+            // Positions come from the matching W3D node transform (so the
+            // physics world aligns with the rendered scene); plane primitives
+            // become large static quad colliders (floor + walls).
             for body_def in &hke.bodies {
                 let already_exists = havok.state.rigid_bodies.iter()
                     .any(|rb| rb.name.eq_ignore_ascii_case(&body_def.name));
@@ -623,10 +738,123 @@ impl HavokPhysicsMemberHandlers {
                 };
                 if let Some(r) = body_def.restitution { rb.restitution = r as f64; }
                 if let Some(f) = body_def.static_friction { rb.friction = f as f64; }
-                if let Some(t) = body_def.translation {
-                    rb.position = [t[0] as f64, t[1] as f64, t[2] as f64];
+                if mass > 0.0 { if let Some(act) = body_def.active { rb.active = act; } }
+                if let Some(v) = body_def.linear_velocity {
+                    rb.linear_velocity = [v[0] as f64*inv_scale, v[1] as f64*inv_scale, v[2] as f64*inv_scale];
                 }
+
+                // World transform: prefer the W3D node (matches the render),
+                // fall back to the HKE translation converted to Director units.
+                let xform = model_transforms.get(&body_def.name.to_lowercase()).copied();
+                if let Some(t) = xform {
+                    rb.position = [t[12] as f64, t[13] as f64, t[14] as f64];
+                } else if let Some(t) = body_def.translation {
+                    rb.position = [t[0] as f64 * inv_scale, t[1] as f64 * inv_scale, t[2] as f64 * inv_scale];
+                }
+
+                // Size + inertia for movable bodies from their primitive geometry.
+                if mass > 0.0 {
+                    let (he, com) = body_def.primitives.iter().find_map(|p| match &p.kind {
+                        super::hke_parser::HkePrimitiveKind::Mesh { mesh_name } =>
+                            mesh_geo.get(&mesh_name.to_lowercase()).copied().or(fallback_geo),
+                        super::hke_parser::HkePrimitiveKind::Sphere { radius } => {
+                            let r = (*radius as f64 * inv_scale).abs();
+                            // Sphere centre offset = its primitive-local translation.
+                            let lt = p.local_translation;
+                            Some(([r, r, r], [lt[0] as f64*inv_scale, lt[1] as f64*inv_scale, lt[2] as f64*inv_scale]))
+                        }
+                        super::hke_parser::HkePrimitiveKind::Plane { .. } => None,
+                    }).or(fallback_geo).unwrap_or(([10.0; 3], [0.0; 3]));
+
+                    let unit_i = super::havok_physics::box_unit_inertia(he);
+                    let (mut it, mut inv_it, mut inv_m) = ([0.0; 9], [0.0; 9], 0.0);
+                    super::havok_physics::recompute_body_inertia(mass, unit_i, &mut it, &mut inv_it, &mut inv_m);
+                    rb.inertia_half_extents = he;
+                    rb.center_of_mass = com;
+                    rb.unit_inertia_tensor = unit_i;
+                    rb.inertia_tensor = it;
+                    rb.inverse_inertia_tensor = inv_it;
+                    rb.inverse_mass = inv_m;
+                }
+
+                let body_pos = rb.position;
                 havok.state.rigid_bodies.push(rb);
+
+                // Build static quad colliders from plane primitives (floor/walls).
+                if mass <= 0.0 {
+                    for prim in &body_def.primitives {
+                        if let super::hke_parser::HkePrimitiveKind::Plane { normal, .. } = &prim.kind {
+                            // World normal = body rotation * local plane normal.
+                            let n_world = if let Some(t) = xform {
+                                // 3x3 columns of the column-major 4x4.
+                                let n = [
+                                    t[0] as f64*normal[0] as f64 + t[4] as f64*normal[1] as f64 + t[8] as f64*normal[2] as f64,
+                                    t[1] as f64*normal[0] as f64 + t[5] as f64*normal[1] as f64 + t[9] as f64*normal[2] as f64,
+                                    t[2] as f64*normal[0] as f64 + t[6] as f64*normal[1] as f64 + t[10] as f64*normal[2] as f64,
+                                ];
+                                super::havok_physics::v3_normalized(n)
+                            } else if let Some(o) = body_def.orientation {
+                                let q = super::havok_physics::quat_from_axis_angle(
+                                    [o[1] as f64, o[2] as f64, o[3] as f64], o[0] as f64);
+                                super::havok_physics::v3_normalized(
+                                    super::havok_physics::quat_rotate_v(q, [normal[0] as f64, normal[1] as f64, normal[2] as f64]))
+                            } else {
+                                [normal[0] as f64, normal[1] as f64, normal[2] as f64]
+                            };
+
+                            if let Some(cmesh) = build_plane_quad(&body_def.name, body_pos, n_world) {
+                                havok.state.collision_meshes.push(cmesh);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Build point-to-point (cable) constraints. Keyed by the HKE constraint
+        // TYPE, not by name — the anchor is body A's world-transformed pivot,
+        // the bob is body B (the movable one, e.g. the lamp). We hold the bob at
+        // its initial distance from the anchor so it hangs where authored and
+        // swings like a pendulum rather than falling.
+        if !havok.state.hke_data.is_empty() {
+            let hke = super::hke_parser::parse_hke(&havok.state.hke_data);
+            for cable in &hke.cables {
+                let idx_b = havok.state.rigid_bodies.iter()
+                    .position(|rb| rb.name.eq_ignore_ascii_case(&cable.body_b));
+                let idx_b = match idx_b { Some(i) => i, None => continue };
+
+                // Anchor = body A's world transform applied to pivot A.
+                let xform_a = model_transforms.get(&cable.body_a.to_lowercase()).copied();
+                let inv_scale = if scale.abs() > 1e-10 { 1.0 / scale } else { 1.0 };
+                let pa = [cable.pivot_a[0] as f64*inv_scale, cable.pivot_a[1] as f64*inv_scale, cable.pivot_a[2] as f64*inv_scale];
+                let anchor = if let Some(t) = xform_a {
+                    [
+                        t[0] as f64*pa[0] + t[4] as f64*pa[1] + t[8] as f64*pa[2] + t[12] as f64,
+                        t[1] as f64*pa[0] + t[5] as f64*pa[1] + t[9] as f64*pa[2] + t[13] as f64,
+                        t[2] as f64*pa[0] + t[6] as f64*pa[1] + t[10] as f64*pa[2] + t[14] as f64,
+                    ]
+                } else {
+                    pa
+                };
+
+                let attach_local = [cable.pivot_b[0] as f64*inv_scale, cable.pivot_b[1] as f64*inv_scale, cable.pivot_b[2] as f64*inv_scale];
+
+                // Bob world attach point at init, and the constraint distance.
+                let rb = &havok.state.rigid_bodies[idx_b];
+                let attach_world = super::havok_physics::v3_add(
+                    rb.position,
+                    super::havok_physics::quat_rotate_v(rb.orientation, attach_local),
+                );
+                let init_dist = super::havok_physics::v3_len(
+                    super::havok_physics::v3_sub(attach_world, anchor));
+                let length = if init_dist > 1e-3 { init_dist } else { (cable.length as f64 * inv_scale).abs() };
+
+                havok.state.cable_constraints.push(crate::player::cast_member::HavokCable {
+                    body_index: idx_b,
+                    anchor,
+                    attach_local,
+                    length,
+                });
             }
         }
 
@@ -661,6 +889,7 @@ impl HavokPhysicsMemberHandlers {
         havok.state.initialized = false;
         havok.state.rigid_bodies.clear();
         havok.state.springs.clear();
+        havok.state.cable_constraints.clear();
         havok.state.linear_dashpots.clear();
         havok.state.angular_dashpots.clear();
         havok.state.collision_meshes.clear();
@@ -742,7 +971,7 @@ impl HavokPhysicsMemberHandlers {
             .filter(|rb| !rb.is_fixed && rb.active)
             .map(|rb| {
                 let t = super::havok_physics::build_sync_transform(
-                    rb.position, rb.orientation, rb.center_of_mass,
+                    rb.position, rb.orientation, rb.center_of_mass, rb.sync_scale,
                 );
                 (rb.name.clone(), t)
             })
@@ -1027,6 +1256,11 @@ impl HavokPhysicsMemberHandlers {
 
         let mut rb = HavokRigidBody::new_movable(&model_name, mass, is_convex);
         rb.position = initial_position;
+        // A body created by Lingo (makeMovableRigidBody) is a script-driven
+        // vehicle (e.g. the SuperSonic car) — keep it on the original collision
+        // path (hover-driven, no box-stacking). HKE-authored bodies (warehouse
+        // crates, the car-demo chassis) stay on the passive path.
+        rb.driven = true;
         rb.inertia_half_extents = mesh_half_extents;
         rb.unit_inertia_tensor = unit_inertia;
         // Apply mass → finalise inertia / inverseInertia (PPC setMass 0x4c930)

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/havok_physics.rs
@@ -482,27 +482,53 @@ pub fn find_ground_z(meshes: &[CollisionMesh], x: f64, y: f64, max_z: f64) -> Op
 /// `tolerance` expands the effective collision distance so Havok detects
 /// contacts before actual surface penetration (matching the Xtra behaviour).
 pub fn detect_body_contacts(
-    meshes: &[CollisionMesh], pos: V3, radius: f64, body_idx: usize, tolerance: f64,
+    meshes: &[CollisionMesh], pos: V3, half_extents: V3, body_idx: usize, tolerance: f64, passive: bool,
+    bodies: &[crate::player::cast_member::HavokRigidBody],
 ) -> Vec<CollisionContact> {
-    let eff_radius = radius + tolerance;
+    // Broad-phase cull uses the largest half-extent. NON-passive scenes (the
+    // tuned SuperSonic car) keep the original sphere-radius narrow phase with no
+    // margin, since that's what their handling was calibrated against. Passive
+    // scenes use the box-support narrow phase + contact margin so resting boxes
+    // sit flush and a stack stays coupled.
+    let max_r = half_extents[0].max(half_extents[1]).max(half_extents[2]) + tolerance;
+    let margin = if passive { CONTACT_MARGIN } else { 0.0 };
     let mut contacts = Vec::new();
     for mesh in meshes {
-        if pos[0]+eff_radius < mesh.aabb_min[0] || pos[0]-eff_radius > mesh.aabb_max[0] { continue; }
-        if pos[1]+eff_radius < mesh.aabb_min[1] || pos[1]-eff_radius > mesh.aabb_max[1] { continue; }
-        if pos[2]+eff_radius < mesh.aabb_min[2] || pos[2]-eff_radius > mesh.aabb_max[2] { continue; }
+        // Skip meshes owned by a MOVABLE body: those are baked at the body's
+        // initial position and go stale once it moves (bogus deep collisions;
+        // dynamic bodies interact via box-vs-box instead). A FIXED body's mesh
+        // never moves, so it stays a valid static collider — and its body_index
+        // lets the resolver use that surface's restitution/friction (the
+        // Properties demo's bouncy/slippery floors).
+        if let Some(owner) = mesh.body_index {
+            if !bodies[owner].pinned { continue; }
+        }
+        if pos[0]+max_r < mesh.aabb_min[0] || pos[0]-max_r > mesh.aabb_max[0] { continue; }
+        if pos[1]+max_r < mesh.aabb_min[1] || pos[1]-max_r > mesh.aabb_max[1] { continue; }
+        if pos[2]+max_r < mesh.aabb_min[2] || pos[2]-max_r > mesh.aabb_max[2] { continue; }
         for tri in &mesh.triangles {
             let v0 = mesh.vertices[tri[0] as usize];
             let v1 = mesh.vertices[tri[1] as usize];
             let v2 = mesh.vertices[tri[2] as usize];
             let normal = v3_normalized(v3_cross(v3_sub(v1, v0), v3_sub(v2, v0)));
             if v3_len_sq(normal) < 1e-10 { continue; }
+            // Passive: exact box support along the triangle normal. Non-passive:
+            // original isotropic sphere radius.
+            let eff_radius = if passive {
+                half_extents[0]*normal[0].abs()
+              + half_extents[1]*normal[1].abs()
+              + half_extents[2]*normal[2].abs()
+              + tolerance
+            } else {
+                max_r
+            };
             let dist = v3_dot(v3_sub(pos, v0), normal);
             if dist.abs() > eff_radius { continue; }
             if dist < -eff_radius * 2.0 { continue; }
             let proj = v3_sub(pos, v3_scale(normal, dist));
             if pt_in_tri_3d(proj, v0, v1, v2) {
                 let depth = eff_radius - dist;
-                if depth > 0.0 {
+                if depth > -margin {
                     contacts.push(CollisionContact {
                         body_a: body_idx,
                         body_b: mesh.body_index,
@@ -646,6 +672,12 @@ fn interp_z(px: f64, py: f64, v0: V3, v1: V3, v2: V3) -> f64 {
 // ============================================================
 
 const MAX_RESOLVER_ITERATIONS: usize = 400;
+/// Contact margin (Director units): generate contacts slightly before bodies
+/// actually overlap so a resting stack stays *coupled* (the resolver can carry
+/// friction + impulses between touching boxes and the floor) instead of each
+/// box flickering in and out of contact. Near-contacts (depth <= 0) only affect
+/// velocity — depenetration still requires real penetration.
+const CONTACT_MARGIN: f64 = 2.0;
 /// Default ground material: friction=0.5, restitution=0.3
 const GROUND_FRICTION: f64 = 0.5;
 const GROUND_RESTITUTION: f64 = 0.3;
@@ -720,10 +752,16 @@ fn resolve_single_contact(state: &HavokPhysicsState, contact: &CollisionContact)
     let normal_impulse_mag = (target_vn - vn) / eff_inv_mass;
     let mut impulse = v3_scale(contact.normal, normal_impulse_mag);
 
-    // Friction (Coulomb cone) — skip for resting contacts so bodies can
-    // slide on tilted surfaces under gravity without friction impulses
-    // killing their tangential velocity every frame.
-    if friction > 0.0 && !is_resting {
+    // Friction (Coulomb cone). For SuperSonic-style driven scenes we skip it on
+    // resting contacts so the car can slide on tilted surfaces under gravity.
+    // For passive scenes we MUST apply it on resting contacts too, otherwise a
+    // crate that slides flat across the floor never slows down or stops. A
+    // driven body (the car) keeps the original skip-on-resting behaviour.
+    let passive = state.springs.is_empty()
+        && state.linear_dashpots.is_empty()
+        && state.angular_dashpots.is_empty()
+        && !state.rigid_bodies[contact.body_a].driven;
+    if friction > 0.0 && (!is_resting || passive) {
         let tangent_vel = v3_sub(rel_vel, v3_scale(contact.normal, vn));
         let tangent_speed = v3_len(tangent_vel);
         if tangent_speed > 1e-6 {
@@ -1221,19 +1259,31 @@ pub fn step_native(state: &mut HavokPhysicsState, time_increment: f64, num_sub_s
         .map(|rb| (rb.force, rb.torque)).collect();
 
     for _sub in 0..n_subs {
-        // Reset forces to scaled game values each substep.
-        // Gravity and drag are added on top in step_single.
+        // Reset forces to game values each substep (gravity/drag added in
+        // step_single). The per-axis force/torque dividers are a SuperSonic-
+        // specific calibration; applying them to OTHER hover cars crushes their
+        // suspension's levelling torque (~0.2%) and tips them over on tilted
+        // roads. Only driven (makeMovableRigidBody) bodies use the calibration;
+        // every other body gets its applied force/torque verbatim.
         for (i, rb) in state.rigid_bodies.iter_mut().enumerate() {
             if i < saved_forces.len() {
+                let (fs, tsp, tsy) = if rb.driven {
+                    (force_scale, torque_scale_pitch_roll, torque_scale_yaw)
+                } else {
+                    // Non-SuperSonic hover cars: scale torque the SAME as force
+                    // (physically consistent) instead of the SuperSonic-only
+                    // pitch/roll/yaw asymmetry that crushed levelling torque.
+                    (force_scale, force_scale, force_scale)
+                };
                 rb.force = [
-                    saved_forces[i].0[0]/force_scale,
-                    saved_forces[i].0[1]/force_scale,
-                    saved_forces[i].0[2]/force_scale,
+                    saved_forces[i].0[0]/fs,
+                    saved_forces[i].0[1]/fs,
+                    saved_forces[i].0[2]/fs,
                 ];
                 rb.torque = [
-                    saved_forces[i].1[0]/torque_scale_pitch_roll,   // world X ≈ body pitch
-                    saved_forces[i].1[1]/torque_scale_pitch_roll,   // world Y ≈ body roll
-                    saved_forces[i].1[2]/torque_scale_yaw,          // world Z ≈ body yaw
+                    saved_forces[i].1[0]/tsp,   // world X ≈ body pitch
+                    saved_forces[i].1[1]/tsp,   // world Y ≈ body roll
+                    saved_forces[i].1[2]/tsy,   // world Z ≈ body yaw
                 ];
             }
         }
@@ -1255,7 +1305,7 @@ pub fn step_native(state: &mut HavokPhysicsState, time_increment: f64, num_sub_s
     // breaks the natural lean-into-the-turn dynamic the springs rely on.
     //
     // Mirrors Havok's `applyDamping` helper at PPC 0x4cf00 (x86 `sub_10013770`).
-    const ANGULAR_DRIFT_DAMP: f64 = 0.05;
+    const ANGULAR_DRIFT_DAMP: f64 = 0.1; //0.05;
     let ang_factor = 1.0 - ANGULAR_DRIFT_DAMP;
     for rb in &mut state.rigid_bodies {
         if rb.pinned || !rb.active { continue; }
@@ -1277,6 +1327,17 @@ pub fn step_native(state: &mut HavokPhysicsState, time_increment: f64, num_sub_s
 fn step_single(state: &mut HavokPhysicsState, dt: f64) {
     let mut remaining = dt;
     let mut retries = 0;
+
+    // Passive scenes (standard Havok behaviour: no Lingo springs/dashpots and no
+    // hover/drive-forced body) use discrete collision: integrate the full step,
+    // then resolve + depenetrate. The bisection rollback path rolls back ALL
+    // bodies on ANY collision, which for a pile of resting bodies starves the
+    // simulation of time and freezes it. Bisection stays on for driven scenes
+    // (the SuperSonic car was tuned against it).
+    let passive = state.springs.is_empty()
+        && state.linear_dashpots.is_empty()
+        && state.angular_dashpots.is_empty()
+        && !state.rigid_bodies.iter().any(|rb| rb.driven);
 
     while remaining > MIN_BISECTION_DT * 0.1 {
         // Phase 1: Save state for rollback
@@ -1300,6 +1361,9 @@ fn step_single(state: &mut HavokPhysicsState, dt: f64) {
             integrate_body(rb, remaining);
         }
 
+        // Phase 4a: Cable / point-to-point constraints (pendulum hang+swing).
+        apply_cables(state);
+
         // Phase 4b: Ground constraint (resting contacts)
         apply_ground_constraints(state);
 
@@ -1314,7 +1378,7 @@ fn step_single(state: &mut HavokPhysicsState, dt: f64) {
         let contacts = detect_all_collisions(state);
         let has_collisions = !contacts.is_empty();
 
-        if has_collisions && remaining > MIN_BISECTION_DT && retries < MAX_BISECTION_RETRIES {
+        if !passive && has_collisions && remaining > MIN_BISECTION_DT && retries < MAX_BISECTION_RETRIES {
             // Collision detected — rollback and bisect
             for rb in &mut state.rigid_bodies {
                 if !rb.pinned && rb.active {
@@ -1334,12 +1398,51 @@ fn step_single(state: &mut HavokPhysicsState, dt: f64) {
                 // trigger a global bisection rollback including bodies that are
                 // already bouncing away).
                 for c in &contacts {
-                    // Read ground friction before mutable borrow
+                    if c.depth <= 0.0 { continue; }
+
+                    // Is body_b another DYNAMIC body (box-vs-box)? Then split the
+                    // depenetration and the relative normal-velocity removal
+                    // between the two by inverse mass, so a stack settles without
+                    // either box being shoved through its neighbour or the floor.
+                    let b_dynamic = match c.body_b {
+                        Some(j) => !state.rigid_bodies[j].pinned && state.rigid_bodies[j].inverse_mass > 0.0,
+                        None => false,
+                    };
+
+                    if b_dynamic {
+                        let j = c.body_b.unwrap();
+                        // A moving body that penetrates a sleeping one wakes it,
+                        // so the impact propagates through the stack.
+                        state.rigid_bodies[c.body_a].active = true;
+                        state.rigid_bodies[j].active = true;
+                        let ia = state.rigid_bodies[c.body_a].inverse_mass;
+                        let ib = state.rigid_bodies[j].inverse_mass;
+                        let isum = ia + ib;
+                        if isum <= 0.0 { continue; }
+                        let fa = ia / isum;
+                        let fb = ib / isum;
+                        for k in 0..3 {
+                            state.rigid_bodies[c.body_a].position[k] += c.normal[k] * c.depth * fa;
+                            state.rigid_bodies[j].position[k]        -= c.normal[k] * c.depth * fb;
+                        }
+                        let va = state.rigid_bodies[c.body_a].linear_velocity;
+                        let vb = state.rigid_bodies[j].linear_velocity;
+                        let rvn = (va[0]-vb[0])*c.normal[0] + (va[1]-vb[1])*c.normal[1] + (va[2]-vb[2])*c.normal[2];
+                        if rvn < 0.0 {
+                            for k in 0..3 {
+                                state.rigid_bodies[c.body_a].linear_velocity[k] -= rvn * fa * c.normal[k];
+                                state.rigid_bodies[j].linear_velocity[k]        += rvn * fb * c.normal[k];
+                            }
+                        }
+                        continue;
+                    }
+
+                    // Static / fixed-body contact: push body_a out fully.
                     let ground_friction = c.body_b
                         .map(|idx| state.rigid_bodies[idx].friction)
                         .unwrap_or(0.5);
                     let rb = &mut state.rigid_bodies[c.body_a];
-                    if !rb.pinned && rb.inverse_mass > 0.0 && c.depth > 0.0 {
+                    if !rb.pinned && rb.inverse_mass > 0.0 {
                         let vn = rb.linear_velocity[0] * c.normal[0]
                                + rb.linear_velocity[1] * c.normal[1]
                                + rb.linear_velocity[2] * c.normal[2];
@@ -1352,21 +1455,18 @@ fn step_single(state: &mut HavokPhysicsState, dt: f64) {
                             rb.linear_velocity[1] -= vn * c.normal[1];
                             rb.linear_velocity[2] -= vn * c.normal[2];
                         }
-                        // Only enter resting contact for low-velocity impacts.
-                        // Bouncy contacts (high restitution) must stay in the
-                        // impulse-based collision system so they can bounce.
+                        // Resting contact only for a body resting on another
+                        // body's OWNED static mesh (SuperSonic car on terrain).
                         if c.body_b.is_some() && vn.abs() < 10.0 {
-                            let (aabb_min, aabb_max) = state.collision_meshes.iter()
-                                .find(|m| m.body_index == c.body_b)
-                                .map(|m| (m.aabb_min, m.aabb_max))
-                                .unwrap_or(([f64::MIN;3], [f64::MAX;3]));
-                            rb.resting_normal = Some(crate::player::cast_member::RestingContact {
-                                normal: c.normal,
-                                plane_point: c.point,
-                                ground_friction,
-                                aabb_min,
-                                aabb_max,
-                            });
+                            if let Some(m) = state.collision_meshes.iter().find(|m| m.body_index == c.body_b) {
+                                rb.resting_normal = Some(crate::player::cast_member::RestingContact {
+                                    normal: c.normal,
+                                    plane_point: c.point,
+                                    ground_friction,
+                                    aabb_min: m.aabb_min,
+                                    aabb_max: m.aabb_max,
+                                });
+                            }
                         }
                     }
                 }
@@ -1387,6 +1487,33 @@ fn step_single(state: &mut HavokPhysicsState, dt: f64) {
             }
             break;
         }
+    }
+}
+
+/// Apply cable / point-to-point constraints as rigid distance constraints
+/// (a pendulum): keep each bob's attach point at `length` from its fixed
+/// anchor, removing radial velocity so it swings under gravity instead of
+/// falling. Position-based so it's stable for a light body like the lamp.
+fn apply_cables(state: &mut HavokPhysicsState) {
+    if state.cable_constraints.is_empty() { return; }
+    let cables = state.cable_constraints.clone();
+    for cable in &cables {
+        let rb = &mut state.rigid_bodies[cable.body_index];
+        if rb.pinned || !rb.active || rb.inverse_mass <= 0.0 { continue; }
+
+        let attach_world = v3_add(rb.position, quat_rotate_v(rb.orientation, cable.attach_local));
+        let d = v3_sub(attach_world, cable.anchor);
+        let dist = v3_len(d);
+        if dist < 1e-6 { continue; }
+        let dir = v3_scale(d, 1.0 / dist);
+
+        // Pull the body so its attach point sits exactly `length` from anchor.
+        let correction = dist - cable.length;
+        rb.position = v3_sub(rb.position, v3_scale(dir, correction));
+
+        // Remove radial velocity (rigid rod) — keep only the tangential (swing).
+        let vr = v3_dot(rb.linear_velocity, dir);
+        rb.linear_velocity = v3_sub(rb.linear_velocity, v3_scale(dir, vr));
     }
 }
 
@@ -1526,11 +1653,69 @@ fn apply_surface_contacts(state: &mut HavokPhysicsState, dt: f64) {
     }
 }
 
+/// Dynamic-vs-dynamic collision using an axis-aligned box approximation around
+/// each body's COM. Resolves along the axis of least penetration (minimum
+/// translation vector), which is stable for the near-axis-aligned crates in the
+/// warehouse demo. Returns one contact per overlapping pair.
+fn detect_body_body_collisions(state: &HavokPhysicsState) -> Vec<CollisionContact> {
+    let mut out = Vec::new();
+    let n = state.rigid_bodies.len();
+    for i in 0..n {
+        let a = &state.rigid_bodies[i];
+        if a.pinned || a.inverse_mass <= 0.0 || a.driven { continue; }
+        let ca = v3_add(a.position, quat_rotate_v(a.orientation, a.center_of_mass));
+        for j in (i+1)..n {
+            let b = &state.rigid_bodies[j];
+            if b.pinned || b.inverse_mass <= 0.0 || b.driven { continue; }
+            // At least one body must be awake — two sleeping bodies in resting
+            // contact must NOT interact, or the whole stack would wake itself.
+            if !a.active && !b.active { continue; }
+            let cb = v3_add(b.position, quat_rotate_v(b.orientation, b.center_of_mass));
+
+            // Per-axis overlap of the two AABBs (half-extents summed).
+            let mut min_overlap = f64::MAX;
+            let mut axis = 0usize;
+            let mut sep = false;
+            for k in 0..3 {
+                let sum = a.inertia_half_extents[k] + b.inertia_half_extents[k];
+                let d = ca[k] - cb[k];
+                let ov = sum - d.abs();
+                if ov <= -CONTACT_MARGIN { sep = true; break; }
+                if ov < min_overlap { min_overlap = ov; axis = k; }
+            }
+            if sep { continue; }
+
+            // Normal points from B toward A along the least-penetrated axis.
+            let mut normal = [0.0; 3];
+            normal[axis] = if ca[axis] - cb[axis] >= 0.0 { 1.0 } else { -1.0 };
+            let point = v3_scale(v3_add(ca, cb), 0.5);
+            out.push(CollisionContact {
+                body_a: i,
+                body_b: Some(j),
+                point,
+                normal,
+                depth: min_overlap,
+            });
+        }
+    }
+    out
+}
+
 /// Detect all transient collisions (body vs static mesh walls/obstacles).
 fn detect_all_collisions(state: &HavokPhysicsState) -> Vec<CollisionContact> {
     if state.collision_meshes.is_empty() { return Vec::new(); }
 
     let mut all_contacts = Vec::new();
+
+    // A "passive" scene (no Lingo springs / dashpots) relies entirely on the
+    // engine to keep bodies on the static ground mesh — this is the standard
+    // Havok behaviour library demo (e.g. the warehouse falling-crates scene).
+    // SuperSonic-style scenes register dashpots/springs and instead drive
+    // ground contact from Lingo hover forces, so for those we keep skipping the
+    // upward-facing static-ground contacts (handled by the ground constraint).
+    let passive_scene = state.springs.is_empty()
+        && state.linear_dashpots.is_empty()
+        && state.angular_dashpots.is_empty();
 
     for bi in 0..state.rigid_bodies.len() {
         let rb = &state.rigid_bodies[bi];
@@ -1538,18 +1723,31 @@ fn detect_all_collisions(state: &HavokPhysicsState) -> Vec<CollisionContact> {
         // Skip bodies in resting contact — handled by apply_surface_contacts
         if rb.resting_normal.is_some() { continue; }
 
-        // Use the body's actual half-extents as collision radius
-        let he = rb.inertia_half_extents;
-        let body_radius = he[0].max(he[1]).max(he[2]);
+        // Per-body decision: a DRIVEN body (the SuperSonic / car-demo car, which
+        // receives hover/drive forces) keeps the original collision path it was
+        // tuned against — even in an otherwise passive scene. Force-free objects
+        // (crates, blocks) use the box-stacking path.
+        let body_passive = passive_scene && !rb.driven;
 
-        let contacts = detect_body_contacts(&state.collision_meshes, rb.position, body_radius, bi, state.tolerance);
+        // Use the body's actual half-extents (box support) for collision.
+        let he = rb.inertia_half_extents;
+        // Box-stacking objects test against the COM-offset box centre (so boxes
+        // rest flush). Driven bodies keep the original origin-centred test.
+        let center = if body_passive {
+            v3_add(rb.position, quat_rotate_v(rb.orientation, rb.center_of_mass))
+        } else {
+            rb.position
+        };
+
+        let contacts = detect_body_contacts(&state.collision_meshes, center, he, bi, state.tolerance, body_passive, &state.rigid_bodies);
         // Keep only the deepest contact per body to avoid duplicate impulses
         // from coplanar triangles (e.g. two triangles forming a box face).
         let mut best: Option<CollisionContact> = None;
         for c in contacts {
-            // Skip upward-facing ground contacts for unowned scenery meshes.
-            // These are handled by the ground constraint safety net.
-            if c.normal[2] > 0.7 && c.body_b.is_none() { continue; }
+            // Skip upward-facing ground contacts for unowned scenery meshes when
+            // a driven body handles ground via hover forces. Box-stacking
+            // objects must keep these or they fall through the floor.
+            if c.normal[2] > 0.7 && c.body_b.is_none() && !body_passive { continue; }
             if best.as_ref().map_or(true, |b| c.depth > b.depth) {
                 best = Some(c);
             }
@@ -1558,6 +1756,14 @@ fn detect_all_collisions(state: &HavokPhysicsState) -> Vec<CollisionContact> {
             all_contacts.push(c);
         }
     }
+
+    // Dynamic body vs dynamic body (axis-aligned box approximation) — passive
+    // scenes only. This is what keeps a stack of crates standing. SuperSonic-
+    // style scenes have no dynamic-vs-dynamic stacks and were tuned without it.
+    if passive_scene {
+        all_contacts.extend(detect_body_body_collisions(state));
+    }
+
     all_contacts
 }
 
@@ -1581,7 +1787,7 @@ pub fn quat_to_yaw(q: Quat) -> f64 {
     siny_cosp.atan2(cosy_cosp)
 }
 
-pub fn build_sync_transform(pos: V3, orientation: Quat, com_local: V3) -> [f32; 16] {
+pub fn build_sync_transform(pos: V3, orientation: Quat, com_local: V3, scale: V3) -> [f32; 16] {
     // Rotation around the center of mass, not around the visual origin.
     //
     // Convention: `pos` is the "reference position" — the visual origin's world
@@ -1612,10 +1818,14 @@ pub fn build_sync_transform(pos: V3, orientation: Quat, com_local: V3) -> [f32; 
     let ty = pos[1] + com_local[1] - ry;
     let tz = pos[2] + com_local[2] - rz;
 
+    // Scale the rotation columns by the authored per-axis model scale so the
+    // rendered model keeps its size (RaycastCar wheel/hover points are derived
+    // from this transform).
+    let (s0, s1, s2) = (scale[0], scale[1], scale[2]);
     [
-        m[0] as f32, m[3] as f32, m[6] as f32, 0.0,
-        m[1] as f32, m[4] as f32, m[7] as f32, 0.0,
-        m[2] as f32, m[5] as f32, m[8] as f32, 0.0,
+        (m[0]*s0) as f32, (m[3]*s0) as f32, (m[6]*s0) as f32, 0.0,
+        (m[1]*s1) as f32, (m[4]*s1) as f32, (m[7]*s1) as f32, 0.0,
+        (m[2]*s2) as f32, (m[5]*s2) as f32, (m[8]*s2) as f32, 0.0,
         tx as f32, ty as f32, tz as f32, 1.0,
     ]
 }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/hke_parser.rs
@@ -18,6 +18,25 @@ pub struct HkeCollisionMesh {
     pub triangles: Vec<[u32; 3]>,
 }
 
+/// A collision primitive attached to a rigid body.
+#[derive(Clone, Debug)]
+pub enum HkePrimitiveKind {
+    /// References a triangle mesh by name (an ENTRY mesh, possibly shared).
+    Mesh { mesh_name: String },
+    /// Infinite plane: local `normal` (unit) at signed `dist` from origin.
+    Plane { normal: [f32; 3], dist: f32 },
+    /// Sphere of `radius` (Havok metres).
+    Sphere { radius: f32 },
+}
+
+#[derive(Clone, Debug)]
+pub struct HkePrimitive {
+    pub kind: HkePrimitiveKind,
+    /// Primitive-local translation relative to the body origin (Havok metres).
+    pub local_translation: [f32; 3],
+    pub mass: f32,
+}
+
 /// Per-body properties parsed from the HKE tail section.
 #[derive(Clone, Debug)]
 pub struct HkeBodyProps {
@@ -27,7 +46,12 @@ pub struct HkeBodyProps {
     pub static_friction: Option<f32>,
     pub dynamic_friction: Option<f32>,
     pub translation: Option<[f32; 3]>,
+    /// Body orientation as axis-angle: `[angle_radians, axisX, axisY, axisZ]`.
+    pub orientation: Option<[f32; 4]>,
+    /// Initial linear velocity (Havok metres/s).
+    pub linear_velocity: Option<[f32; 3]>,
     pub active: Option<bool>,
+    pub primitives: Vec<HkePrimitive>,
 }
 
 /// Drag action parsed from HKE tail.
@@ -37,6 +61,17 @@ pub struct HkeDragAction {
     pub angular_drag: f32,
 }
 
+/// A cable / point-to-point constraint between two bodies (e.g. the hanging
+/// lamp). `pivot_*` are body-local attachment points (Havok metres).
+#[derive(Clone, Debug)]
+pub struct HkeCable {
+    pub body_a: String,
+    pub pivot_a: [f32; 3],
+    pub body_b: String,
+    pub pivot_b: [f32; 3],
+    pub length: f32,
+}
+
 pub struct HkeWorld {
     pub world_name: String,
     pub world_scale: f32,
@@ -44,6 +79,7 @@ pub struct HkeWorld {
     pub drag: Option<HkeDragAction>,
     pub meshes: Vec<HkeCollisionMesh>,
     pub bodies: Vec<HkeBodyProps>,
+    pub cables: Vec<HkeCable>,
 }
 
 // --- Markers and tokens (from C# HkeParser.cs) ---
@@ -90,6 +126,10 @@ const DYNAMIC_FRICTION_TOKEN: [u8; 4] = [0xAE, 0xA1, 0xC1, 0x00];
 const TRANSLATION_TOKEN: [u8; 4] = [0x0E, 0xEC, 0x5F, 0x08];
 const ACTIVE_TOKEN: [u8; 4] = [0xA5, 0x8E, 0x58, 0x04];
 const PRIMITIVE_MASS_TOKEN: [u8; 4] = [0x83, 0x16, 0x05, 0x00];
+const ORIENTATION_TOKEN: [u8; 4] = [0x4E, 0x89, 0x86, 0x04]; // [angle, axisX, axisY, axisZ]
+const LINEAR_VELOCITY_TOKEN: [u8; 4] = [0xD9, 0x4A, 0xA5, 0x0C]; // [vx, vy, vz] m/s
+const PLANE_NORMAL_TOKEN: [u8; 4] = [0x25, 0x06, 0x55, 0x00]; // [nx, ny, nz, dist]
+const SPHERE_RADIUS_TOKEN: [u8; 4] = [0xA3, 0x8E, 0x65, 0x05]; // [radius]
 
 // Subspace tokens
 const SUBSPACE_GRAVITY_TOKEN: [u8; 4] = [0xD9, 0xAE, 0x66, 0x0C];
@@ -106,6 +146,7 @@ pub fn parse_hke(data: &[u8]) -> HkeWorld {
         drag: None,
         meshes: Vec::new(),
         bodies: Vec::new(),
+        cables: Vec::new(),
     };
 
     // Parse header
@@ -139,6 +180,9 @@ pub fn parse_hke(data: &[u8]) -> HkeWorld {
 
     // Parse tail section (rigid bodies, primitives, actions)
     parse_tail(data, tail_start, &mut world);
+
+    // Parse cable / point-to-point constraints (the hanging lamp).
+    parse_cables(data, &mut world);
 
     // Log results
     let movable: Vec<&str> = world.bodies.iter()
@@ -283,6 +327,46 @@ fn parse_tail(data: &[u8], start: usize, world: &mut HkeWorld) {
     }
 }
 
+// Cable / point-to-point constraint tokens.
+const CABLE_MARKER: [u8; 8] = [0x7E, 0x34, 0x31, 0x07, 0x47, 0x90, 0xA7, 0x05];
+const CABLE_BODY_REF: [u8; 3] = [0x9F, 0x73, 0x04]; // followed by body name
+const CABLE_PIVOT_A: [u8; 4] = [0x61, 0x3A, 0x3E, 0x05]; // "a:" + vec3
+const CABLE_PIVOT_B: [u8; 4] = [0x62, 0x3A, 0x3E, 0x05]; // "b:" + vec3
+const CABLE_LENGTH: [u8; 4] = [0xBE, 0x26, 0xCC, 0x0E];
+
+/// Parse every cable constraint record. Each holds two body references
+/// (`9F 73 04` + name), an "a:"/"b:" pivot vec3, and a length scalar.
+fn parse_cables(data: &[u8], world: &mut HkeWorld) {
+    let mut search = 0;
+    while let Some(m) = find_bytes(data, &CABLE_MARKER, search) {
+        let mut pos = m + CABLE_MARKER.len();
+        let _name = read_null_string(data, &mut pos);
+        // Bound the record at the next cable marker (or end).
+        let end = find_bytes(data, &CABLE_MARKER, pos).unwrap_or(data.len());
+        let seg = &data[pos..end];
+
+        // Two body references, in order (A then B).
+        let mut body_a = String::new();
+        let mut body_b = String::new();
+        let mut bsearch = 0;
+        while let Some(bi) = find_bytes(seg, &CABLE_BODY_REF, bsearch) {
+            let mut np = bi + CABLE_BODY_REF.len();
+            let name = read_null_string(seg, &mut np);
+            if body_a.is_empty() { body_a = name; } else if body_b.is_empty() { body_b = name; }
+            bsearch = bi + CABLE_BODY_REF.len();
+        }
+
+        let pivot_a = try_read_vec3_after_token(seg, &CABLE_PIVOT_A).unwrap_or([0.0; 3]);
+        let pivot_b = try_read_vec3_after_token(seg, &CABLE_PIVOT_B).unwrap_or([0.0; 3]);
+        let length = try_read_f32_after_token(seg, &CABLE_LENGTH).unwrap_or(0.0);
+
+        if !body_b.is_empty() {
+            world.cables.push(HkeCable { body_a, pivot_a, body_b, pivot_b, length });
+        }
+        search = end;
+    }
+}
+
 fn parse_rigid_body(data: &[u8], pos: &mut usize, marker_len: usize, world: &mut HkeWorld) {
     *pos += marker_len;
     let name = read_null_string(data, pos);
@@ -298,41 +382,61 @@ fn parse_rigid_body(data: &[u8], pos: &mut usize, marker_len: usize, world: &mut
         static_friction: try_read_f32_after_token(payload, &STATIC_FRICTION_TOKEN),
         dynamic_friction: try_read_f32_after_token(payload, &DYNAMIC_FRICTION_TOKEN),
         translation: try_read_vec3_after_token(payload, &TRANSLATION_TOKEN),
+        orientation: try_read_vec4_after_token(payload, &ORIENTATION_TOKEN),
+        linear_velocity: try_read_vec3_after_token(payload, &LINEAR_VELOCITY_TOKEN),
         active: try_read_bool_after_token(payload, &ACTIVE_TOKEN),
+        primitives: Vec::new(),
     };
 
     *pos = body_end;
 
-    // Parse child primitives and sum their masses
+    // Parse child primitives (geometry + mass).
     while *pos < data.len() {
-        if match_bytes(data, *pos, &PRIMITIVE_MESH_MARKER) {
-            body.total_mass += parse_primitive_mass(data, pos, PRIMITIVE_MESH_MARKER.len());
-            continue;
+        let kind_marker = if match_bytes(data, *pos, &PRIMITIVE_MESH_MARKER) {
+            Some((PRIMITIVE_MESH_MARKER.len(), 0u8))
+        } else if match_bytes(data, *pos, &PRIMITIVE_SPHERE_MARKER) {
+            Some((PRIMITIVE_SPHERE_MARKER.len(), 1u8))
+        } else if match_bytes(data, *pos, &PRIMITIVE_PLANE_MARKER) {
+            Some((PRIMITIVE_PLANE_MARKER.len(), 2u8))
+        } else {
+            None
+        };
+        let (marker_len, kind_id) = match kind_marker { Some(v) => v, None => break };
+
+        if let Some(prim) = parse_primitive(data, pos, marker_len, kind_id) {
+            body.total_mass += prim.mass;
+            body.primitives.push(prim);
         }
-        if match_bytes(data, *pos, &PRIMITIVE_SPHERE_MARKER) {
-            body.total_mass += parse_primitive_mass(data, pos, PRIMITIVE_SPHERE_MARKER.len());
-            continue;
-        }
-        if match_bytes(data, *pos, &PRIMITIVE_PLANE_MARKER) {
-            body.total_mass += parse_primitive_mass(data, pos, PRIMITIVE_PLANE_MARKER.len());
-            continue;
-        }
-        break;
     }
 
     world.bodies.push(body);
 }
 
-fn parse_primitive_mass(data: &[u8], pos: &mut usize, marker_len: usize) -> f32 {
+/// Parse a single collision primitive: name, transform, geometry, mass.
+/// `kind_id`: 0 = mesh, 1 = sphere, 2 = plane.
+fn parse_primitive(data: &[u8], pos: &mut usize, marker_len: usize, kind_id: u8) -> Option<HkePrimitive> {
     *pos += marker_len;
-    let _name = read_null_string(data, pos);
+    let name = read_null_string(data, pos);
 
     let prim_end = find_next_primitive_boundary(data, *pos).unwrap_or(data.len());
     let payload = &data[*pos..prim_end];
     let mass = try_read_f32_after_token(payload, &PRIMITIVE_MASS_TOKEN).unwrap_or(0.0);
+    let local_translation = try_read_vec3_after_token(payload, &TRANSLATION_TOKEN).unwrap_or([0.0; 3]);
+
+    let kind = match kind_id {
+        1 => {
+            let radius = try_read_f32_after_token(payload, &SPHERE_RADIUS_TOKEN).unwrap_or(0.0);
+            HkePrimitiveKind::Sphere { radius }
+        }
+        2 => {
+            let p = try_read_vec4_after_token(payload, &PLANE_NORMAL_TOKEN).unwrap_or([0.0, 0.0, 1.0, 0.0]);
+            HkePrimitiveKind::Plane { normal: [p[0], p[1], p[2]], dist: p[3] }
+        }
+        _ => HkePrimitiveKind::Mesh { mesh_name: name },
+    };
 
     *pos = prim_end;
-    mass
+    Some(HkePrimitive { kind, local_translation, mass })
 }
 
 // --- Token readers ---
@@ -350,6 +454,20 @@ fn try_read_bool_after_token(data: &[u8], token: &[u8; 4]) -> Option<bool> {
     let idx = find_bytes(data, token, 0)?;
     if idx + 4 + 1 <= data.len() {
         Some(data[idx + 4] != 0)
+    } else {
+        None
+    }
+}
+
+fn try_read_vec4_after_token(data: &[u8], token: &[u8; 4]) -> Option<[f32; 4]> {
+    let idx = find_bytes(data, token, 0)?;
+    if idx + 4 + 16 <= data.len() {
+        Some([
+            read_f32(data, idx + 4),
+            read_f32(data, idx + 8),
+            read_f32(data, idx + 12),
+            read_f32(data, idx + 16),
+        ])
     } else {
         None
     }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -113,7 +113,11 @@ impl Shockwave3dMemberHandlers {
     }
 
     fn native_text_supersample(smoothness: u32) -> i32 {
-        (2 + (smoothness as i32 / 4)).clamp(2, 5)
+        // The native-font path traces the rasterised glyph at this resolution, so
+        // the extruded silhouette is only as smooth as the supersample. Bias it
+        // higher (Director smoothness 0..10 → 3..6) so text like Pacman's score
+        // popups (smoothness 5 → 5) reads far less stair-stepped.
+        (3 + (smoothness as i32 / 2)).clamp(3, 6)
     }
 
     fn render_native_text_bitmap(
@@ -212,6 +216,89 @@ impl Shockwave3dMemberHandlers {
             scene.clod_meshes.insert("Text".to_string(), vec![mesh]);
             scene.mesh_content_version += 1;
         }
+    }
+
+    /// Build an extruded 3D glyph mesh from a Text3D source + state (the same
+    /// native-alpha-mask extrusion used by the #mode3D path). Shared by
+    /// member.extrude3d(scene) and the resulting resource's geometry setters.
+    pub(crate) fn build_text3d_mesh(
+        source: &crate::player::cast_member::Text3dSource,
+        state: &crate::player::cast_member::Text3dState,
+    ) -> Option<crate::director::chunks::w3d::types::ClodDecodedMesh> {
+        let (bw, bh, rgba) = Self::render_native_text_bitmap(source, state.smoothness)?;
+        // Marching-squares extrusion: smooth (sub-pixel) silhouette vs the
+        // per-pixel voxel mesh, matching Director's vector-outline edges.
+        Some(crate::director::chunks::w3d::primitives::extrude_alpha_mask_smooth(
+            bw, bh, &rgba,
+            source.width as f32, source.height as f32,
+            state.tunnel_depth,
+        ))
+    }
+
+    /// Re-extrude an extrude3d resource (keyed by `resname`) into `member`'s
+    /// scene from the retained source + state.
+    pub(crate) fn rebuild_extruded_text(player: &mut DirPlayer, member_ref: &CastMemberRef, resname: &str) {
+        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(member_ref) {
+            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                if let Some((source, state)) = w3d.runtime_state.text3d_resources.get(resname).cloned() {
+                    if let Some(mut mesh) = Self::build_text3d_mesh(&source, &state) {
+                        mesh.name = resname.to_string();
+                        if let Some(scene) = w3d.scene_mut() {
+                            scene.clod_meshes.insert(resname.to_string(), vec![mesh]);
+                            scene.mesh_content_version += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Apply a Text3D geometry property (tunnelDepth/bevelDepth/bevelType/
+    /// smoothness) to an extrude3d resource and re-extrude its mesh. Returns
+    /// true if `resname` is an extrude3d resource (so the prop was consumed),
+    /// false otherwise (caller can fall back to other handling).
+    pub(crate) fn set_extruded_text_param(
+        player: &mut DirPlayer,
+        member_ref: &CastMemberRef,
+        resname: &str,
+        prop: &str,
+        value: &Datum,
+    ) -> bool {
+        let mut found = false;
+        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(member_ref) {
+            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                if let Some((_src, state)) = w3d.runtime_state.text3d_resources.get_mut(resname) {
+                    found = true;
+                    match prop.to_ascii_lowercase().as_str() {
+                        "tunneldepth" => {
+                            state.tunnel_depth = value.float_value()
+                                .or_else(|_| value.int_value().map(|v| v as f64))
+                                .unwrap_or(state.tunnel_depth as f64).max(1.0) as f32;
+                        }
+                        "beveldepth" => {
+                            state.bevel_depth = value.float_value()
+                                .or_else(|_| value.int_value().map(|v| v as f64))
+                                .unwrap_or(state.bevel_depth as f64) as f32;
+                        }
+                        "smoothness" => {
+                            state.smoothness = value.int_value().unwrap_or(state.smoothness as i32) as u32;
+                        }
+                        "beveltype" => {
+                            state.bevel_type = match value.string_value().unwrap_or_default().trim_start_matches('#') {
+                                "miter" => 1,
+                                "round" => 2,
+                                _ => 0,
+                            };
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        if found {
+            Self::rebuild_extruded_text(player, member_ref, resname);
+        }
+        found
     }
 
     fn scale_text3d_mesh_depth(
@@ -697,6 +784,17 @@ impl Shockwave3dMemberHandlers {
                 Ok(Datum::Symbol(symbol.to_string()))
             }
 
+            "text" => {
+                // A Text member with displayMode #mode3D is represented here as a
+                // converted Shockwave3D member; Director keeps its .text live. Read
+                // it back from the retained 3D-text spans.
+                let s = player.movie.cast_manager.find_member_by_ref(cast_member_ref)
+                    .and_then(|m| m.member_type.as_shockwave3d())
+                    .and_then(|w3d| w3d.text3d_source.as_ref())
+                    .map(|src| src.spans.iter().map(|sp| sp.text.as_str()).collect::<String>())
+                    .unwrap_or_default();
+                Ok(Datum::String(s))
+            }
             _ => {
                 Err(ScriptError::new(format!(
                     "Cannot get Shockwave3D property '{}'", prop
@@ -830,6 +928,28 @@ impl Shockwave3dMemberHandlers {
                             }
                             w3d.runtime_state.node_transforms.insert("DefaultDirectional".to_string(), t);
                         }
+                    }
+                }
+                Ok(())
+            }
+            "text" => {
+                // member("x").text = "..." on a Text member that was promoted to a
+                // 3D-text member (displayMode #mode3D). Director keeps the text live
+                // and re-extrudes; replace the retained span content (preserving the
+                // first span's style) and rebuild the mesh. Returning Ok here is what
+                // stops PacMan3D crashing on its score-popup updates.
+                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(cast_member_ref) {
+                    if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                        let new_text = value.string_value().unwrap_or_default();
+                        if let Some(source) = w3d.text3d_source.as_mut() {
+                            if let Some(first) = source.spans.first().cloned() {
+                                source.spans = vec![crate::player::handlers::datum_handlers::cast_member::font::StyledSpan {
+                                    text: new_text,
+                                    style: first.style,
+                                }];
+                            }
+                        }
+                        Self::rebuild_native_text_mesh(w3d);
                     }
                 }
                 Ok(())
@@ -1991,10 +2111,69 @@ impl Shockwave3dMemberHandlers {
                         return Ok(player.alloc_datum(Datum::Void));
                     }
 
-                    // loadFile, extrude3d, getPref, setPref
-                    if handler_name == "loadFile" || handler_name == "extrude3d"
-                        || handler_name == "getPref" || handler_name == "setPref" {
+                    // loadFile, getPref, setPref — stubs
+                    if handler_name == "loadFile" || handler_name == "getPref" || handler_name == "setPref" {
                         return Ok(player.alloc_datum(Datum::Void));
+                    }
+
+                    // extrude3d(targetScene): extrude THIS text member's glyphs into a
+                    // model resource inside the target 3D scene member (arg 0) and
+                    // return that resource. `member_ref` was promoted to a 3D-text
+                    // member by ensure_text3d at call() entry, so its retained
+                    // text3d_source/state hold the glyphs + extrude params.
+                    if handler_name == "extrude3d" {
+                        let (source, state) = {
+                            let m = player.movie.cast_manager.find_member_by_ref(&member_ref);
+                            let w3d = m.and_then(|m| m.member_type.as_shockwave3d());
+                            match (
+                                w3d.and_then(|w| w.text3d_source.clone()),
+                                w3d.and_then(|w| w.text3d_state.clone()),
+                            ) {
+                                (Some(s), Some(st)) => (s, st),
+                                _ => return Ok(player.alloc_datum(Datum::Void)),
+                            }
+                        };
+                        let target_ref = match args.get(0).map(|a| player.get_datum(a)) {
+                            Some(Datum::CastMember(r)) => r.clone(),
+                            _ => return Ok(player.alloc_datum(Datum::Void)),
+                        };
+                        let src_name = player.movie.cast_manager.find_member_by_ref(&member_ref)
+                            .map(|m| m.name.clone()).unwrap_or_else(|| "text".to_string());
+                        let resname = format!("{}_extrude3d", src_name);
+                        let mut mesh = match Self::build_text3d_mesh(&source, &state) {
+                            Some(m) => m,
+                            None => return Ok(player.alloc_datum(Datum::Void)),
+                        };
+                        mesh.name = resname.clone();
+                        let num_faces = mesh.faces.len() as u32;
+                        if let Some(target) = player.movie.cast_manager.find_mut_member_by_ref(&target_ref) {
+                            if let Some(w3d_t) = target.member_type.as_shockwave3d_mut() {
+                                if let Some(scene) = w3d_t.scene_mut() {
+                                    use crate::director::chunks::w3d::types::*;
+                                    scene.clod_meshes.insert(resname.clone(), vec![mesh]);
+                                    let mut mi = ClodMeshInfo::default();
+                                    mi.num_faces = num_faces;
+                                    scene.model_resources.insert(resname.clone(), ModelResourceInfo {
+                                        name: resname.clone(),
+                                        mesh_infos: vec![mi],
+                                        shader_bindings: vec![ModelShaderBinding {
+                                            name: String::new(),
+                                            mesh_bindings: vec![String::new()],
+                                        }],
+                                        ..Default::default()
+                                    });
+                                    scene.mesh_content_version += 1;
+                                }
+                                w3d_t.runtime_state.text3d_resources.insert(resname.clone(), (source, state));
+                            }
+                        }
+                        use crate::director::lingo::datum::Shockwave3dObjectRef;
+                        return Ok(player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                            cast_lib: target_ref.cast_lib,
+                            cast_member: target_ref.cast_member,
+                            object_type: "modelResource".to_string(),
+                            name: resname,
+                        })));
                     }
 
                     // If no parsed scene exists, create a minimal empty scene

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -1124,12 +1124,26 @@ impl Shockwave3dMemberHandlers {
                     }
 
                     if handler_name == "resetWorld" {
+                        use std::sync::atomic::{AtomicU64, Ordering};
+                        // Monotonic generation so each resetWorld stamps a brand-new
+                        // content version — guarantees the renderer's per-member GPU
+                        // mesh cache is rebuilt. Without this, a deterministic restart
+                        // (game over → resetWorld → rebuild the same models) can land
+                        // back on a cached version and leave the PREVIOUS game's models
+                        // on screen (stale models, maze rebuilt over old transforms).
+                        static RESET_GEN: AtomicU64 = AtomicU64::new(1_000_000);
                         let member = player.movie.cast_manager.find_mut_member_by_ref(&member_ref)
                             .ok_or_else(|| ScriptError::new("Member not found".to_string()))?;
                         if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
-                            // resetWorld: restore to state when member was first loaded into memory
+                            // resetWorld: restore to the state from when the member was
+                            // first loaded. Deep-clone the retained source so runtime
+                            // edits never leak back into it, and stamp a fresh version.
                             if let Some(ref source) = w3d.source_scene {
-                                w3d.parsed_scene = Some(source.clone());
+                                let mut fresh = (**source).clone();
+                                let reset_gen = RESET_GEN.fetch_add(1, Ordering::Relaxed);
+                                fresh.mesh_content_version = reset_gen;
+                                fresh.texture_content_version = reset_gen;
+                                w3d.parsed_scene = Some(std::rc::Rc::new(fresh));
                             }
                             w3d.runtime_state = crate::player::cast_member::Shockwave3dRuntimeState::from_info(&w3d.info, w3d.parsed_scene.as_deref());
                         }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -2144,9 +2144,15 @@ impl Shockwave3dMemberHandlers {
                         if let Some(w3d) = member.and_then(|m| m.member_type.as_shockwave3d()) {
                             let transforms = w3d.runtime_state.node_transforms.clone();
                             let mut excluded = std::collections::HashSet::new();
-                            for (name, &vis_mode) in &w3d.runtime_state.node_visibility {
-                                if vis_mode == 0 { excluded.insert(name.clone()); } // #none
-                            }
+                            // NOTE: do NOT exclude models by visibility. Per the Director
+                            // 11.5 dictionary, modelsUnderRay filters only by the optional
+                            // #modelList and maxDistance — `visibility = #none` is a
+                            // render-only flag and such models are still hit by the ray.
+                            // Invisible collision geometry (e.g. the estate explore's
+                            // `model("invisible")` boundary, hidden with visibility=#none
+                            // but used by touch() to block the camera) depends on this;
+                            // excluding it let the player walk off the map. Only
+                            // removeFromWorld (detached_nodes) removes a model from raycasts.
                             for name in &w3d.runtime_state.detached_nodes {
                                 excluded.insert(name.clone());
                             }

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/shockwave3d.rs
@@ -1812,6 +1812,17 @@ impl Shockwave3dMemberHandlers {
                                                 primitive_length: 1.0,
                                                 primitive_height: 1.0,
                                                 primitive_radius: 1.0,
+                                                primitive_top_radius: 1.0,
+                                                primitive_resolution: 0, // 0 → default tessellation
+                                                primitive_start_angle: 0.0,
+                                                primitive_end_angle: 360.0,
+                                                // Spec lists topCap default FALSE / bottomCap TRUE, but every
+                                                // capped cylinder in these movies (Coke can, maze pipes) relies on
+                                                // BOTH caps without setting topCap, and Shockwave renders them
+                                                // sealed — so default both TRUE. Models that want an open tube set
+                                                // the flag explicitly (the ghost body sets topCap=0 AND bottomCap=0).
+                                                primitive_top_cap: true,
+                                                primitive_bottom_cap: true,
                                                 ..Default::default()
                                             });
 

--- a/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/havok_object.rs
@@ -287,15 +287,15 @@ impl HavokObjectDatumHandlers {
         let sync_data = if needs_w3d_sync {
             havok.state.rigid_bodies.iter()
                 .find(|r| r.name.eq_ignore_ascii_case(rb_name))
-                .map(|rb| (rb.position, rb.orientation, rb.center_of_mass))
+                .map(|rb| (rb.position, rb.orientation, rb.center_of_mass, rb.sync_scale))
         } else { None };
 
         // Sync rigid body position+rotation to W3D model transform (quaternion-based).
         // Goes through set_node_transform so the Lingo-visible persistent datum
         // is also updated, not just node_transforms.
-        if let Some((pos, orientation, com)) = sync_data {
+        if let Some((pos, orientation, com, sscale)) = sync_data {
             let t = crate::player::handlers::datum_handlers::cast_member::havok_physics::build_sync_transform(
-                pos, orientation, com,
+                pos, orientation, com, sscale,
             );
             let w3d_ref = CastMemberRef { cast_lib: w3d_cast_lib, cast_member: w3d_cast_member };
             crate::player::handlers::datum_handlers::shockwave3d_object::set_node_transform(
@@ -325,6 +325,7 @@ impl HavokObjectDatumHandlers {
                 if let Some(rb) = havok.state.rigid_bodies.iter_mut()
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
+                    rb.active = true;
                     rb.force[0] += force[0];
                     rb.force[1] += force[1];
                     rb.force[2] += force[2];
@@ -345,6 +346,7 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_sub, quat_rotate_v, v3_cross};
+                    rb.active = true;
                     // Add linear force (world-space)
                     rb.force[0] += force[0];
                     rb.force[1] += force[1];
@@ -375,6 +377,7 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_add, v3_scale};
+                    rb.active = true;
                     if rb.inverse_mass > 0.0 {
                         rb.linear_velocity = v3_add(rb.linear_velocity, v3_scale(impulse, rb.inverse_mass));
                     }
@@ -397,6 +400,7 @@ impl HavokObjectDatumHandlers {
                     .find(|r| r.name.eq_ignore_ascii_case(rb_name))
                 {
                     use super::cast_member::havok_physics::{v3_sub, v3_add, v3_scale, v3_cross, quat_rotate_v, mat3_transform};
+                    rb.active = true;
                     if rb.inverse_mass > 0.0 {
                         // Linear: v += impulse * inverseMass
                         rb.linear_velocity = v3_add(rb.linear_velocity, v3_scale(impulse, rb.inverse_mass));

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -1487,6 +1487,15 @@ impl Shockwave3dObjectDatumHandlers {
                     // modelResource property set: vertexList, textureCoordinateList, colorList, normalList
                     use crate::player::cast_member::MeshBuildData;
                     match_ci!(prop_name, {
+                        // Text3D geometry params on an extrude3d resource (textres.tunnelDepth
+                        // = 5, .bevelType = #round, ...): update state + re-extrude. A no-op
+                        // for non-text resources, so it never errors.
+                        "tunnelDepth" | "tunneldepth" | "bevelDepth" | "beveldepth"
+                        | "bevelType" | "beveltype" | "smoothness" => {
+                            crate::player::handlers::datum_handlers::cast_member::shockwave3d::Shockwave3dMemberHandlers::set_extruded_text_param(
+                                player, &member_ref, &s3d_ref.name, prop_name, value,
+                            );
+                        },
                         "vertexList" => {
                             let verts: Vec<[f32; 3]> = if let Datum::List(_, items, _) = value {
                                 items.iter().map(|r| {

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -1993,12 +1993,14 @@ impl Shockwave3dObjectDatumHandlers {
                 // ─── Node transform methods ───
                 "translate" => {
                     let (dx, dy, dz) = read_xyz_args(player, args);
-                    apply_translation(player, &member_ref, &s3d_ref.name, dx, dy, dz);
+                    let world = args_relative_to_world(player, args);
+                    apply_translation(player, &member_ref, &s3d_ref.name, dx, dy, dz, world);
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "rotate" => {
                     let (rx, ry, rz) = read_xyz_args(player, args);
-                    apply_rotation(player, &member_ref, &s3d_ref.name, rx, ry, rz);
+                    let world = args_relative_to_world(player, args);
+                    apply_rotation(player, &member_ref, &s3d_ref.name, rx, ry, rz, world);
                     Ok(player.alloc_datum(Datum::Void))
                 },
                 "scale" => {
@@ -5500,6 +5502,27 @@ fn read_xyz_args(player: &crate::player::DirPlayer, args: &[crate::player::Datum
     }
 }
 
+/// Read the optional trailing `relativeTo` symbol of translate/rotate.
+/// Per the Director spec a NODE reference defaults to `#self` (the node's own
+/// local axes); `#world`/`#parent` apply the change in the parent/world frame.
+/// Returns true only for an explicit `#world`/`#parent`.
+fn args_relative_to_world(player: &crate::player::DirPlayer, args: &[crate::player::DatumRef]) -> bool {
+    let sym_ref = if args.len() >= 4 {
+        Some(&args[3]) // translate(x, y, z, relativeTo)
+    } else if args.len() == 2 {
+        Some(&args[1]) // translate(vector, relativeTo)
+    } else {
+        None
+    };
+    if let Some(r) = sym_ref {
+        if let Datum::Symbol(s) = player.get_datum(r) {
+            let s = s.to_ascii_lowercase();
+            return s == "world" || s == "parent";
+        }
+    }
+    false
+}
+
 const IDENTITY: [f32; 16] = [
     1.0, 0.0, 0.0, 0.0,
     0.0, 1.0, 0.0, 0.0,
@@ -5940,6 +5963,7 @@ fn apply_translation(
     member_ref: &crate::player::cast_lib::CastMemberRef,
     node_name: &str,
     dx: f32, dy: f32, dz: f32,
+    world_relative: bool,
 ) {
     // Flush any pending persistent Transform3d mutations into node_transforms
     // first — otherwise a prior `transform.position = v` on the cached datum is
@@ -5948,9 +5972,21 @@ fn apply_translation(
     // stale position, silently dropping the Lingo write. Mirrors apply_point_at.
     sync_persistent_transforms(player);
     let mut m = get_or_init_node_transform(player, member_ref, node_name);
-    m[12] += dx;
-    m[13] += dy;
-    m[14] += dz;
+    if world_relative {
+        // #world / #parent: increments are in the (parent-space) position frame.
+        m[12] += dx;
+        m[13] += dy;
+        m[14] += dz;
+    } else {
+        // #self (the node-reference default): increments run along the node's own
+        // local axes, i.e. the rotation columns of its transform. Pacman's death
+        // slide relies on this — rz=90 puts local +X along world +Y, so
+        // translate(0.5,0,0) lifts him up (worldPosition.y climbs to the respawn
+        // threshold) instead of sliding sideways.
+        m[12] += m[0] * dx + m[4] * dy + m[8] * dz;
+        m[13] += m[1] * dx + m[5] * dy + m[9] * dz;
+        m[14] += m[2] * dx + m[6] * dy + m[10] * dz;
+    }
     set_node_transform(player, member_ref, node_name, m);
 }
 
@@ -5959,6 +5995,7 @@ fn apply_rotation(
     member_ref: &crate::player::cast_lib::CastMemberRef,
     node_name: &str,
     rx_deg: f32, ry_deg: f32, rz_deg: f32,
+    world_relative: bool,
 ) {
     // See apply_translation comment — same flush requirement.
     sync_persistent_transforms(player);
@@ -5966,8 +6003,18 @@ fn apply_rotation(
     // Director uses left-handed coordinates where Y rotation is opposite to OpenGL's
     // right-handed convention, so negate Y.
     let rot = euler_to_matrix_f32(rx_deg, -ry_deg, rz_deg);
-    // Apply rotation in world axes but keep the node positioned in place.
-    let mut result = mat4_mul_f32(&rot, &m);
+    let mut result = if world_relative {
+        // #world / #parent: compose in the world/parent frame (rot · R).
+        mat4_mul_f32(&rot, &m)
+    } else {
+        // #self (the node-reference default): compose in the node's LOCAL frame
+        // (R · rot), so the rotation runs about the node's own axes. Pacman's
+        // death spin uses rotate(5,0,0): about local X (which rz=90 aligns with
+        // world +Y), so local X stays fixed and his upward slide doesn't drift.
+        mat4_mul_f32(&m, &rot)
+    };
+    // Keep the node positioned in place (m * rot already preserves translation,
+    // but restore explicitly for the world-frame branch).
     result[12] = m[12];
     result[13] = m[13];
     result[14] = m[14];

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -1072,6 +1072,52 @@ impl Shockwave3dObjectDatumHandlers {
                     }
                     Ok(())
                 },
+                "reflectionMap" | "reflectionmap" => {
+                    // 3D shader helper property (Director 11.5 Scripting Dictionary,
+                    // "reflectionMap"): sets the texture used for reflections on the
+                    // model surface. It is applied to the THIRD texture layer and is
+                    // exactly equivalent to:
+                    //   shader.textureList[3]       = tex
+                    //   shader.textureModeList[3]   = #reflection
+                    //   shader.blendFunctionList[3] = #blend
+                    //   shader.blendSourceList[3]   = #constant
+                    //   shader.blendConstantList[3] = 50.0
+                    // (encodings mirror the blend*List setters in this file:
+                    //  tex_mode 4=#reflection, blend_func 3=#blend, blend_src 0=#constant.)
+                    if s3d_ref.object_type != "shader" { return Ok(()); }
+                    let tex_name = match value {
+                        Datum::Shockwave3dObjectRef(r) => r.name.clone(),
+                        Datum::String(s) => s.clone(),
+                        Datum::Void => String::new(),
+                        _ => String::new(),
+                    };
+                    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                        if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                            if let Some(scene) = w3d.scene_mut() {
+                                if let Some(shader) = scene.shaders.iter_mut().find(|s| s.name == s3d_ref.name) {
+                                    // The reflection texture lives on layer index 2 (Lingo
+                                    // textureList[3]); grow the list so it exists.
+                                    while shader.texture_layers.len() <= 2 {
+                                        shader.texture_layers.push(
+                                            crate::director::chunks::w3d::types::W3dTextureLayer::default(),
+                                        );
+                                    }
+                                    let layer = &mut shader.texture_layers[2];
+                                    layer.name = tex_name;
+                                    layer.tex_mode = 4;     // #reflection
+                                    layer.blend_func = 3;   // #blend
+                                    layer.blend_src = 0;    // #constant
+                                    // Default constant 50% per the dictionary; a later
+                                    // blendConstantList[3] assignment overrides it.
+                                    if layer.blend_const <= 0.0 {
+                                        layer.blend_const = 0.5;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    Ok(())
+                },
                 "rootNode" => {
                   if s3d_ref.object_type != "camera" { return Ok(()); }
                     let cam_key = s3d_ref.name.to_ascii_lowercase();
@@ -4434,6 +4480,26 @@ impl Shockwave3dObjectDatumHandlers {
                     name: tex_name.to_string(),
                 })))
             },
+            "reflectionMap" | "reflectionmap" => {
+                // Getter for the reflection helper property: returns the texture on
+                // the third texture layer, or VOID if none (Director 11.5 default).
+                let tex_name = shader
+                    .and_then(|s| s.texture_layers.get(2))
+                    .map(|l| l.name.as_str())
+                    .filter(|n| !n.is_empty());
+                match tex_name {
+                    Some(name) => {
+                        use crate::director::lingo::datum::Shockwave3dObjectRef;
+                        Ok(player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                            cast_lib: member_ref.cast_lib,
+                            cast_member: member_ref.cast_member,
+                            object_type: "texture".to_string(),
+                            name: name.to_string(),
+                        })))
+                    }
+                    None => Ok(player.alloc_datum(Datum::Void)),
+                }
+            },
             "textureList" => {
                 // Return a persistent textureList so assignments like
                 // shaderList[m].textureList[n] = tex persist
@@ -4557,6 +4623,19 @@ impl Shockwave3dObjectDatumHandlers {
                 )))
             },
             "blendConstantList" => {
+                // Persist the list so `shader.blendConstantList[i] = N` (e.g. the 30%
+                // override after reflectionMap) is visible to sync_shader_texture_lists
+                // at render time. Without persistence the index-set mutated a throwaway
+                // list and the layer kept the reflectionMap helper's 50% default.
+                let existing_ref = {
+                    let member = player.movie.cast_manager.find_member_by_ref(member_ref);
+                    member.and_then(|m| m.member_type.as_shockwave3d())
+                        .and_then(|w3d| w3d.runtime_state.shader_blend_constant_lists.get(shader_name))
+                        .cloned()
+                };
+                if let Some(list_ref) = existing_ref {
+                    return Ok(list_ref);
+                }
                 let mut items = VecDeque::new();
                 if let Some(s) = shader {
                     for layer in &s.texture_layers {
@@ -4566,9 +4645,16 @@ impl Shockwave3dObjectDatumHandlers {
                 while items.len() < 8 {
                     items.push_back(player.alloc_datum(Datum::Float(50.0)));
                 }
-                Ok(player.alloc_datum(Datum::List(
+                let list_ref = player.alloc_datum(Datum::List(
                     crate::director::lingo::datum::DatumType::List, items, false,
-                )))
+                ));
+                let shader_name_owned = shader_name.to_string();
+                if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(member_ref) {
+                    if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                        w3d.runtime_state.shader_blend_constant_lists.insert(shader_name_owned, list_ref.clone());
+                    }
+                }
+                Ok(list_ref)
             },
             "textureRepeatList" => {
                 let mut items = VecDeque::new();
@@ -5463,6 +5549,7 @@ pub fn sync_shader_texture_lists(player: &mut crate::player::DirPlayer) {
     // Collect (cast_lib, member_num, shader_name, list_ref) tuples
     let mut entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
     let mut mode_entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
+    let mut blend_entries: Vec<(i32, u32, String, DatumRef)> = Vec::new();
     for cast in &player.movie.cast_manager.casts {
         for (member_num, member) in &cast.members {
             if let Some(w3d) = member.member_type.as_shockwave3d() {
@@ -5471,6 +5558,36 @@ pub fn sync_shader_texture_lists(player: &mut crate::player::DirPlayer) {
                 }
                 for (shader_name, list_ref) in &w3d.runtime_state.shader_texture_mode_lists {
                     mode_entries.push((cast.number as i32, *member_num, shader_name.clone(), list_ref.clone()));
+                }
+                for (shader_name, list_ref) in &w3d.runtime_state.shader_blend_constant_lists {
+                    blend_entries.push((cast.number as i32, *member_num, shader_name.clone(), list_ref.clone()));
+                }
+            }
+        }
+    }
+
+    // Sync blend constants (0..100) back to shader.texture_layers[].blend_const (0..1).
+    for (cast_lib, cast_member, shader_name, list_ref) in blend_entries {
+        let consts: Vec<f32> = if let Datum::List(_, items, _) = player.get_datum(&list_ref) {
+            items.iter().map(|item_ref| {
+                (player.get_datum(item_ref).to_float().unwrap_or(50.0) as f32 / 100.0).clamp(0.0, 1.0)
+            }).collect()
+        } else {
+            continue;
+        };
+        let member_ref = CastMemberRef { cast_lib, cast_member: cast_member as i32 };
+        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+            if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                if let Some(scene) = w3d.scene_mut() {
+                    if let Some(shader) = scene.shaders.iter_mut().find(|s| s.name == shader_name) {
+                        use crate::director::chunks::w3d::types::W3dTextureLayer;
+                        while shader.texture_layers.len() < consts.len() {
+                            shader.texture_layers.push(W3dTextureLayer::default());
+                        }
+                        for (i, c) in consts.iter().enumerate() {
+                            shader.texture_layers[i].blend_const = *c;
+                        }
+                    }
                 }
             }
         }

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -2282,8 +2282,28 @@ impl Shockwave3dObjectDatumHandlers {
                             Datum::String(s) => s.clone(),
                             _ => String::new(),
                         };
+                        // 2nd arg selects transform handling. Default #preserveParent keeps
+                        // the child's LOCAL transform. #preserveWorld keeps the child's WORLD
+                        // transform, recomputing local = inverse(parentWorld) * childWorld.
+                        // Required by the Pacman maze (pipes parented to pipePink1) and the
+                        // ghosts (top/eyes parented to the body) — without it each child
+                        // inherited the parent's transform on top of its own (misplaced maze,
+                        // ghost parts floating off the body).
+                        let preserve_world = match args.get(1).map(|a| player.get_datum(a)) {
+                            Some(Datum::Symbol(s)) => s.eq_ignore_ascii_case("preserveWorld"),
+                            Some(Datum::String(s)) => s.eq_ignore_ascii_case("preserveWorld"),
+                            _ => false,
+                        };
                         if !child_name.is_empty() {
                             let member_ref = CastMemberRef { cast_lib: s3d_ref.cast_lib, cast_member: s3d_ref.cast_member };
+                            if preserve_world {
+                                // Compute both world transforms under the OLD hierarchy, then
+                                // rebase the child's local transform onto the new parent.
+                                let child_world = node_world_transform(player, &member_ref, &child_name);
+                                let parent_world = node_world_transform(player, &member_ref, &s3d_ref.name);
+                                let new_local = mat4_mul_f32(&invert_transform_f32(&parent_world), &child_world);
+                                set_node_transform(player, &member_ref, &child_name, new_local);
+                            }
                             if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                                 if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
                                     w3d.runtime_state.detached_nodes.remove(&child_name);
@@ -5577,6 +5597,34 @@ fn get_node_transform(
     IDENTITY
 }
 
+/// Like get_node_transform, but reads the LIVE persistent transform datum first.
+/// model.transform.position/rotation mutate that datum immediately, while the
+/// node_transforms cache is only flushed once per frame (sync_persistent_transforms).
+/// Mid-script callers (e.g. addChild #preserveWorld, run right after the position is
+/// set) must see the live value, not the stale cache.
+fn get_node_transform_live(
+    player: &crate::player::DirPlayer,
+    member_ref: &crate::player::cast_lib::CastMemberRef,
+    node_name: &str,
+) -> [f32; 16] {
+    let dr_opt = player.movie.cast_manager.find_member_by_ref(member_ref)
+        .and_then(|m| m.member_type.as_shockwave3d())
+        .and_then(|w3d| {
+            w3d.runtime_state.node_transform_datums.get(node_name).cloned()
+                .or_else(|| w3d.runtime_state.node_transform_datums.iter()
+                    .find(|(k, _)| k.eq_ignore_ascii_case(node_name))
+                    .map(|(_, v)| v.clone()))
+        });
+    if let Some(dr) = dr_opt {
+        if let Datum::Transform3d(m) = player.get_datum(&dr) {
+            let mut out = [0.0f32; 16];
+            for i in 0..16 { out[i] = m[i] as f32; }
+            return out;
+        }
+    }
+    get_node_transform(player, member_ref, node_name)
+}
+
 /// Get the accumulated WORLD position for a node by walking the parent chain.
 /// This matches Director's `model.worldPosition` / `group.worldPosition` behavior.
 fn get_world_position(
@@ -5696,6 +5744,32 @@ pub fn set_node_transform(
             w3d.runtime_state.node_transforms.insert(key, m);
         }
     }
+}
+
+/// World-relative transform of a node, accumulated up its parent chain (same
+/// convention as the getWorldTransform handler). Used by addChild #preserveWorld.
+fn node_world_transform(
+    player: &crate::player::DirPlayer,
+    member_ref: &crate::player::cast_lib::CastMemberRef,
+    node_name: &str,
+) -> [f32; 16] {
+    let mut result = get_node_transform_live(player, member_ref, node_name);
+    let mut current = node_name.to_string();
+    for _ in 0..20 {
+        let parent_name = {
+            player.movie.cast_manager.find_member_by_ref(member_ref)
+                .and_then(|m| m.member_type.as_shockwave3d())
+                .and_then(|w| w.parsed_scene.as_ref())
+                .and_then(|s| s.nodes.iter().find(|n| n.name.eq_ignore_ascii_case(&current)))
+                .map(|n| n.parent_name.clone())
+                .unwrap_or_default()
+        };
+        if parent_name.is_empty() || parent_name.eq_ignore_ascii_case("World") { break; }
+        let pt = get_node_transform_live(player, member_ref, &parent_name);
+        result = mat4_mul_f32(&pt, &result);
+        current = parent_name;
+    }
+    result
 }
 
 /// Get or create a persistent Transform3d DatumRef for a node.

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -194,6 +194,37 @@ impl Shockwave3dObjectDatumHandlers {
                     },
                 })
             },
+            // #particle range objects — read .start / .end back from the particle state.
+            // Scripts gate flow on these (e.g. `if resource.blendRange.start > 0`), so the
+            // getter must return what was set, not a placeholder.
+            "colorRange" | "sizeRange" | "blendRange" => {
+                let ps = {
+                    let member = player.movie.cast_manager.find_member_by_ref(member_ref);
+                    member.and_then(|m| m.member_type.as_shockwave3d())
+                        .and_then(|w3d| w3d.runtime_state.particles.get(&s3d_ref.name))
+                        .cloned()
+                };
+                let is_start = prop_name.eq_ignore_ascii_case("start");
+                match_ci!(s3d_ref.object_type.as_str(), {
+                    "colorRange" => {
+                        let c = ps.as_ref().map(|p| if is_start { p.color_start } else { p.color_end })
+                            .unwrap_or([1.0, 1.0, 1.0]);
+                        let to_u8 = |v: f32| (v * 255.0).round().clamp(0.0, 255.0) as u8;
+                        Ok(player.alloc_datum(Datum::ColorRef(crate::player::sprite::ColorRef::Rgb(
+                            to_u8(c[0]), to_u8(c[1]), to_u8(c[2])))))
+                    },
+                    "sizeRange" => {
+                        let v = ps.as_ref().map(|p| if is_start { p.size_start } else { p.size_end }).unwrap_or(0.0);
+                        Ok(player.alloc_datum(Datum::Float(v as f64)))
+                    },
+                    "blendRange" => {
+                        // Stored as the raw IFX alpha (0..1, default 0.1); report as set.
+                        let v = ps.as_ref().map(|p| if is_start { p.blend_start } else { p.blend_end }).unwrap_or(0.1);
+                        Ok(player.alloc_datum(Datum::Float(v as f64)))
+                    },
+                    _ => Ok(player.alloc_datum(Datum::Void)),
+                })
+            },
             "sds" => {
                 // Subdivision Surface modifier properties
                 let sds = {
@@ -527,6 +558,81 @@ impl Shockwave3dObjectDatumHandlers {
                                     };
                                 }
                                 _ => {}
+                            }
+                        }
+                    }
+                    return Ok(());
+                }
+            }
+
+            // ── #particle model-resource property sets ──
+            // colorRange/sizeRange/blendRange are range objects (.start/.end); lifeTime,
+            // texture, gravity, wind, drag are direct resource props. All persist into the
+            // ParticleSystemState (created lazily; gravity defaults to vector(0,0,0) per the
+            // Director dictionary, NOT the struct's fire-style default). Handled before the
+            // generic match so the named `texture` (shader) arm doesn't intercept it.
+            {
+                let ot = s3d_ref.object_type.as_str();
+                let is_range = ot.eq_ignore_ascii_case("colorRange")
+                    || ot.eq_ignore_ascii_case("sizeRange")
+                    || ot.eq_ignore_ascii_case("blendRange");
+                let is_res_prop = ot.eq_ignore_ascii_case("modelResource") && (
+                    prop_name.eq_ignore_ascii_case("lifetime")
+                    || prop_name.eq_ignore_ascii_case("texture")
+                    || prop_name.eq_ignore_ascii_case("gravity")
+                    || prop_name.eq_ignore_ascii_case("wind")
+                    || prop_name.eq_ignore_ascii_case("drag"));
+                if is_range || is_res_prop {
+                    if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                        if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
+                            let ps = w3d.runtime_state.particles
+                                .entry(s3d_ref.name.clone())
+                                .or_insert_with(|| {
+                                    let mut p = crate::player::cast_member::ParticleSystemState::default();
+                                    p.gravity = [0.0, 0.0, 0.0]; // #particle default gravity
+                                    p
+                                });
+                            if is_range {
+                                let is_start = prop_name.eq_ignore_ascii_case("start");
+                                match_ci!(ot, {
+                                    "colorRange" => {
+                                        if let Datum::ColorRef(crate::player::sprite::ColorRef::Rgb(r, g, b)) = value {
+                                            let c = [*r as f32 / 255.0, *g as f32 / 255.0, *b as f32 / 255.0];
+                                            if is_start { ps.color_start = c; } else { ps.color_end = c; }
+                                        }
+                                    },
+                                    "sizeRange" => {
+                                        let v = value.float_value().unwrap_or(0.0) as f32;
+                                        if is_start { ps.size_start = v; } else { ps.size_end = v; }
+                                    },
+                                    "blendRange" => {
+                                        // IFX particle blend is the per-particle ALPHA (0..1, default
+                                        // 0.1) — NOT a 0..100 percentage. Store the raw value; values
+                                        // >1 (the faucet's 2-3 / 6-7 at full flow) clamp to fully
+                                        // opaque at render time. See CIFXShaderParticle (vertex RGBA).
+                                        let v = value.float_value().unwrap_or(0.1) as f32;
+                                        if is_start { ps.blend_start = v; } else { ps.blend_end = v; }
+                                    },
+                                    _ => {}
+                                });
+                            } else {
+                                match_ci!(prop_name, {
+                                    // lifetime is in milliseconds (default 10000); store seconds.
+                                    "lifetime" => ps.lifetime = (value.float_value().unwrap_or(10000.0) as f32 / 1000.0).max(0.001),
+                                    "texture" => {
+                                        let tn = match value {
+                                            Datum::Shockwave3dObjectRef(r) if r.object_type == "texture" => r.name.clone(),
+                                            Datum::String(s) => s.clone(),
+                                            _ => String::new(),
+                                        };
+                                        ps.texture_name = tn.to_lowercase();
+                                    },
+                                    "gravity" => if let Datum::Vector(v) = value { ps.gravity = [v[0] as f32, v[1] as f32, v[2] as f32]; },
+                                    "wind" => if let Datum::Vector(v) = value { ps.wind = [v[0] as f32, v[1] as f32, v[2] as f32]; },
+                                    // drag is 0 (none) .. 100 (full); store 0..1.
+                                    "drag" => ps.drag = (value.float_value().unwrap_or(0.0) as f32 / 100.0).clamp(0.0, 1.0),
+                                    _ => {}
+                                });
                             }
                         }
                     }
@@ -1576,6 +1682,23 @@ impl Shockwave3dObjectDatumHandlers {
                     // Handle meshDeformTexLayer.textureCoordinateList = data
                     if s3d_ref.object_type == "emitter" {
                         use crate::player::cast_member::EmitterState;
+                        // emitter.region is assigned as a LIST of positions (Director's API,
+                        // e.g. the car demos' `emitter.region = [exhaust.worldPosition]` to make
+                        // the smoke follow the tailpipe); a bare vector is also accepted. Resolve
+                        // the first position here (needs immutable player access) BEFORE taking the
+                        // mutable member borrow. Without this the list silently failed to match
+                        // `Datum::Vector`, region stayed (0,0,0), and the white exhaust particles
+                        // piled up at the origin — right at the camera — whiting out the scene.
+                        let region_override: Option<[f64; 3]> = if prop_name.eq_ignore_ascii_case("region") {
+                            match value {
+                                Datum::Vector(v) => Some(*v),
+                                Datum::List(_, items, _) => items.front().and_then(|r| match player.get_datum(r) {
+                                    Datum::Vector(v) => Some(*v),
+                                    _ => None,
+                                }),
+                                _ => None,
+                            }
+                        } else { None };
                         if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                             if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
                                 let em = w3d.runtime_state.emitters
@@ -1586,7 +1709,7 @@ impl Shockwave3dObjectDatumHandlers {
                                     "mode" => em.mode = value.symbol_value().unwrap_or_else(|_| value.string_value().unwrap_or_default()),
                                     "numParticles" => em.num_particles = value.int_value().unwrap_or(100),
                                     "direction" => if let Datum::Vector(v) = value { em.direction = *v; },
-                                    "region" => if let Datum::Vector(v) = value { em.region = *v; },
+                                    "region" => if let Some(rv) = region_override { em.region = rv; em.has_region = true; },
                                     "distribution" => em.distribution = value.symbol_value().unwrap_or_else(|_| value.string_value().unwrap_or_default()),
                                     "angle" => em.angle = value.float_value().unwrap_or(30.0),
                                     "minSpeed" => em.min_speed = value.float_value().unwrap_or(1.0),
@@ -5051,26 +5174,17 @@ impl Shockwave3dObjectDatumHandlers {
                 })))
             },
             // Particle system resource properties — range objects with #start and #end
-            "colorRange" => {
-                let sk = player.alloc_datum(Datum::Symbol("start".to_string()));
-                let sv = player.alloc_datum(Datum::ColorRef(crate::player::sprite::ColorRef::Rgb(255, 255, 255)));
-                let ek = player.alloc_datum(Datum::Symbol("end".to_string()));
-                let ev = player.alloc_datum(Datum::ColorRef(crate::player::sprite::ColorRef::Rgb(255, 255, 255)));
-                Ok(player.alloc_datum(Datum::PropList(VecDeque::from(vec![(sk, sv), (ek, ev)]), false)))
-            },
-            "sizeRange" => {
-                let sk = player.alloc_datum(Datum::Symbol("start".to_string()));
-                let sv = player.alloc_datum(Datum::Float(1.0));
-                let ek = player.alloc_datum(Datum::Symbol("end".to_string()));
-                let ev = player.alloc_datum(Datum::Float(1.0));
-                Ok(player.alloc_datum(Datum::PropList(VecDeque::from(vec![(sk, sv), (ek, ev)]), false)))
-            },
-            "blendRange" => {
-                let sk = player.alloc_datum(Datum::Symbol("start".to_string()));
-                let sv = player.alloc_datum(Datum::Int(100));
-                let ek = player.alloc_datum(Datum::Symbol("end".to_string()));
-                let ev = player.alloc_datum(Datum::Int(100));
-                Ok(player.alloc_datum(Datum::PropList(VecDeque::from(vec![(sk, sv), (ek, ev)]), false)))
+            // #particle range objects — return a ref so `resource.colorRange.start = X`
+            // routes to set_prop (object_type colorRange/sizeRange/blendRange). The set
+            // persists into the ParticleSystemState; a thrown-away PropList wouldn't.
+            "colorRange" | "sizeRange" | "blendRange" => {
+                use crate::director::lingo::datum::Shockwave3dObjectRef;
+                Ok(player.alloc_datum(Datum::Shockwave3dObjectRef(Shockwave3dObjectRef {
+                    cast_lib: member_ref.cast_lib,
+                    cast_member: member_ref.cast_member,
+                    object_type: prop.to_string(), // "colorRange" | "sizeRange" | "blendRange"
+                    name: resource_name.to_string(),
+                })))
             },
             "lifetime" => Ok(player.alloc_datum(Datum::Int(1000))),
             "gravity" => Ok(player.alloc_datum(Datum::Vector([0.0, -9.8, 0.0]))),

--- a/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/shockwave3d_object.rs
@@ -1563,18 +1563,32 @@ impl Shockwave3dObjectDatumHandlers {
                                 }
                             }
                         },
-                        "width" | "length" | "height" | "radius" => {
+                        "width" | "length" | "height" | "radius"
+                        | "topRadius" | "bottomRadius" | "resolution"
+                        | "startAngle" | "endAngle" | "topCap" | "bottomCap" => {
                             use crate::director::chunks::w3d::types::ClodDecodedMesh;
                             let val = value.to_float().unwrap_or(1.0) as f32;
                             if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
                                 if let Some(w3d) = member.member_type.as_shockwave3d_mut() {
                                     if let Some(scene) = w3d.scene_mut() {
                                         if let Some(res) = scene.model_resources.get_mut(&s3d_ref.name) {
-                                            match prop_name {
+                                            // The outer match_ci! matched case-insensitively; normalise
+                                            // for the inner exact match.
+                                            match prop_name.to_ascii_lowercase().as_str() {
                                                 "width" => res.primitive_width = val,
                                                 "length" => res.primitive_length = val,
                                                 "height" => res.primitive_height = val,
-                                                "radius" => res.primitive_radius = val,
+                                                // #cylinder taper: bottomRadius -> radius, topRadius -> top.
+                                                // A bare `radius` (e.g. sphere) sets both so a cylinder
+                                                // stays uniform unless top/bottom are set explicitly.
+                                                "radius" => { res.primitive_radius = val; res.primitive_top_radius = val; },
+                                                "topradius" => res.primitive_top_radius = val,
+                                                "bottomradius" => res.primitive_radius = val,
+                                                "resolution" => res.primitive_resolution = val.round().max(3.0) as u32,
+                                                "startangle" => res.primitive_start_angle = val,
+                                                "endangle" => res.primitive_end_angle = val,
+                                                "topcap" => res.primitive_top_cap = val != 0.0,
+                                                "bottomcap" => res.primitive_bottom_cap = val != 0.0,
                                                 _ => {}
                                             }
                                         }
@@ -1621,39 +1635,62 @@ impl Shockwave3dObjectDatumHandlers {
                                                     }]
                                                 },
                                                 "sphere" => {
-                                                    // Generate a UV sphere at the given radius.
-                                                    // Poles along Y so that after the typical
-                                                    // rotation(90,0,0) the poles end up vertical.
+                                                    // Exact match to Director's #sphere, verified by dumping pacModel
+                                                    // via the meshDeform modifier:
+                                                    //   phi (polar, 0=+Y pole .. PI=-Y pole) over `stacks` steps,
+                                                    //   L = startAngle + sweep*(j/slices) swept around the Y axis
+                                                    //   from +Z toward +X, over `slices` steps.
+                                                    //   x = r·sin(phi)·sin(L),  y = r·cos(phi),  z = r·sin(phi)·cos(L)
+                                                    //   u = j/slices  (fraction along the sweep)
+                                                    //   v = 1 - phi/PI  (1 at the +Y pole, 0 at -Y)
+                                                    // startAngle 25 / endAngle 335 leaves the 50° Pacman mouth open;
+                                                    // startAngle 180 gives the ghost-dome hemisphere.
+                                                    use std::f32::consts::PI;
                                                     let r = res.primitive_radius;
-                                                    let stacks = 12u32;
-                                                    let slices = 16u32;
-                                                    let uv_scale = 1.0f32;
+                                                    let start = res.primitive_start_angle.to_radians();
+                                                    let mut sweep = (res.primitive_end_angle - res.primitive_start_angle).to_radians();
+                                                    if sweep <= 0.0 { sweep = 2.0 * PI; }
+                                                    let stacks = 20u32;
+                                                    let slices = ((sweep / (2.0 * PI)) * 28.0).round().max(8.0) as u32;
+                                                    let stride = slices + 1;
                                                     let mut pos = Vec::new();
                                                     let mut nrm = Vec::new();
                                                     let mut uvs = Vec::new();
                                                     let mut faces = Vec::new();
                                                     for i in 0..=stacks {
-                                                        let phi = std::f32::consts::PI * i as f32 / stacks as f32;
-                                                        let sp = phi.sin();
-                                                        let cp = phi.cos();
+                                                        let phi = PI * i as f32 / stacks as f32; // 0 = +Y pole .. PI = -Y pole
+                                                        let (sp, cp) = (phi.sin(), phi.cos());
                                                         for j in 0..=slices {
-                                                            let theta = 2.0 * std::f32::consts::PI * j as f32 / slices as f32;
-                                                            let st = theta.sin();
-                                                            let ct = theta.cos();
-                                                            let nx = cp;
-                                                            let ny = sp * ct;
-                                                            let nz = sp * st;
-                                                            pos.push([r*nx, r*ny, r*nz]);
+                                                            let l = start + sweep * (j as f32 / slices as f32);
+                                                            let (sl, cl) = (l.sin(), l.cos());
+                                                            // Verified against BOTH the Pacman and ghost-dome
+                                                            // meshDeform dumps: x = -sin(theta), z = cos(theta).
+                                                            // (For a sphere whose sweep is centred on theta=0, like
+                                                            // Pacman's mouth or a full sphere, +sin and -sin are
+                                                            // identical; the ghost dome's startAngle 180 hemisphere
+                                                            // exposes the real sign — it must sit on +X so Rz(90)
+                                                            // lifts it into a head.)
+                                                            let nx = -sp * sl; let ny = cp; let nz = sp * cl;
+                                                            pos.push([r * nx, r * ny, r * nz]);
                                                             nrm.push([nx, ny, nz]);
-                                                            uvs.push([(j as f32 / slices as f32 - 0.05) * uv_scale, i as f32 / stacks as f32 * uv_scale]);
+                                                            // Director-dump texcoords: u = 1 - j/slices, v = 1 - i/stacks.
+                                                            // The shared 3D vertex shader applies the CLOD remap
+                                                            // (u+0.5, 0.5-v) to the main texcoord, so emit PRE-CENTERED
+                                                            // here; after the remap they reconstruct the dumped (u, v).
+                                                            let u = 1.0 - j as f32 / slices as f32;
+                                                            let v = 1.0 - i as f32 / stacks as f32;
+                                                            uvs.push([u - 0.5, 0.5 - v]);
                                                         }
                                                     }
                                                     for i in 0..stacks {
                                                         for j in 0..slices {
-                                                            let a = i * (slices + 1) + j;
-                                                            let b = a + slices + 1;
-                                                            if i != 0 { faces.push([a, b, a + 1]); }
-                                                            if i != stacks - 1 { faces.push([a + 1, b, b + 1]); }
+                                                            let a = i * stride + j;
+                                                            let b = a + stride;
+                                                            // With x=-sin·sin, z=cos·sin the outward winding is
+                                                            // [a, a+1, b]. Partial sweeps simply omit the gap faces,
+                                                            // leaving the mouth/section open.
+                                                            faces.push([a, a + 1, b]);
+                                                            faces.push([a + 1, b + 1, b]);
                                                         }
                                                     }
                                                     vec![ClodDecodedMesh {
@@ -1663,6 +1700,109 @@ impl Shockwave3dObjectDatumHandlers {
                                                         diffuse_colors: vec![], specular_colors: vec![],
                                                         bone_indices: vec![], bone_weights: vec![],
                                                     }]
+                                                },
+                                                "cylinder" => {
+                                                    // Director #cylinder: axis along Y, centered. `resolution` is
+                                                    // the radial segment count (default 20; the Pacman pipes use 6
+                                                    // for hexagonal tubes). topRadius/bottomRadius give the taper
+                                                    // (topRadius 0 => cone). topCap/bottomCap default FALSE, so the
+                                                    // cylinder is an open side wall (no end caps) unless a movie
+                                                    // seals them — which Pacman doesn't. Winding matches the sphere
+                                                    // (ring 0 = top -> ring 1 = bottom) so faces front outward.
+                                                    use std::f32::consts::PI;
+                                                    let bottom_r = res.primitive_radius;
+                                                    let top_r = res.primitive_top_radius;
+                                                    let hy = res.primitive_height / 2.0;
+                                                    let segs = if res.primitive_resolution >= 3 { res.primitive_resolution } else { 20 };
+                                                    let stride = segs + 1;
+                                                    // Director's #cylinder is THREE mesh groups: side wall, top cap,
+                                                    // bottom cap — so shaderList[1]/[2]/[3] can each differ (the Coke
+                                                    // can is the cokeT label on the side and silver canTop on the
+                                                    // caps). Emit each as a separate same-named mesh; the renderer
+                                                    // binds a per-mesh-index shader from node_shaders (set by Lingo
+                                                    // shaderList[i]=ref). Cap groups are gated by the cap flags (the
+                                                    // ghost body sets both to 0 → side only).
+                                                    let mut out: Vec<ClodDecodedMesh> = Vec::new();
+                                                    // group 0 → shaderList[1]: side wall
+                                                    {
+                                                        let mut pos = Vec::new();
+                                                        let mut nrm = Vec::new();
+                                                        let mut uvs = Vec::new();
+                                                        let mut faces = Vec::new();
+                                                        for ring in 0..=1u32 {
+                                                            let (y, r) = if ring == 0 { (hy, top_r) } else { (-hy, bottom_r) };
+                                                            for i in 0..=segs {
+                                                                let u = i as f32 / segs as f32;
+                                                                let theta = u * 2.0 * PI;
+                                                                let (c, s) = (theta.cos(), theta.sin());
+                                                                pos.push([c * r, y, s * r]);
+                                                                nrm.push([c, 0.0, s]);
+                                                                // pre-centre to cancel the shader CLOD remap; final UV
+                                                                // is (u, ring): v=0 at the top ring, v=1 at the bottom
+                                                                // edge (where GTEX bakes its black sawtooth).
+                                                                uvs.push([u - 0.5, 0.5 - ring as f32]);
+                                                            }
+                                                        }
+                                                        for i in 0..segs {
+                                                            let a = i;
+                                                            let b = a + stride;
+                                                            faces.push([a, a + 1, b]);
+                                                            faces.push([a + 1, b + 1, b]);
+                                                        }
+                                                        out.push(ClodDecodedMesh {
+                                                            name: s3d_ref.name.clone(), positions: pos, normals: nrm,
+                                                            tex_coords: vec![uvs], faces,
+                                                            diffuse_colors: vec![], specular_colors: vec![],
+                                                            bone_indices: vec![], bone_weights: vec![],
+                                                        });
+                                                    }
+                                                    // group 1 → shaderList[2]: top cap (+Y), fan, disc UV pre-centred
+                                                    if res.primitive_top_cap {
+                                                        let mut pos: Vec<[f32; 3]> = vec![[0.0, hy, 0.0]];
+                                                        let mut nrm: Vec<[f32; 3]> = vec![[0.0, 1.0, 0.0]];
+                                                        let mut uvs: Vec<[f32; 2]> = vec![[0.0, 0.0]];
+                                                        let mut faces = Vec::new();
+                                                        for i in 0..=segs {
+                                                            let theta = i as f32 / segs as f32 * 2.0 * PI;
+                                                            let (c, s) = (theta.cos(), theta.sin());
+                                                            pos.push([c * top_r, hy, s * top_r]);
+                                                            nrm.push([0.0, 1.0, 0.0]);
+                                                            uvs.push([c * 0.5, -s * 0.5]);
+                                                        }
+                                                        for i in 0..segs {
+                                                            faces.push([0u32, 1 + i + 1, 1 + i]);
+                                                        }
+                                                        out.push(ClodDecodedMesh {
+                                                            name: s3d_ref.name.clone(), positions: pos, normals: nrm,
+                                                            tex_coords: vec![uvs], faces,
+                                                            diffuse_colors: vec![], specular_colors: vec![],
+                                                            bone_indices: vec![], bone_weights: vec![],
+                                                        });
+                                                    }
+                                                    // group 2 → shaderList[3]: bottom cap (-Y)
+                                                    if res.primitive_bottom_cap {
+                                                        let mut pos: Vec<[f32; 3]> = vec![[0.0, -hy, 0.0]];
+                                                        let mut nrm: Vec<[f32; 3]> = vec![[0.0, -1.0, 0.0]];
+                                                        let mut uvs: Vec<[f32; 2]> = vec![[0.0, 0.0]];
+                                                        let mut faces = Vec::new();
+                                                        for i in 0..=segs {
+                                                            let theta = i as f32 / segs as f32 * 2.0 * PI;
+                                                            let (c, s) = (theta.cos(), theta.sin());
+                                                            pos.push([c * bottom_r, -hy, s * bottom_r]);
+                                                            nrm.push([0.0, -1.0, 0.0]);
+                                                            uvs.push([c * 0.5, -s * 0.5]);
+                                                        }
+                                                        for i in 0..segs {
+                                                            faces.push([0u32, 1 + i, 1 + i + 1]);
+                                                        }
+                                                        out.push(ClodDecodedMesh {
+                                                            name: s3d_ref.name.clone(), positions: pos, normals: nrm,
+                                                            tex_coords: vec![uvs], faces,
+                                                            diffuse_colors: vec![], specular_colors: vec![],
+                                                            bone_indices: vec![], bone_weights: vec![],
+                                                        });
+                                                    }
+                                                    out
                                                 },
                                                 _ => vec![],
                                             };

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -968,6 +968,7 @@ impl MovieHandlers {
         // I moved the renderer's dt advance onto runtime_state.
         crate::player::events::dispatch_w3d_timer_events().await;
         crate::player::events::tick_w3d_animations().await;
+        crate::player::events::tick_w3d_particles().await;
         crate::player::events::dispatch_physx_collision_callbacks().await;
 
         reserve_player_mut(|player| {

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -3387,6 +3387,11 @@ async fn run_movie_init_sequence() {
     // while the body animates.
     crate::player::events::tick_w3d_animations().await;
 
+    // Step #particle systems (faucet water, fire, etc.) each frame, independent of
+    // animation_playing — emit/age/move particles using the emitter params + model
+    // position set by Lingo (see tick_w3d_particles).
+    crate::player::events::tick_w3d_particles().await;
+
     // After prepareFrame behaviors have run (which is where simulate()
     // typically lives), drain any pending PhysX collision reports and
     // dispatch the script's registered #collisionCallback. AGEIA's xtra

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -3233,7 +3233,9 @@ impl WebGL2Renderer {
                 texture
             }
             TextureSource::Shockwave3dScene { width, height, member_key, scene, runtime_state, active_camera, extra_cameras } => {
-                // Render primary camera
+                // Render primary camera. Camera backdrops (Director `addBackdrop`,
+                // e.g. the estate sky) are drawn inside render_scene_with_state_ex,
+                // after its clear and before the models — see draw_backdrops_inline.
                 self.scene3d.active_camera = active_camera;
                 if let Err(e) = self.scene3d.render_scene_with_state(
                     &self.context, member_key, &scene, width, height, Some(&runtime_state)
@@ -3275,8 +3277,8 @@ impl WebGL2Renderer {
                     }
                 }
 
-                // TODO: Backdrops should render BEFORE 3D scene (need separate clear logic)
-                // For now, only overlays are rendered (on top of 3D scene)
+                // Backdrops were already drawn before the scene (see render_backdrops_to_fbo
+                // above). Overlays render on top of everything.
 
                 // Render overlays on top of everything
                 for (_, overlays) in &runtime_state.camera_overlays {

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -382,6 +382,9 @@ in vec2 v_texcoord2;
 in float v_view_dist;
 in vec4 v_vertex_color;
 
+// Must match the vertex shader's precision (highp, the VS default) — a precision
+// mismatch on a uniform shared across stages is a GLSL ES link error.
+uniform highp mat4 u_view;  // for eye-space reflection (sphere map)
 uniform vec4 u_diffuse_color;
 uniform int u_has_vertex_color;
 uniform vec4 u_ambient_color;
@@ -446,6 +449,54 @@ vec3 blend_layer(vec3 base, vec4 layer_sample, int mode, float intensity) {
         return mix(base, layer_sample.rgb, layer_sample.a * intensity);
     }
     return base;
+}
+
+// Classic OpenGL GL_SPHERE_MAP UV for a reflection / environment map, computed
+// in EYE space (like Director's #reflection mode). worldN = world-space surface
+// normal, worldPos = world-space fragment position. Working in eye space makes
+// every camera-facing surface reflect consistently — a world-space version made
+// the sampled sky region depend on the surface's world orientation, so only
+// windows facing one direction appeared to reflect the backdrop.
+vec2 sphere_map_uv(vec3 worldN, vec3 worldPos) {
+    vec3 n_eye = normalize(mat3(u_view) * worldN);
+    vec3 pos_eye = (u_view * vec4(worldPos, 1.0)).xyz;
+    vec3 incident = normalize(pos_eye);          // eye(origin) → fragment
+    vec3 r = reflect(incident, n_eye);
+    float m = 2.0 * sqrt(r.x * r.x + r.y * r.y + (r.z + 1.0) * (r.z + 1.0));
+    m = max(m, 1e-4);
+    // Flip the V (vertical) coord: the sky texture is stored top-down, so the raw
+    // sphere-map t would render the reflection upside down.
+    return vec2(r.x / m + 0.5, 0.5 - r.y / m);
+}
+
+// Blend a colour toward the fog colour by distance. fog_mode: 0=linear, 1=exp,
+// 2=exp2. Applied to BOTH the textured and non-textured paths so all geometry
+// fogs consistently (the estate movie enables fog; previously the textured path
+// returned before fogging, so the brick house never faded into the fog).
+vec3 apply_fog(vec3 color) {
+    if (u_fog_enabled <= 0) {
+        return color;
+    }
+    // Use the euclidean world distance from the camera, NOT v_view_dist (-view_pos.z).
+    // The eye-space Z sign depends on IFX's view-matrix handedness; if it came out
+    // negative, fog_factor clamped to 1 and fog never showed. length() is always
+    // positive and matches Director's camera-relative fog distance.
+    float dist = length(u_camera_pos - v_position);
+    float fog_factor;
+    if (u_fog_mode == 0) {
+        // #linear: interpolate between near and far (GL_LINEAR).
+        fog_factor = (u_fog_far - dist) / (u_fog_far - u_fog_near);
+    } else if (u_fog_mode == 1) {
+        // #exponential (Director default): GL_EXP, density = ln(100)/far, near ignored.
+        // Matches IFX CIFXRenderDevice::CalcFogDensity (EXPONENTIAL_FOG_CONSTANT/fFar).
+        float density = 4.6051701859880914 / u_fog_far;
+        fog_factor = exp(-density * dist);
+    } else {
+        // #exponential2: GL_EXP2, density = sqrt(ln(100))/far, near ignored.
+        float density = 2.1459660262893472 / u_fog_far;
+        fog_factor = exp(-(density * dist) * (density * dist));
+    }
+    return mix(u_fog_color, color, clamp(fog_factor, 0.0, 1.0));
 }
 
 void main() {
@@ -516,7 +567,12 @@ void main() {
         }
 
         // Apply third texture layer if present
-        if (u_layer2_blend > 0) {
+        if (u_layer2_blend == 5) {
+            // Reflection / environment map (#reflection): sphere-mapped sky blended
+            // over the textured surface at the #constant factor (u_layer2_intensity).
+            vec3 refl = texture(u_layer2_tex, sphere_map_uv(N, v_position)).rgb;
+            final_color = mix(final_color, refl, u_layer2_intensity);
+        } else if (u_layer2_blend > 0) {
             vec2 l2_uv = (u_has_texcoord2 > 0) ? v_texcoord2 : v_texcoord;
             vec4 l2_sample = texture(u_layer2_tex, l2_uv);
             float l2_intensity = u_layer2_intensity;
@@ -529,7 +585,7 @@ void main() {
             }
         }
 
-        frag_color = vec4(final_color, u_opacity * tex_sample.a);
+        frag_color = vec4(apply_fog(final_color), u_opacity * tex_sample.a);
         return;
     }
 
@@ -591,20 +647,16 @@ void main() {
         }
     }
 
-    // Apply fog
-    if (u_fog_enabled > 0) {
-        float fog_factor;
-        if (u_fog_mode == 0) {
-            fog_factor = clamp((u_fog_far - v_view_dist) / (u_fog_far - u_fog_near), 0.0, 1.0);
-        } else if (u_fog_mode == 1) {
-            float density = 2.0 / (u_fog_far - u_fog_near);
-            fog_factor = exp(-density * v_view_dist);
-        } else {
-            float density = 2.0 / (u_fog_far - u_fog_near);
-            fog_factor = exp(-density * density * v_view_dist * v_view_dist);
-        }
-        result = mix(u_fog_color, result, clamp(fog_factor, 0.0, 1.0));
+    // Reflection / environment map on an untextured surface — e.g. tinted glass:
+    // material diffuse colour with a sphere-mapped sky reflection mixed in at the
+    // #constant blend factor (reflectionMap helper, u_layer2_blend == 5).
+    if (u_layer2_blend == 5) {
+        vec3 refl = texture(u_layer2_tex, sphere_map_uv(N, v_position)).rgb;
+        result = mix(result, refl, u_layer2_intensity);
     }
+
+    // Apply fog (shared with the textured path via apply_fog).
+    result = apply_fog(result);
 
     float alpha = u_opacity * tex_sample.a * u_diffuse_color.a;
     frag_color = vec4(result, alpha);
@@ -1392,6 +1444,9 @@ void main() {
         self.ensure_fbo(context, width, height)?;
         self.ensure_member_data(context, member_key, scene)?;
         self.ensure_checker_texture(&context.gl());
+        // Backdrops are drawn with the overlay quad later in this pass; ensure it
+        // exists now while we still have &mut self (before the shader borrow).
+        self.ensure_overlay_quad(&context.gl());
 
         // Sync lightmap UVs: check scene CLOD mesh tex_coords[1] and upload to GPU if new
         if let Some(gpu_data) = self.member_data.get_mut(&member_key) {
@@ -1529,6 +1584,50 @@ void main() {
         // Skinning defaults to off (enabled when bone data is present)
         gl.uniform1i(shader.u_has_texcoord2.as_ref(), 0);
         gl.uniform1i(shader.u_texcoord2_direct.as_ref(), 0);
+
+        // Draw camera backdrops (Director `addBackdrop`) BEHIND the scene: after the
+        // colour clear, before any models, with depth test off so all geometry
+        // occludes them. Only on the clearing (primary) pass — extra-camera passes
+        // (clear_fbo=false) must not redraw them. The FBO is already bound, cleared,
+        // and feedback-safe here, which avoids the stale/uninitialised-white that a
+        // separate pre-pass produced. After drawing, the 3D camera matrices and GL
+        // state are restored for the model loop.
+        if clear_fbo {
+            if let Some(rs) = runtime_state {
+                let cam_key = self.active_camera.as_deref()
+                    .unwrap_or("defaultview").to_ascii_lowercase();
+                let backdrops = rs.camera_backdrops.get(&cam_key)
+                    .filter(|b| !b.is_empty())
+                    .or_else(|| {
+                        // The sprite only has an active_camera when the movie called
+                        // addCamera. When it didn't (it just used member.camera[1],
+                        // like the estate explore), active_camera is None and the
+                        // renderer defaults to DefaultView — fall back to whichever
+                        // single camera owns backdrops. With an explicit camera, match
+                        // strictly so a multi-camera movie doesn't cross backdrops.
+                        if self.active_camera.is_none() {
+                            rs.camera_backdrops.values().find(|b| !b.is_empty())
+                        } else {
+                            None
+                        }
+                    });
+                if let Some(backdrops) = backdrops {
+                    self.draw_backdrops_inline(gl, shader, &member_key, backdrops, width, height);
+                    // Restore camera matrices + render state for the model loop.
+                    gl.uniform_matrix4fv_with_f32_array(shader.u_view.as_ref(), false, &view_matrix);
+                    gl.uniform_matrix4fv_with_f32_array(shader.u_projection.as_ref(), false, &projection_matrix);
+                    // Re-enable fog for the models (the backdrop disabled it; near/far/
+                    // color/mode were set before the backdrop and are untouched).
+                    gl.uniform1i(shader.u_fog_enabled.as_ref(), if rs.fog_enabled { 1 } else { 0 });
+                    gl.enable(WebGl2RenderingContext::DEPTH_TEST);
+                    gl.depth_mask(true);
+                    gl.enable(WebGl2RenderingContext::CULL_FACE);
+                    gl.cull_face(WebGl2RenderingContext::FRONT);
+                    gl.front_face(WebGl2RenderingContext::CCW);
+                    gl.disable(WebGl2RenderingContext::BLEND);
+                }
+            }
+        }
 
         // Traverse scene graph and draw model nodes
         if self.member_data.contains_key(&member_key) {
@@ -1921,6 +2020,146 @@ void main() {
 
     // Old render_overlays_static removed — functionality merged into render_overlays_to_fbo
 
+    /// Render camera backdrops into the FBO. Backdrops are positioned 2D images
+    /// drawn BEHIND the 3D scene (Director 11.5 `addBackdrop`): each is a textured
+    /// quad placed by loc/scale/regPoint/rotation, with loc measured from the
+    /// sprite's upper-left corner. This is the backdrop counterpart of
+    /// render_overlays_to_fbo (which draws on top). It must run before the scene's
+    /// geometry: it clears the FBO to the member background colour, fills it with
+    /// the backdrop images, and leaves the colour buffer intact so the subsequent
+    /// `render_scene_with_state_ex(clear_fbo=false)` only clears depth and composites
+    /// the models on top.
+    /// Draw camera backdrops into the CURRENTLY-BOUND, ALREADY-CLEARED FBO, in the
+    /// middle of render_scene_with_state_ex (after the clear, before the models).
+    /// Each backdrop is a positioned 2D quad (loc/scale/regPoint/rotation, loc from
+    /// the sprite's upper-left per the Director dictionary), drawn with depth test
+    /// off so all geometry occludes it. The sky is shown unlit/full-bright: emissive
+    /// is forced to white so the textured-path lighting clamps to 1 and the texture
+    /// shows as-is, which also means u_num_lights is left untouched (the model loop
+    /// keeps its lighting). The caller restores u_view/u_projection + GL state after.
+    fn draw_backdrops_inline(
+        &self,
+        gl: &WebGl2RenderingContext,
+        shader: &Shader3d,
+        member_key: &(i32, i32),
+        backdrops: &[crate::player::cast_member::CameraOverlay],
+        width: u32,
+        height: u32,
+    ) {
+        let gpu_data = match self.member_data.get(member_key) { Some(d) => d, None => return };
+
+        // Bind the default VAO before touching vertex attrib pointers. Otherwise the
+        // vertexAttribPointer calls below would write onto whatever VAO is currently
+        // bound — which is the 2D compositor's sprite-quad VAO (left bound from the
+        // previous sprite). The 3D scene still renders (models bind their own VAOs),
+        // but the compositor would then draw every sprite, including this 3D one, with
+        // a corrupted quad → a degenerate / full-screen white quad ("all white").
+        gl.bind_vertex_array(None);
+
+        // 2D orthographic state — depth off (behind everything), no cull, alpha blend.
+        gl.disable(WebGl2RenderingContext::DEPTH_TEST);
+        // CRITICAL: also disable depth WRITES. On ANGLE/D3D (Windows) disabling the
+        // depth test alone does not reliably stop depth writes, so the full-screen
+        // backdrop quad would stamp its depth (~0.5) over the whole buffer and then
+        // every house surface farther than that fails the LEQUAL test and vanishes —
+        // leaving only the sky ("fades to white"). The skybox model path does the
+        // same. The caller restores depth_mask(true) before the model loop.
+        gl.depth_mask(false);
+        gl.disable(WebGl2RenderingContext::CULL_FACE);
+        gl.enable(WebGl2RenderingContext::BLEND);
+        gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+
+        let w = width as f32;
+        let h = height as f32;
+        // Ortho: (0,0)=top-left in sprite space. FBO is Y-flipped when composited, so
+        // use positive Y here (matches render_overlays_to_fbo).
+        let ortho: [f32; 16] = [
+            2.0/w,  0.0,    0.0, 0.0,
+            0.0,    2.0/h,  0.0, 0.0,
+            0.0,    0.0,   -1.0, 0.0,
+           -1.0,   -1.0,    0.0, 1.0,
+        ];
+        let identity: [f32; 16] = [1.0,0.0,0.0,0.0, 0.0,1.0,0.0,0.0, 0.0,0.0,1.0,0.0, 0.0,0.0,0.0,1.0];
+        gl.uniform_matrix4fv_with_f32_array(shader.u_projection.as_ref(), false, &ortho);
+        gl.uniform_matrix4fv_with_f32_array(shader.u_view.as_ref(), false, &identity);
+        // Unlit full-bright: emissive=1 → lighting clamps to 1 → final = texture.
+        gl.uniform4f(shader.u_emissive_color.as_ref(), 1.0, 1.0, 1.0, 1.0);
+        gl.uniform4f(shader.u_diffuse_color.as_ref(), 1.0, 1.0, 1.0, 1.0);
+        gl.uniform4f(shader.u_ambient_color.as_ref(), 0.0, 0.0, 0.0, 1.0);
+        gl.uniform1i(shader.u_has_lightmap.as_ref(), 0);
+        gl.uniform1i(shader.u_layer2_blend.as_ref(), 0);
+        gl.uniform1i(shader.u_has_specular_map.as_ref(), 0);
+        gl.uniform1i(shader.u_shader_mode.as_ref(), 0);
+        gl.uniform1i(shader.u_has_vertex_color.as_ref(), 0);
+        gl.uniform1i(shader.u_has_texcoord2.as_ref(), 0);
+        // The 2D backdrop is the scene background — never fogged (the caller
+        // re-enables fog for the models afterward).
+        gl.uniform1i(shader.u_fog_enabled.as_ref(), 0);
+        // u_skinning_enabled = -1 → vertex shader skips CLOD UV remap for the quad.
+        gl.uniform1i(shader.u_skinning_enabled.as_ref(), -1);
+        gl.uniform1i(shader.u_uv_proj_mode.as_ref(), 0);
+        gl.uniform_matrix4fv_with_f32_array(shader.u_tex_transform.as_ref(), false, &identity);
+        gl.uniform_matrix4fv_with_f32_array(shader.u_wrap_transform.as_ref(), false, &identity);
+
+        // Bind quad VBOs once
+        gl.bind_buffer(WebGl2RenderingContext::ARRAY_BUFFER, self.overlay_quad_vbo.as_ref());
+        gl.enable_vertex_attrib_array(0);
+        gl.vertex_attrib_pointer_with_i32(0, 3, WebGl2RenderingContext::FLOAT, false, 24, 0);
+        gl.enable_vertex_attrib_array(1);
+        gl.vertex_attrib_pointer_with_i32(1, 3, WebGl2RenderingContext::FLOAT, false, 24, 12);
+        gl.bind_buffer(WebGl2RenderingContext::ARRAY_BUFFER, self.overlay_quad_uv.as_ref());
+        gl.enable_vertex_attrib_array(2);
+        gl.vertex_attrib_pointer_with_i32(2, 2, WebGl2RenderingContext::FLOAT, false, 0, 0);
+
+        for backdrop in backdrops {
+            if backdrop.source_texture.is_empty() || backdrop.blend <= 0.0 { continue; }
+            let tex = match gpu_data.textures.get(&backdrop.source_texture_lower) {
+                Some(t) => t,
+                None => continue,
+            };
+            let (tex_w, tex_h) = gpu_data.texture_sizes
+                .get(&backdrop.source_texture_lower)
+                .map(|&(w, h)| (w as f32, h as f32))
+                .unwrap_or((64.0, 64.0));
+
+            gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+            gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(tex));
+            gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_S, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+            gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_T, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+            gl.uniform1i(shader.u_diffuse_tex.as_ref(), 0);
+            gl.uniform1i(shader.u_has_texture.as_ref(), 1);
+            gl.uniform1f(shader.u_opacity.as_ref(), (backdrop.blend / 100.0) as f32);
+
+            let x = backdrop.loc[0] as f32;
+            let y = backdrop.loc[1] as f32;
+            let sx = (backdrop.scale * backdrop.scale_x) as f32;
+            let sy = (backdrop.scale * backdrop.scale_y) as f32;
+            let rx = backdrop.reg_point[0] as f32;
+            let ry = backdrop.reg_point[1] as f32;
+            let rot_rad = (backdrop.rotation as f32).to_radians();
+            let cos_r = rot_rad.cos();
+            let sin_r = rot_rad.sin();
+
+            let sw = sx * tex_w;
+            let sh = sy * tex_h;
+            let model: [f32; 16] = [
+                cos_r * sw, sin_r * sw, 0.0, 0.0,
+               -sin_r * sh, cos_r * sh, 0.0, 0.0,
+                0.0,        0.0,        1.0, 0.0,
+                x - rx * sx * cos_r + ry * sy * sin_r,
+                y - rx * sx * sin_r - ry * sy * cos_r,
+                0.0, 1.0,
+            ];
+            gl.uniform_matrix4fv_with_f32_array(shader.u_model.as_ref(), false, &model);
+            gl.draw_arrays(WebGl2RenderingContext::TRIANGLES, 0, 6);
+        }
+
+        gl.disable_vertex_attrib_array(0);
+        gl.disable_vertex_attrib_array(1);
+        gl.disable_vertex_attrib_array(2);
+        gl.bind_buffer(WebGl2RenderingContext::ARRAY_BUFFER, None);
+    }
+
     /// Fallback: draw all meshes with identity transform when no scene graph
     fn draw_all_meshes_fallback(
         &self,
@@ -2104,6 +2343,8 @@ void main() {
                     if !bound {
                         self.bind_material(gl, shader, scene, model_node, member_key, runtime_state, force_blend);
                     }
+                    // Reflection map last so the per-mesh candidate search can't clobber it.
+                    self.apply_reflection_map(gl, shader, scene, model_node, member_key, runtime_state);
 
                     if mesh_buf.has_bones && has_skeleton_data {
                         gl.uniform1i(shader.u_skinning_enabled.as_ref(), 1);
@@ -2915,6 +3156,15 @@ void main() {
                 None => continue,
             };
 
+            // tex_mode 4 = reflection / environment map (Director `reflectionMap`).
+            // Sampled with sphere-mapped UVs (not the mesh's authored UVs), so it
+            // must be kept out of the diffuse/extra-layer slots here. It is bound
+            // separately as a final step via apply_reflection_map() so the per-mesh
+            // candidate search can't clobber its u_layer2_blend signal.
+            if layer.tex_mode == 4 {
+                continue;
+            }
+
             // tex_mode 6 = specular map
             if layer.tex_mode == 6 {
                 if result.specular.is_none() {
@@ -3051,6 +3301,102 @@ void main() {
         }
 
         tex_bound
+    }
+
+    /// Resolve a model's primary shader name the same way the Lingo `model.shader`
+    /// getter (get_model_prop) does, so reflection binding targets the exact shader
+    /// the movie assigned `reflectionMap` to. Precedence: runtime override →
+    /// model-resource first-mesh binding (prefer non-DefaultShader) → node
+    /// shader_name → model-index→shader-index.
+    fn resolve_model_primary_shader(
+        scene: &W3dScene,
+        model_node: &W3dNode,
+        runtime_state: Option<&crate::player::cast_member::Shockwave3dRuntimeState>,
+    ) -> Option<String> {
+        // 1) Runtime override (model.shader = s1 / shaderList[1] = ref)
+        if let Some(name) = runtime_state
+            .and_then(|rs| Self::node_shader_override(rs, &model_node.name, None))
+        {
+            return Some(name.clone());
+        }
+        // 2) Model-resource first-mesh shader binding (prefer non-DefaultShader)
+        let resource = if !model_node.model_resource_name.is_empty() {
+            &model_node.model_resource_name
+        } else {
+            &model_node.resource_name
+        };
+        if let Some(res) = scene.model_resources.get(resource) {
+            let mut fallback = String::new();
+            for binding in &res.shader_bindings {
+                if !binding.mesh_bindings.is_empty() && !binding.mesh_bindings[0].is_empty() {
+                    let name = &binding.mesh_bindings[0];
+                    if !name.eq_ignore_ascii_case("DefaultShader") {
+                        return Some(name.clone());
+                    } else if fallback.is_empty() {
+                        fallback = name.clone();
+                    }
+                }
+            }
+            if !fallback.is_empty() { return Some(fallback); }
+        }
+        // 3) Node's shader_name
+        if !model_node.shader_name.is_empty() {
+            return Some(model_node.shader_name.clone());
+        }
+        // 4) Model index → shader index
+        let mi = scene.nodes.iter()
+            .filter(|n| n.node_type == W3dNodeType::Model)
+            .position(|n| n.name == model_node.name);
+        if let Some(mi) = mi {
+            if mi < scene.shaders.len() {
+                return Some(scene.shaders[mi].name.clone());
+            }
+        }
+        None
+    }
+
+    /// Bind the model's reflection / environment map as the FINAL material step.
+    /// Director's `reflectionMap` helper puts the texture on the third layer with
+    /// tex_mode 4 (#reflection); we sample it sphere-mapped in the fragment shader
+    /// and signal it via u_layer2_blend = 5. This runs after bind_material[_for_mesh]
+    /// so the per-mesh path's multi-candidate texture search (which calls
+    /// bind_texture_layers repeatedly and resets u_layer2_blend) cannot clobber it.
+    /// Untextured surfaces (e.g. tinted glass) therefore still get their reflection.
+    fn apply_reflection_map(
+        &self,
+        gl: &WebGl2RenderingContext,
+        shader: &Shader3d,
+        scene: &W3dScene,
+        model_node: &W3dNode,
+        member_key: &(i32, i32),
+        runtime_state: Option<&crate::player::cast_member::Shockwave3dRuntimeState>,
+    ) {
+        // Resolve the model's SINGLE primary shader exactly as `model.shader`
+        // (get_model_prop) does — that is the shader the reflectionMap helper was
+        // assigned to. Scanning every shader the model's resource references is
+        // wrong: house models share one model-resource whose bindings include the
+        // glass's `roofshad`, so a broad scan applied the reflection (and its 50%
+        // sky blend) to every surface and washed the scene white.
+        let shader_name = match Self::resolve_model_primary_shader(scene, model_node, runtime_state) {
+            Some(s) => s,
+            None => return,
+        };
+        let refl = Self::find_shader_ci(&scene.shaders, &shader_name)
+            .and_then(|sh| sh.texture_layers.iter()
+                .find(|l| l.tex_mode == 4 && !l.name.is_empty())
+                .map(|l| (l.name.clone(), l.blend_const)));
+        let (tex_name, blend_const) = match refl { Some(x) => x, None => return };
+        let gpu_data = match self.member_data.get(member_key) { Some(d) => d, None => return };
+        let tex = match gpu_data.textures.get(&tex_name.to_lowercase()) {
+            Some(t) => t,
+            None => return,
+        };
+        gl.active_texture(WebGl2RenderingContext::TEXTURE2);
+        gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(tex));
+        gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_S, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        gl.tex_parameteri(WebGl2RenderingContext::TEXTURE_2D, WebGl2RenderingContext::TEXTURE_WRAP_T, WebGl2RenderingContext::CLAMP_TO_EDGE as i32);
+        gl.uniform1i(shader.u_layer2_blend.as_ref(), 5);
+        gl.uniform1f(shader.u_layer2_intensity.as_ref(), blend_const.clamp(0.0, 1.0));
     }
 
     /// Bind material properties for a model node
@@ -3636,11 +3982,12 @@ void main() {
             if f > 100000.0 || f <= 0.0 { f = 10000.0; }
             let mut n = node.near_plane;
             if n <= 0.0 { n = 1.0; }
-            let cam_aspect = if node.screen_width > 0 && node.screen_height > 0 {
-                node.screen_width as f32 / node.screen_height as f32
-            } else {
-                _fbo_aspect
-            };
+            // Director scales the projection plane to fit the SPRITE rect, so the
+            // aspect must come from the sprite/FBO — NOT the camera's stored screen
+            // size. W3dNode.screen_width/height are an unparsed 640x480 default that
+            // never updates, which forced every movie to 4:3 (fine for 4:3 sprites,
+            // but horizontally stretched for square sprites like the estate explore).
+            let cam_aspect = _fbo_aspect;
             // Each camera uses its own FOV/near/far settings
             let (fov, n, f) = (node.fov, n, f);
             (fov.to_radians(), n, f, cam_aspect)

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -4055,6 +4055,11 @@ void main() {
     fn build_projection_matrix(&self, scene: &W3dScene, _fbo_aspect: f32,
         runtime_state: Option<&crate::player::cast_member::Shockwave3dRuntimeState>,
     ) -> [f32; 16] {
+        // Guard against a degenerate render-target aspect (0 / NaN / inf). The
+        // projection is driven by the real sprite/FBO aspect (_fbo_aspect = w/h); a
+        // 0-sized rect (e.g. briefly, before the score sizes a W3D sprite) would give
+        // 0/inf/NaN and collapse the matrix, blanking the scene. Fall back to 4:3.
+        let fbo_aspect = if _fbo_aspect.is_finite() && _fbo_aspect > 0.0 { _fbo_aspect } else { 4.0 / 3.0 };
         let default_cam = "DefaultView".to_string();
         let cam_name = self.active_camera.as_ref().unwrap_or(&default_cam);
         // Find camera node (case-insensitive), fall back to first view node
@@ -4072,12 +4077,12 @@ void main() {
             // size. W3dNode.screen_width/height are an unparsed 640x480 default that
             // never updates, which forced every movie to 4:3 (fine for 4:3 sprites,
             // but horizontally stretched for square sprites like the estate explore).
-            let cam_aspect = _fbo_aspect;
+            let cam_aspect = fbo_aspect;
             // Each camera uses its own FOV/near/far settings
             let (fov, n, f) = (node.fov, n, f);
             (fov.to_radians(), n, f, cam_aspect)
         } else {
-            (34.516f32.to_radians(), 1.0, 10000.0, _fbo_aspect)
+            (34.516f32.to_radians(), 1.0, 10000.0, fbo_aspect)
         };
 
         // Check for orthographic projection mode

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -552,8 +552,11 @@ void main() {
 
         // IFX fixed-function clamps per-vertex lighting to [0,1] before GL_MODULATE
         lighting = clamp(lighting, vec3(0.0), vec3(1.0));
-        // GL_MODULATE: fragment = texture * lighting
-        vec3 final_color = tex_sample.rgb * lighting;
+        // GL_MODULATE: fragment = texture * lighting * vertex color. Vertex colors
+        // are identity-white for normal meshes; extruded 3D text bakes its tunnel
+        // shading here (gray side walls vs white front) so the glyphs read 3D.
+        vec3 vcol_t = (u_has_vertex_color > 0) ? v_vertex_color.rgb : vec3(1.0);
+        vec3 final_color = tex_sample.rgb * lighting * vcol_t;
 
         // Apply second texture layer (shadow/lightmap) if present
         if (u_has_lightmap > 0) {

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -140,8 +140,13 @@ struct ParticleShader {
     u_camera_up: Option<WebGlUniformLocation>,
     u_color_start: Option<WebGlUniformLocation>,
     u_color_end: Option<WebGlUniformLocation>,
-    u_size: Option<WebGlUniformLocation>,
+    u_size_start: Option<WebGlUniformLocation>,
+    u_size_end: Option<WebGlUniformLocation>,
+    u_blend_start: Option<WebGlUniformLocation>,
+    u_blend_end: Option<WebGlUniformLocation>,
     u_lifetime: Option<WebGlUniformLocation>,
+    u_tex: Option<WebGlUniformLocation>,
+    u_has_tex: Option<WebGlUniformLocation>,
 }
 
 /// Simple fullscreen quad shader for post-processing passes
@@ -736,7 +741,8 @@ layout(location = 2) in vec2 a_corner; // (-1,-1) to (1,1)
 uniform mat4 u_view_projection;
 uniform vec3 u_camera_right;
 uniform vec3 u_camera_up;
-uniform float u_size;
+uniform float u_size_start;
+uniform float u_size_end;
 uniform float u_lifetime;
 
 out float v_age_ratio;
@@ -746,14 +752,32 @@ void main() {
     v_age_ratio = clamp(a_age / u_lifetime, 0.0, 1.0);
     v_uv = a_corner * 0.5 + 0.5;
 
-    // Size fades out near end of life
-    float size_factor = u_size * (1.0 - v_age_ratio * 0.5);
+    // sizeRange is the world-unit sprite size (IFX builds a `size`-wide quad per
+    // particle); a_corner spans -1..1 so 0.5 == `size` wide. We use 0.25 (half
+    // that) so the stream is a thin jet matching Shockwave's water output, rather
+    // than a thick column — the visible blob of the particle texture is narrower
+    // than the full quad.
+    float size_factor = mix(u_size_start, u_size_end, v_age_ratio) * 0.25;
 
-    vec3 world_pos = a_center
-        + u_camera_right * a_corner.x * size_factor
-        + u_camera_up * a_corner.y * size_factor;
-
-    gl_Position = u_view_projection * vec4(world_pos, 1.0);
+    // Cull particles that are behind the eye OR so close that the billboard balloons
+    // across the screen. A chase camera following a car repeatedly passes through the
+    // exhaust/wheel-spray it just emitted; as a particle's center nears the eye
+    // (clip.w -> small) its size/w blows the quad up to many times the screen, and a
+    // few such quads white out the entire 3D scene. Measure the billboard's on-screen
+    // half-extent in NDC and discard the quad when it would exceed the screen.
+    vec4 center_clip = u_view_projection * vec4(a_center, 1.0);
+    vec4 edge_clip   = u_view_projection * vec4(a_center + u_camera_right * size_factor, 1.0);
+    bool bad = center_clip.w <= 0.0001 || edge_clip.w <= 0.0001;
+    float ndc_half = bad ? 1e9
+        : length(edge_clip.xy / edge_clip.w - center_clip.xy / center_clip.w);
+    if (bad || ndc_half > 1.0) {
+        gl_Position = vec4(2.0, 2.0, 2.0, 1.0); // outside NDC clip volume → discarded
+    } else {
+        vec3 world_pos = a_center
+            + u_camera_right * a_corner.x * size_factor
+            + u_camera_up * a_corner.y * size_factor;
+        gl_Position = u_view_projection * vec4(world_pos, 1.0);
+    }
 }
 "#;
 
@@ -765,20 +789,38 @@ in vec2 v_uv;
 
 uniform vec3 u_color_start;
 uniform vec3 u_color_end;
+uniform float u_blend_start;
+uniform float u_blend_end;
+uniform sampler2D u_tex;
+uniform int u_has_tex;
 
 out vec4 frag_color;
 
 void main() {
-    // Circular soft particle
-    float dist = length(v_uv - 0.5) * 2.0;
-    if (dist > 1.0) discard;
-    float alpha = 1.0 - dist * dist;
-
-    // Fade out with age
-    alpha *= 1.0 - v_age_ratio;
-
+    // colorRange / blendRange interpolate start->end over the particle's life.
     vec3 color = mix(u_color_start, u_color_end, v_age_ratio);
-    frag_color = vec4(color, alpha);
+    // blendRange is the per-particle ALPHA (the script comments call it the
+    // "transparency", scaled by how far the tap is turned). The ParticleTexture is
+    // a solid white square with useAlpha=false, so the texture adds nothing — the
+    // whole look is colorRange (tint) + blendRange (alpha). The faucet drives blend
+    // to 2..3 (cold) / 6..7 (hot) at full flow; clamped that's opaque, but Shockwave
+    // renders the stream translucent (you see the drain through it), so we cap full
+    // flow at ~half. Low flow scales below that toward a faint trickle.
+    float opacity = clamp(mix(u_blend_start, u_blend_end, v_age_ratio), 0.0, 1.0) * 0.5;
+
+    float alpha;
+    if (u_has_tex > 0) {
+        vec4 tex = texture(u_tex, v_uv);
+        alpha = tex.a;
+        color *= tex.rgb;
+    } else {
+        // Soft circular fallback when no particle texture is assigned.
+        float dist = length(v_uv - 0.5) * 2.0;
+        if (dist > 1.0) discard;
+        alpha = 1.0 - dist * dist;
+    }
+
+    frag_color = vec4(color, alpha * opacity);
 }
 "#;
 
@@ -795,8 +837,13 @@ void main() {
             u_camera_up: u("u_camera_up"),
             u_color_start: u("u_color_start"),
             u_color_end: u("u_color_end"),
-            u_size: u("u_size"),
+            u_size_start: u("u_size_start"),
+            u_size_end: u("u_size_end"),
+            u_blend_start: u("u_blend_start"),
+            u_blend_end: u("u_blend_end"),
             u_lifetime: u("u_lifetime"),
+            u_tex: u("u_tex"),
+            u_has_tex: u("u_has_tex"),
             program,
         });
 
@@ -807,6 +854,7 @@ void main() {
     fn render_particles(
         &mut self,
         context: &WebGL2Context,
+        member_key: &(i32, i32),
         runtime_state: Option<&crate::player::cast_member::Shockwave3dRuntimeState>,
         view_matrix: &[f32; 16],
         projection_matrix: &[f32; 16],
@@ -815,9 +863,9 @@ void main() {
             Some(rs) if !rs.particles.is_empty() => rs,
             _ => return Ok(()),
         };
-
         self.ensure_particle_shader(context)?;
         let gl = context.gl();
+        let gpu_data = self.member_data.get(member_key);
         let shader = self.particle_shader.as_ref().unwrap();
 
         gl.use_program(Some(&shader.program));
@@ -831,18 +879,39 @@ void main() {
         gl.uniform3f(shader.u_camera_right.as_ref(), view_matrix[0], view_matrix[4], view_matrix[8]);
         gl.uniform3f(shader.u_camera_up.as_ref(), view_matrix[1], view_matrix[5], view_matrix[9]);
 
-        // Enable additive blending for particles
-        gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE);
+        // Standard alpha blending — Director's default particle blend. Additive
+        // (SRC_ALPHA, ONE) over-saturates dense overlapping particles to white
+        // (e.g. the faucet's translucent pink/red water turned into an opaque white
+        // jet); alpha blending keeps them translucent and colored like Shockwave.
+        gl.enable(WebGl2RenderingContext::BLEND);
+        gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
         gl.disable(WebGl2RenderingContext::CULL_FACE);
         gl.depth_mask(false); // Don't write to depth buffer
 
         for (_name, ps) in &rs.particles {
             if ps.positions.is_empty() { continue; }
 
-            gl.uniform1f(shader.u_size.as_ref(), ps.particle_size);
-            gl.uniform1f(shader.u_lifetime.as_ref(), ps.lifetime);
-            gl.uniform3f(shader.u_color_start.as_ref(), 1.0, 1.0, 0.5); // yellow-ish
-            gl.uniform3f(shader.u_color_end.as_ref(), 1.0, 0.2, 0.0);   // red-ish
+            // colorRange / sizeRange / blendRange — interpolated over each particle's
+            // life in the shader (see vs/fs above).
+            gl.uniform1f(shader.u_size_start.as_ref(), ps.size_start);
+            gl.uniform1f(shader.u_size_end.as_ref(), ps.size_end);
+            gl.uniform1f(shader.u_lifetime.as_ref(), ps.lifetime.max(0.001));
+            gl.uniform3f(shader.u_color_start.as_ref(), ps.color_start[0], ps.color_start[1], ps.color_start[2]);
+            gl.uniform3f(shader.u_color_end.as_ref(), ps.color_end[0], ps.color_end[1], ps.color_end[2]);
+            gl.uniform1f(shader.u_blend_start.as_ref(), ps.blend_start);
+            gl.uniform1f(shader.u_blend_end.as_ref(), ps.blend_end);
+
+            // Bind the particle texture (set via resource.texture) if present.
+            let mut has_tex = false;
+            if !ps.texture_name.is_empty() {
+                if let Some(tex) = gpu_data.and_then(|d| d.textures.get(&ps.texture_name)) {
+                    gl.active_texture(WebGl2RenderingContext::TEXTURE0);
+                    gl.bind_texture(WebGl2RenderingContext::TEXTURE_2D, Some(tex));
+                    gl.uniform1i(shader.u_tex.as_ref(), 0);
+                    has_tex = true;
+                }
+            }
+            gl.uniform1i(shader.u_has_tex.as_ref(), if has_tex { 1 } else { 0 });
 
             // Build billboard quad vertex data: 4 verts per particle (center + age + corner)
             let alive_count = ps.alive.iter().filter(|&&a| a).count();
@@ -924,10 +993,14 @@ void main() {
             gl.delete_vertex_array(Some(&vao));
         }
 
-        // Restore state
+        // Restore state. Crucially DISABLE blend: the rest of the camera pass and the
+        // FBO→stage composite run with blend OFF (it's disabled at pass start). Leaving
+        // it enabled here made the 2D composite alpha-blend the whole 3D FBO by its
+        // alpha — fine for the faucet (opaque alpha=1 FBO) but the car/track models
+        // write alpha<1, so the entire scene faded out and read as "3D doesn't render".
         gl.depth_mask(true);
         gl.enable(WebGl2RenderingContext::CULL_FACE);
-        gl.blend_func(WebGl2RenderingContext::SRC_ALPHA, WebGl2RenderingContext::ONE_MINUS_SRC_ALPHA);
+        gl.disable(WebGl2RenderingContext::BLEND);
 
         Ok(())
     }
@@ -1649,6 +1722,18 @@ void main() {
                     // Skip directly detached nodes
                     if detached_nodes.contains(n.name.as_str()) { return false; }
 
+                    // Skip #particle models — their resource is a billboard placeholder;
+                    // the particle system itself is drawn by render_particles, not as a
+                    // static quad here.
+                    let res = if !n.model_resource_name.is_empty() { &n.model_resource_name } else { &n.resource_name };
+                    if scene.model_resources.get(res)
+                        .and_then(|r| r.primitive_type.as_deref())
+                        .map(|t| t.eq_ignore_ascii_case("particle"))
+                        .unwrap_or(false)
+                    {
+                        return false;
+                    }
+
                     if let Some(ref root) = root_node_filter {
                         // Camera has rootNode: only render nodes in that subtree
                         self.is_child_of(scene, &n.name, root)
@@ -1840,8 +1925,8 @@ void main() {
             gl.use_program(Some(&shader.program));
         }
 
-        // Render particles (after opaque geometry, with additive blending)
-        let _ = self.render_particles(context, runtime_state, &view_matrix, &projection_matrix);
+        // Render particles (after opaque geometry), alpha-blended.
+        let _ = self.render_particles(context, &member_key, runtime_state, &view_matrix, &projection_matrix);
 
         // Note: overlays are rendered AFTER all camera passes, not per-camera
 


### PR DESCRIPTION
The following improvements were done:
- Havok
  - added more token parsing for HKE's
  - apply model state (active)
  - initialize linear velocity from parsed HKE (warehouse movie, the moving box on start)

- W3D
  - read reference corners at the resolution collapse boundary (improves the rendering quality of most models)

Movie improvements:
- LEGO SuperSonic RC: the whole map can now be explored, before you were hitting invisible walls because of broken mesh, rendering improvement the wheels do look now more like in shockwave player
- Havok Demo - Warehouse: the movie has now non active models which prevents the models from falling down, the box is sliding in, when you click on some of the models you will get an error (WIP)
- Havok Demo - HavokCarDemo: the car is landing now and you can drive with it forward, but currently no steering is possible (WIP)
- Gorillaz - Finaldrive: the car is now also landing same as the HavokCarDemo you cannot steer (WIP)
- Estate: supports the whole movie now #156 
- Faucet: added a particle engine
- PacMan3D: supports the movie #157 


<img width="313" height="380" alt="grafik" src="https://github.com/user-attachments/assets/cc9358ac-9d3c-4074-9245-fc52810bede7" />

<img width="645" height="488" alt="grafik" src="https://github.com/user-attachments/assets/a7915eb4-e260-433e-b858-d7fc1777e585" />

