### PR TITLE
Fix panic decompiling nested &&/|| short-circuit expressions

### DIFF
--- a/vm-rust/src/player/js_lingo/decompiler.rs
+++ b/vm-rust/src/player/js_lingo/decompiler.rs
@@ -719,11 +719,27 @@ impl<'a> DecompState<'a> {
     /// and ?:. Returns the expression text — if the slice produces multiple
     /// statements or no value, returns "/* expr */".
     fn render_subexpr(&self, start: usize, end: usize) -> String {
+        // The child state renumbers instructions from 0, so the parent's
+        // offset_to_idx (parent-relative indices) is wrong here — a nested
+        // &&/|| inside the subexpr would resolve its jump target to an index
+        // past the subslice and panic ("range end index N out of range").
+        // Rebuild the map in child coordinates, with a virtual entry for the
+        // end-boundary offset (mirroring the end-of-script sentinel in
+        // `new()`) so chained short-circuits whose join point is exactly
+        // `end` resolve to one-past-last instead of falling back.
+        let end = end.min(self.instructions.len());
+        let start = start.min(end);
+        let sub: Vec<DecodedIns> = self.instructions[start..end].to_vec();
+        let mut sub_map: std::collections::HashMap<usize, usize> =
+            sub.iter().enumerate().map(|(k, ins)| (ins.offset, k)).collect();
+        if let Some(boundary) = self.instructions.get(end) {
+            sub_map.insert(boundary.offset, sub.len());
+        }
         let mut child = DecompState {
             ir: self.ir,
             bindings: self.bindings,
-            instructions: self.instructions[start..end].to_vec(),
-            offset_to_idx: self.offset_to_idx.clone(),
+            instructions: sub,
+            offset_to_idx: sub_map,
             stack: Vec::new(),
             out: Vec::new(),
             indent: 0,

--- a/vm-rust/src/player/js_lingo/interp_tests.rs
+++ b/vm-rust/src/player/js_lingo/interp_tests.rs
@@ -975,3 +975,53 @@ fn synth_array_literal_via_initelem() {
     atoms.push(JsAtom::String("Array".into())); // atom[3]
     assert!(matches!(run_synth(bc, atoms).unwrap(), JsValue::Array(_)));
 }
+
+#[test]
+fn decompile_nested_short_circuit_expressions() {
+    // Regression test: `a && (b && c)` — the inner AND's join target is the
+    // same offset as the outer AND's, one instruction past the right-hand
+    // slice that render_subexpr re-runs. The child DecompState renumbers its
+    // instructions from 0, so resolving that jump through the parent's
+    // offset_to_idx (parent-relative indices) produced an out-of-range slice
+    // and panicked ("range end index N out of range").
+    use super::decompiler::decompile;
+
+    // a && (b && c);
+    // a || (b || c);
+    let atoms = vec![
+        JsAtom::String("a".into()),
+        JsAtom::String("b".into()),
+        JsAtom::String("c".into()),
+    ];
+    let mut bc = Vec::new();
+    for op in [JsOp::And, JsOp::Or] {
+        let join = bc.len() as i32 + 15;                      // offset of the POP below
+        bc.push(JsOp::Name as u8); bc.extend(u16_be(0));      // push a
+        let outer_pc = bc.len() as i32;
+        bc.push(op as u8); bc.extend(i16_be((join - outer_pc) as i16));
+        bc.push(JsOp::Name as u8); bc.extend(u16_be(1));      // push b
+        let inner_pc = bc.len() as i32;
+        bc.push(op as u8); bc.extend(i16_be((join - inner_pc) as i16));
+        bc.push(JsOp::Name as u8); bc.extend(u16_be(2));      // push c
+        bc.push(JsOp::Pop as u8);                              // statement boundary
+    }
+    let ir = super::xdr::JsScriptIR {
+        magic: 0xdead_0003,
+        bytecode: bc,
+        prolog_length: 0,
+        version: 150,
+        atoms,
+        source_notes: Vec::new(),
+        filename: None,
+        lineno: 1,
+        max_stack_depth: 2,
+        try_notes: Vec::new(),
+    };
+    let dec = decompile(&ir, &[]);
+    let source: String = dec.lines.iter()
+        .map(|l| l.text.clone())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(source.contains("a && b && c;"), "got:\n{}", source);
+    assert!(source.contains("a || b || c;"), "got:\n{}", source);
+}


### PR DESCRIPTION
## Fix panic decompiling nested `&&`/`||` short-circuit expressions

Hello. This fix is absolutely vibe coded with Claude Fable (sorry) but it did seem to fix an issue I hit whilst decompiling a mid-2000s DVD rom made with Director. Hopefully it's useful? Here's Claude's summary.

### Problem

`DecompState::render_subexpr` (in `vm-rust/src/player/js_lingo/decompiler.rs`) re-runs a child `DecompState` over a **subslice** of the parent's instructions, but it clones the parent's `offset_to_idx` map:

```rust
instructions: self.instructions[start..end].to_vec(),
offset_to_idx: self.offset_to_idx.clone(),
```

The child renumbers its instructions from index `0`, but `offset_to_idx` still maps bytecode offsets to **parent-relative** indices. When the subexpression contains a *nested* `&&`/`||`, resolving that inner jump target through the stale map returns an index past the end of the child subslice. The next `self.instructions[start..end]` slice then panics:

```
range end index N out of range for slice of length M
```

This triggers on any script with chained short-circuit operators, e.g. `a && b && c`. I hit it decompiling a real Director `Lscr` from a shipped title (SpiderMonkey 1.5 XDR).

### Fix

Rebuild `offset_to_idx` in **child-local** coordinates from the subslice. A virtual end-boundary entry is added — mirroring the end-of-script sentinel that `new()` already inserts — so a chained short-circuit whose join point is exactly `end` resolves to one-past-last instead of panicking.

### Test

Adds `decompile_nested_short_circuit_expressions`, which synthesizes bytecode for `a && b && c;` and `a || b || c;`. It panics on the current `main` with the out-of-range slice, and passes with this change. Verified locally with `cargo test --lib decompile_nested_short_circuit_expressions` (passes with the fix; reverting only the `decompiler.rs` change reproduces `range end index 5 out of range for slice of length 3`).
