### PR TITLE
fix(palette): resolve bare palette indices through the movie's active palette

### DIFF
--- a/vm-rust/src/director/chunks/config.rs
+++ b/vm-rust/src/director/chunks/config.rs
@@ -47,6 +47,12 @@ pub struct ConfigChunk {
     /* 60 */ pub field29: u32,
     /* 64 */ pub checksum: u32,
     /* 68 */ pub remnants: Vec<u8>,
+
+    /// Movie default palette from the cast/VWCF config (ScummVM `_defaultPalette`).
+    /// `member > 0` => custom palette cast member (in `default_palette_castlib`);
+    /// `member < 0` => built-in palette id; `member == 0` => unset.
+    pub default_palette_castlib: i16,
+    pub default_palette_member: i16,
 }
 
 impl ConfigChunk {
@@ -113,6 +119,32 @@ impl ConfigChunk {
         let checksum = reader.read_u32().unwrap();
         let remnants = reader.read_bytes(len as usize - reader.pos).unwrap();
 
+        // Movie default palette, parsed per ScummVM `Cast::loadConfig`. `remnants`
+        // begins at config offset 68 (just past the checksum). For Director 5+ the
+        // layout is field30(2), defPaletteNum(2), chunkBaseNum(4),
+        // defaultPalette.castLib(2), defaultPalette.member(2); for Director 4 it is
+        // field30(2) then defaultPalette.member(2). Built-in palette ids in this
+        // header start at 0 and go negative, so `member <= 0` is decremented by 1.
+        let rd_i16_be = |b: &[u8], off: usize| -> i16 {
+            if b.len() >= off + 2 { i16::from_be_bytes([b[off], b[off + 1]]) } else { 0 }
+        };
+        let mut default_palette_castlib: i16 = 0;
+        let mut default_palette_member: i16 = 0;
+        if raw_version >= 0x4B1 {
+            // Director 5+
+            default_palette_castlib = rd_i16_be(remnants, 8);
+            default_palette_member = rd_i16_be(remnants, 10);
+            if default_palette_member <= 0 { default_palette_member -= 1; }
+        } else if raw_version >= 0x45B {
+            // Director 4
+            default_palette_member = rd_i16_be(remnants, 2);
+            if default_palette_member <= 0 {
+                default_palette_member -= 1;
+            } else {
+                default_palette_castlib = 1; // DEFAULT_CAST_LIB
+            }
+        }
+
         let config = ConfigChunk {
             len: len,
             file_version: file_version,
@@ -150,6 +182,8 @@ impl ConfigChunk {
             field29: field29,
             checksum: checksum,
             remnants: remnants.to_vec(),
+            default_palette_castlib,
+            default_palette_member,
         };
 
         let computed_checksum = config.compute_checksum(dir_endian);

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -746,8 +746,7 @@ impl CastMemberRefHandlers {
                             let palettes: &_ = &*palettes_rc;
                             let frame_palette = player
                                 .movie
-                                .score
-                                .get_frame_palette(player.movie.current_frame);
+                                .get_active_palette(player.movie.current_frame);
                             let fg_rgb = resolve_color_ref(
                                 palettes,
                                 &ColorRef::PaletteIndex(info_owned.fore_color),

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -113,6 +113,36 @@ impl Movie {
         self.stage_color_ref = stage_color_ref;
     }
 
+    /// The movie's default palette (cast/VWCF config) as a `PaletteRef`, if set.
+    /// `member > 0` is a custom palette cast member; `member < 0` a built-in id.
+    pub fn default_palette_ref(&self) -> Option<crate::player::bitmap::bitmap::PaletteRef> {
+        use crate::player::bitmap::bitmap::PaletteRef;
+        let config = &self.file.as_ref()?.config;
+        let member = config.default_palette_member;
+        if member > 0 {
+            Some(PaletteRef::Member(CastMemberRef {
+                cast_lib: config.default_palette_castlib as i32,
+                cast_member: member as i32,
+            }))
+        } else if member < 0 {
+            Some(PaletteRef::from(member, config.default_palette_castlib, 0))
+        } else {
+            None
+        }
+    }
+
+    /// The palette active for `frame`, used to resolve bare palette indices (the
+    /// stage background colour, shape colours, …). Resolution order matches Adobe
+    /// Director: the most recent score palette-channel entry that sets a real cast
+    /// palette, else the movie's default palette, else the system palette.
+    pub fn get_active_palette(&self, frame: u32) -> crate::player::bitmap::bitmap::PaletteRef {
+        use crate::player::bitmap::bitmap::{get_system_default_palette, PaletteRef};
+        self.score
+            .get_frame_cast_palette(frame)
+            .or_else(|| self.default_palette_ref())
+            .unwrap_or_else(|| PaletteRef::BuiltIn(get_system_default_palette()))
+    }
+
     pub fn get_prop(&self, prop: &str) -> Result<Datum, ScriptError> {
         match_ci!(prop, {
             "alertHook" => match self.alert_hook.to_owned() {

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -3126,27 +3126,30 @@ impl Score {
         }
     }
 
-    pub fn get_frame_palette(&self, frame: u32) -> PaletteRef {
+    /// The most recent palette-channel entry at or before `frame` that selects a
+    /// real **custom cast palette** (member > 0), carrying forward across frames
+    /// that don't change the palette. Returns `None` when no such entry exists, in
+    /// which case the caller should fall back to the movie's default palette.
+    ///
+    /// Channel entries with `member <= 0` are treated as "no palette change" here:
+    /// confirmed against real Adobe Director on Ask Chef, where the kitchen frames'
+    /// `member == -1` / `member == 0` entries leave the movie default palette
+    /// (counter.pict) active rather than forcing a SystemMac built-in.
+    pub fn get_frame_cast_palette(&self, frame: u32) -> Option<PaletteRef> {
         self.palette_channel_data
             .iter()
             .rev()
-            .find(|(frame_idx, _, _)| *frame_idx < frame)
-            .map(|(_, cast_lib, member)| {
-                if *member < 0 {
-                    // Negative member = built-in palette
-                    PaletteRef::from(*member, *cast_lib, 0)
-                } else if *member > 0 {
-                    // Positive member = cast member palette
-                    PaletteRef::Member(CastMemberRef {
+            .filter(|(frame_idx, _, _)| *frame_idx < frame)
+            .find_map(|(_, cast_lib, member)| {
+                if *member > 0 {
+                    Some(PaletteRef::Member(CastMemberRef {
                         cast_lib: *cast_lib as i32,
                         cast_member: *member as i32,
-                    })
+                    }))
                 } else {
-                    // member == 0: use system default
-                    PaletteRef::BuiltIn(get_system_default_palette())
+                    None
                 }
             })
-            .unwrap_or_else(|| PaletteRef::BuiltIn(get_system_default_palette()))
     }
 }
 

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -338,12 +338,14 @@ pub fn render_preview_bitmap(
                 PaletteRef::BuiltIn(get_system_default_palette()),
             );
             let palettes = &player.movie.cast_manager.palettes();
+            // bg_color is a bare palette index -> resolve via the active palette.
+            let active_palette = player.movie.get_active_palette(player.movie.current_frame);
             bitmap.fill_relative_rect(
                 0, 0, 0, 0,
                 resolve_color_ref(
                     &palettes,
                     &player.bg_color,
-                    &PaletteRef::BuiltIn(get_system_default_palette()),
+                    &active_palette,
                     original_bit_depth,
                 ),
                 palettes,
@@ -1334,7 +1336,7 @@ fn render_filmloop_from_channel_data(
                     ((255.0 - data.blend as f32) * 100.0 / 255.0) as i32
                 };
 
-                let frame_palette = player.movie.score.get_frame_palette(player.movie.current_frame);
+                let frame_palette = player.movie.get_active_palette(player.movie.current_frame);
                 bitmap.draw_shape_with_sprite(&temp_sprite, &shape_member.shape_info, sprite_rect, &palettes, &frame_palette);
             }
             CastMemberType::VectorShape(vector_member) => {
@@ -1708,7 +1710,10 @@ pub fn render_score_to_bitmap_with_offset(
         return;
     }
 
-    // For stage rendering, use the player's background color
+    // For stage rendering, use the player's background color. The stage color is a
+    // bare palette index, so resolve it through the movie's active palette for this
+    // frame (score palette channel -> movie default palette -> system).
+    let active_palette = player.movie.get_active_palette(player.movie.current_frame);
     bitmap.clear_rect(
         dest_rect.left,
         dest_rect.top,
@@ -1717,7 +1722,7 @@ pub fn render_score_to_bitmap_with_offset(
         resolve_color_ref(
             &palettes,
             &player.bg_color,
-            &PaletteRef::BuiltIn(get_system_default_palette()),
+            &active_palette,
             bitmap.original_bit_depth,
         ),
         &palettes,
@@ -1997,7 +2002,7 @@ pub fn render_score_to_bitmap_with_offset(
                     }
                 }
 
-                let frame_palette = player.movie.score.get_frame_palette(player.movie.current_frame);
+                let frame_palette = player.movie.get_active_palette(player.movie.current_frame);
                 debug!(
                     "  SHAPE RENDER: channel {} member {:?} type {:?} size {}x{} color {:?} bg {:?} ink {} blend {} filled={} lineThick={}",
                     channel_num, sprite.member, shape_member.shape_info.shape_type,

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -645,10 +645,14 @@ impl WebGL2Renderer {
     /// Get stage background color as normalized floats
     fn get_stage_bg_color(&self, player: &DirPlayer) -> (f32, f32, f32) {
         let palettes = player.movie.cast_manager.palettes();
+        // The stage background is a bare palette index; resolve it through the
+        // movie's active palette for this frame (score palette channel -> movie
+        // default palette -> system), not a hard system palette.
+        let active_palette = player.movie.get_active_palette(player.movie.current_frame);
         let (r, g, b) = resolve_color_ref(
             &palettes,
             &player.bg_color,
-            &PaletteRef::BuiltIn(get_system_default_palette()),
+            &active_palette,
             8, // bit depth
         );
         (r as f32 / 255.0, g as f32 / 255.0, b as f32 / 255.0)
@@ -1426,7 +1430,7 @@ impl WebGL2Renderer {
                     }
 
                     let palettes = player.movie.cast_manager.palettes();
-                    let frame_palette = player.movie.score.get_frame_palette(player.movie.current_frame);
+                    let frame_palette = player.movie.get_active_palette(player.movie.current_frame);
                     let fg_rgb = resolve_color_ref(
                         &palettes,
                         &fg_color,


### PR DESCRIPTION
## What

Bare palette indices — the stage `bgColor`, shape colors, and field fore/back colors — were resolved against the hard system palette. For movies whose art relies on a custom palette, that produced wrong colors. In South Park *Ask Chef* the blue kitchen wall rendered olive and the wooden frame rendered magenta.

Director resolves a bare palette index through the movie's **active palette**: the score's palette channel for the current frame, carried forward, falling back to the movie's **default palette** (cast/VWCF config) and finally the system palette. dirplayer never parsed the movie default palette and had no carry-forward, so it fell straight to the system palette.

## Changes

- **config**: parse the movie default palette from the cast/VWCF config (byte layout per ScummVM `Cast::loadConfig`).
- **score**: `get_frame_cast_palette()` — the most recent palette-channel entry that selects a real cast palette (member > 0), carried forward across frames that don't change the palette; removes the now-dead `get_frame_palette`.
- **movie**: `default_palette_ref()` + `get_active_palette(frame)` = palette channel → movie default → system.
- **rendering / webgl2 / cast_member_ref**: resolve the stage background, shape colors, and field fore/back colors through `get_active_palette`.

## Verification

Diffed against **real Adobe Director 11.5** (driven in a QEMU Windows-XP "oracle" VM), South Park *Ask Chef* kitchen:

- stage bg (palette index 47) → `rgb(0,117,191)` blue, matching Director's `rgb(0,112,184)` (counter.pict).
- the frame (shape, bare index) → wood brown, matching Director.
- 12-point pixel diff across bg / shapes / bitmaps: **worst per-channel diff = 7** — a *uniform* offset present on unchanged bitmaps too, i.e. the oracle VM's 16-bit display quantization (`& 0xF8`), not a dirplayer difference.
- Confirmed the `member == -1` palette-channel entries on the kitchen frames leave the **movie default** palette active (not SystemMac), matching Director.

## Out of scope (intentional)

palette_id=0 **bitmaps** are deliberately left on the **system palette**. Confirmed against real Director that `member.palette = 0` resolves to the SystemMac built-in (identical to `palette −1`), **not** the movie default palette — so bare indices and palette-less bitmaps behave differently, and only the former are changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
