### PR TITLE
Bugfix for w3d, text rendering and multiuser

### DIFF
--- a/src/views/LoadMovie/index.tsx
+++ b/src/views/LoadMovie/index.tsx
@@ -24,6 +24,16 @@ type RecentMovie = {
   // Whether this entry routes its cross-origin fetches through the CORS proxy.
   // Opt-in per movie (advanced-options checkbox); undefined/false = direct.
   useCorsProxy?: boolean;
+  // The projector command line this entry was launched from, kept RAW rather
+  // than pre-parsed so it stays re-parsable as the parser gains flags — and so
+  // it can be read and edited in Advanced Options.
+  //
+  // This has to be persisted: the player CONSUMES its startup payloads
+  // (`run_startup_do` does a `.take()`), so replaying an entry without the
+  // command leaves a leech-protection wrapper with no idea where the real game
+  // lives. It loads its default — the original, long-dead url — and you get a
+  // 404 followed by "[go] eager mount FAILED".
+  launchCommand?: string;
   timestamp: number;
 };
 
@@ -123,9 +133,10 @@ function loadRecentMovies(): RecentMovie[] {
   }
 }
 
-function saveRecentMovie(url: string, params: ExternalParam[], fakeMoviePath?: string, useCorsProxy?: boolean): RecentMovie[] {
+function saveRecentMovie(url: string, params: ExternalParam[], fakeMoviePath?: string, useCorsProxy?: boolean,
+  launchCommand?: string): RecentMovie[] {
   const existing = loadRecentMovies().filter(m => m.url !== url);
-  const updated = [{ url, params, fakeMoviePath, useCorsProxy, timestamp: Date.now() }, ...existing].slice(0, MAX_RECENT_MOVIES);
+  const updated = [{ url, params, fakeMoviePath, useCorsProxy, launchCommand, timestamp: Date.now() }, ...existing].slice(0, MAX_RECENT_MOVIES);
   window.localStorage.setItem(RECENT_MOVIES_KEY, JSON.stringify(updated));
   return updated;
 }
@@ -226,6 +237,7 @@ const MAX_ROW_TAGS = 4;
 function movieTags(movie: RecentMovie): MovieTag[] {
   const tags: MovieTag[] = [];
   if (movie.useCorsProxy) tags.push({ key: 'proxy', label: 'proxy', accent: true });
+  if (movie.launchCommand) tags.push({ key: 'launch', label: 'launch cmd', accent: true });
   if (movie.fakeMoviePath) tags.push({ key: 'fakePath', label: `fakePath=${movie.fakeMoviePath}` });
   movie.params.forEach((p, i) => {
     if (p.key.trim()) tags.push({ key: `p${i}`, label: `${p.key}=${p.value}` });
@@ -238,6 +250,7 @@ function matchesFilter(movie: RecentMovie, tokens: string[]): boolean {
   const haystack = [
     movie.url,
     movie.fakeMoviePath ?? '',
+    movie.launchCommand ?? '',
     ...movie.params.map(p => `${p.key}=${p.value}`),
   ].join(' ').toLowerCase();
   return tokens.every(token => haystack.includes(token));
@@ -253,6 +266,7 @@ export default function LoadMovie() {
   const [autoPlay, setAutoPlay] = useState<boolean>(process.env.REACT_APP_MOVIE_AUTO_PLAY === 'true');
   const [externalParams, setExternalParams] = useState<ExternalParam[]>(() => getEnvExternalParams());
   const [fakeMoviePath, setFakeMoviePath] = useState<string>('');
+  const [launchCommand, setLaunchCommand] = useState<string>('');
   const [recentMovies, setRecentMovies] = useState<RecentMovie[]>(() => loadRecentMovies());
   const [paramsExpanded, setParamsExpanded] = useState(() => getEnvExternalParams().length > 0);
   const [loaderUrl, setLoaderUrl] = useState<string>('');
@@ -279,7 +293,7 @@ export default function LoadMovie() {
   }, []);
 
   const loadMovieFile = useCallback(async (fullPath: string, params?: ExternalParam[], fakePath?: string, useProxy?: boolean,
-    launch?: ReturnType<typeof parseLaunchCommand> | null) => {
+    launchCmd?: string) => {
     try {
       setIsLoading(true);
       setHasError(false);
@@ -316,13 +330,18 @@ export default function LoadMovie() {
       // the LeechProtectionRemovalHelp flags synthesised into `--do`). These
       // MUST be installed before load_movie_file: the movie-init sequence
       // consumes them. See docs/github_wiki/Projector-Launch-Commands.md.
-      if (launch) {
-        if (launch.startupDoBefore) set_startup_do_before(launch.startupDoBefore);
-        if (launch.startupDo) set_startup_do(launch.startupDo);
-        if (launch.startupGo) set_startup_go(launch.startupGo);
-        if (launch.ignored.length) {
-          console.warn('[LoadMovie] launch command: ignored projector-only flags:', launch.ignored.join(', '));
-        }
+      //
+      // Re-parsed and re-applied on EVERY load, never just the first. The
+      // player TAKES these slots when it runs them, so they are gone by the
+      // second load of the same entry; and an empty string CLEARS the slot, so
+      // a payload left behind by a load that failed before consuming it cannot
+      // leak into the next movie (same hazard as the CORS proxy global above).
+      const launch = parseLaunchCommand(launchCmd ?? launchCommand);
+      set_startup_do_before(launch.startupDoBefore);
+      set_startup_do(launch.startupDo);
+      set_startup_go(launch.startupGo);
+      if (launch.ignored.length) {
+        console.warn('[LoadMovie] launch command: ignored projector-only flags:', launch.ignored.join(', '));
       }
       document.title = `${fullPath.split('/').pop() || fullPath} - ${APP_TITLE}`;
       // Wait for any in-flight boot-time external xtra loads (the
@@ -345,14 +364,14 @@ export default function LoadMovie() {
     } finally {
       setIsLoading(false);
     }
-  }, [autoPlay, dispatch, externalParams, fakeMoviePath, corsProxy, useCorsProxy]);
+  }, [autoPlay, dispatch, externalParams, fakeMoviePath, corsProxy, useCorsProxy, launchCommand]);
 
   const onLoadClick = useCallback(async () => {
     if (!movieUrl.trim()) { setHasError(true); return; }
-    const updated = saveRecentMovie(movieUrl, externalParams, fakeMoviePath, useCorsProxy);
+    const updated = saveRecentMovie(movieUrl, externalParams, fakeMoviePath, useCorsProxy, launchCommand.trim() || undefined);
     setRecentMovies(updated);
     await loadMovieFile(movieUrl, undefined, undefined, useCorsProxy);
-  }, [movieUrl, externalParams, fakeMoviePath, useCorsProxy, loadMovieFile]);
+  }, [movieUrl, externalParams, fakeMoviePath, useCorsProxy, launchCommand, loadMovieFile]);
 
   // Loader mode: fetch a Shockwave loader page through the dev CORS proxy,
   // extract the Director embed (movie URL + sw* external params), enable proxy
@@ -401,10 +420,11 @@ export default function LoadMovie() {
           }
           setMovieUrl(loadUrl);
           setExternalParams(lcParams);
+          setLaunchCommand(launchCmd);
           if (lcParams.length > 0) setParamsExpanded(true);
           setUseCorsProxy(true);
-          setRecentMovies(saveRecentMovie(loadUrl, lcParams, undefined, true));
-          await loadMovieFile(loadUrl, lcParams, undefined, true, launch);
+          setRecentMovies(saveRecentMovie(loadUrl, lcParams, undefined, true, launchCmd));
+          await loadMovieFile(loadUrl, lcParams, undefined, true, launchCmd);
           return;
         }
         console.warn('[LoadMovie] data-launch-command names no movie; falling back to embed scrape.');
@@ -418,12 +438,15 @@ export default function LoadMovie() {
       }
       setMovieUrl(parsed.movieUrl);
       setExternalParams(parsed.params);
+      // A scraped embed carries no projector arguments; drop whatever command
+      // the previously-inspected entry left in the form.
+      setLaunchCommand('');
       if (parsed.params.length > 0) setParamsExpanded(true);
       // Loader mode inherently requires the proxy (the game's own cross-origin
       // fetches route through it), so force it on and persist that for the entry.
       setUseCorsProxy(true);
       setRecentMovies(saveRecentMovie(parsed.movieUrl, parsed.params, undefined, true));
-      await loadMovieFile(parsed.movieUrl, parsed.params, undefined, true);
+      await loadMovieFile(parsed.movieUrl, parsed.params, undefined, true, '');
     } catch (e) {
       console.error('[LoadMovie] Loader load failed', e);
       setHasError(true);
@@ -448,20 +471,25 @@ export default function LoadMovie() {
     setMovieUrl(movie.url);
     setExternalParams(movie.params);
     setFakeMoviePath(movie.fakeMoviePath ?? '');
+    const launch = movie.launchCommand ?? '';
+    setLaunchCommand(launch);
     // Honor the per-entry opt-in (default OFF for legacy entries with no flag).
     const proxy = movie.useCorsProxy ?? false;
     setUseCorsProxy(proxy);
-    const updated = saveRecentMovie(movie.url, movie.params, movie.fakeMoviePath, proxy);
+    const updated = saveRecentMovie(movie.url, movie.params, movie.fakeMoviePath, proxy, movie.launchCommand);
     setRecentMovies(updated);
-    loadMovieFile(movie.url, movie.params, movie.fakeMoviePath, proxy);
+    // Pass the command explicitly: `setLaunchCommand` above has not landed in
+    // state yet, and a replay without it is exactly the bug this fixes.
+    loadMovieFile(movie.url, movie.params, movie.fakeMoviePath, proxy, launch);
   }, [loadMovieFile]);
 
   const onEditRecent = useCallback((movie: RecentMovie) => {
     setMovieUrl(movie.url);
     setExternalParams(movie.params);
     setFakeMoviePath(movie.fakeMoviePath ?? '');
+    setLaunchCommand(movie.launchCommand ?? '');
     setUseCorsProxy(movie.useCorsProxy ?? false);
-    if (movie.params.length > 0 || movie.fakeMoviePath) {
+    if (movie.params.length > 0 || movie.fakeMoviePath || movie.launchCommand) {
       setParamsExpanded(true);
     }
   }, []);
@@ -605,8 +633,9 @@ export default function LoadMovie() {
                 &#9654;
               </span>
               Advanced Options
-              {(hasParams || fakeMoviePath) && !paramsExpanded && (
-                <span> ({[hasParams && `${externalParams.length} params`, fakeMoviePath && 'fake path'].filter(Boolean).join(', ')})</span>
+              {(hasParams || fakeMoviePath || launchCommand) && !paramsExpanded && (
+                <span> ({[hasParams && `${externalParams.length} params`, fakeMoviePath && 'fake path',
+                  launchCommand && 'launch cmd'].filter(Boolean).join(', ')})</span>
               )}
             </button>
             {paramsExpanded && (
@@ -661,13 +690,35 @@ export default function LoadMovie() {
                     cross-origin fetches need proxying. Fetch &amp; Load turns it on
                     automatically. Start the proxy first: <code>node cors-proxy.cjs</code>.
                   </div>
-                  <div style={{ fontSize: '0.8em', color: '#888', marginTop: 4 }}>
+                  <div className={styles.hintText} style={{ marginTop: 4 }}>
                     Fetch &amp; Load also reads a <code>data-launch-command</code> from an
                     archive entry page (9o3o / Flashpoint) and applies the projector
                     arguments — the movie URL, <code>--setExternalParam</code> pairs, the
                     LeechProtectionRemovalHelp flags and the <code>--do</code> payload.
                     Many archived games are launched from a wrapper movie that does
                     nothing without them.
+                  </div>
+                </div>
+                <div className={styles.fieldContainer}>
+                  <label className={styles.label} htmlFor="launchCommand">
+                    Launch command (optional)
+                  </label>
+                  <textarea
+                    id="launchCommand"
+                    className={`${styles.input} ${styles.commandInput}`}
+                    rows={3}
+                    spellCheck={false}
+                    placeholder={'"…/wrapper.dcr" --do "member(\'gameUrl\').text = \'…/game.dcr\'"'}
+                    value={launchCommand}
+                    onChange={e => setLaunchCommand(e.currentTarget.value)}
+                    disabled={isLoading}
+                    title="Projector arguments, re-applied on every load of this entry."
+                  />
+                  <div className={styles.hintText}>
+                    Filled in by Fetch &amp; Load and saved with the entry. It is
+                    re-applied on every load, because the player consumes its
+                    startup payloads — without it a wrapper movie reloads with no
+                    game URL and 404s.
                   </div>
                 </div>
                 <div className={styles.fieldContainer}>

--- a/src/views/LoadMovie/styles.module.css
+++ b/src/views/LoadMovie/styles.module.css
@@ -210,6 +210,17 @@
   }
 }
 
+/* A projector command line is long, quote-dense and worth reading exactly, so
+   it gets a monospace box that grows downwards rather than a one-line input. */
+.commandInput {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
+  font-size: 0.82em;
+  line-height: 1.45;
+  resize: vertical;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
 .inputError {
   border-color: var(--danger);
 

--- a/vm-rust/src/director/chunks/w3d/parser.rs
+++ b/vm-rust/src/director/chunks/w3d/parser.rs
@@ -238,7 +238,7 @@ impl W3dFileParser {
     /// R0 is recorded in `scene.model_root_com` so the renderer strips precisely
     /// the matrix composed here and the two sides cannot drift apart.
     fn apply_root_com_to_model_nodes(&mut self) {
-        let mut fixups: Vec<(usize, [f32; 16])> = Vec::new();
+        let mut fixups: Vec<(usize, [f32; 16], Option<Symbol>)> = Vec::new();
 
         for (i, node) in self.scene.nodes.iter().enumerate() {
             if node.node_type != W3dNodeType::Model { continue; }
@@ -251,25 +251,29 @@ impl W3dFileParser {
                         || s.name == node.name)
             }) else { continue };
 
-            // Reference motion, in the same priority order the renderer uses to pick
-            // its relativization reference: an authored idle first (the bot rigs are
-            // modelled at Idle_Rest), otherwise the rig's own like-named motion.
-            let reference = self.scene.motions.iter()
-                .find(|m| m.name.as_lower_str().contains("idle_rest"))
-                .or_else(|| self.scene.motions.iter().find(|m| m.name.as_lower_str().contains("idle")))
-                .or_else(|| self.scene.motions.iter().find(|m| m.name == skel.name));
-            let Some(reference) = reference else { continue };
+            // A member may hold the rig with NO motion at all: AreaZero keeps each
+            // robot in its own cast member and every clip in a member of its own,
+            // then clones both into the level at runtime. Frame 0 of "no motion" is
+            // the skeleton's REST pose, so that is what Director folds — and it has
+            // to, or `member("RobotGun").model("RobotGun").getWorldTransform()` (the
+            // transform the game copies onto every robot it spawns) comes back
+            // without the biped COM while the renderer still strips it. The robots
+            // then aim correctly and render 90 degrees off, because a 3ds-Max biped
+            // root sits at +90 about Z.
+            let reference = super::skeleton::import_root_com_motion(&self.scene, skel);
 
-            let posed = super::skeleton::build_bone_matrices(skel, Some(reference), 0.0);
+            let posed = super::skeleton::build_bone_matrices(skel, reference, 0.0);
             let Some(r0) = posed.first() else { continue };
             if is_identity_mat4(r0) { continue; }
 
-            fixups.push((i, *r0));
+            fixups.push((i, *r0, reference.map(|m| m.name)));
         }
 
-        for (i, r0) in fixups {
+        for (i, r0, reference) in fixups {
             let name = self.scene.nodes[i].name.to_ascii_lowercase();
-            log(&format!("  Root COM folded into model node {:?}", self.scene.nodes[i].name));
+            log(&format!("  Root COM folded into model node {:?} (from {})",
+                self.scene.nodes[i].name,
+                reference.map(|n| n.as_str()).unwrap_or("the rest pose")));
             self.scene.nodes[i].transform = mat4_mul(&self.scene.nodes[i].transform, &r0);
             self.scene.model_root_com.insert(name, r0);
         }

--- a/vm-rust/src/director/chunks/w3d/skeleton.rs
+++ b/vm-rust/src/director/chunks/w3d/skeleton.rs
@@ -30,8 +30,65 @@ pub fn default_motion_for_model<'a>(scene: &'a W3dScene, model_name: Symbol) -> 
     scene.motions.iter()
         .find(|m| m.name == skeleton.name)
         .or_else(|| scene.motions.iter().find(|m| {
-            m.tracks.len() > 1 && !m.name.eq_ignore_ascii_case("DefaultMotion")
+            m.tracks.len() > 1
+                && !m.name.eq_ignore_ascii_case("DefaultMotion")
+                && motion_drives_skeleton(skeleton, m)
         }))
+}
+
+/// True when `motion` was authored for `skeleton` — at least one of its tracks
+/// names a bone of this rig.
+///
+/// A member's motion table is scene-global, and a game that clones several rigs
+/// plus all their clips into one member has many motions that drive OTHER
+/// skeletons. Sampling one of those leaves every bone on its rest TRS (no track
+/// name matches), which reads as a plausible pose and is silently wrong.
+pub fn motion_drives_skeleton(skeleton: &W3dSkeleton, motion: &W3dMotion) -> bool {
+    motion.tracks.iter().any(|t| skeleton.bones.iter().any(|b| b.name == t.bone_name))
+}
+
+/// The rig's authored idle, whose frame-0 root is the reference the renderer
+/// relativizes a skinned draw by (`[root-relativize]` in `scene3d.rs`).
+///
+/// Restricted to motions that drive this skeleton's ROOT bone: that is what the
+/// caller samples, and it is the authoritative ownership test. AreaZero's level
+/// member holds RobotGun, RobotMelee, RobotFrog and RobotTank with every clip
+/// cloned in beside them, so an unfiltered "first motion whose name contains
+/// idle" hands three of the four rigs a clip that cannot move them — it samples
+/// to the rest TRS and reads as a plausible pose.
+///
+/// Deliberately narrower than `import_root_com_for_skeleton`: falling back to the
+/// rig's like-named motion here would start relativizing draws that were never
+/// relativized before, and a model whose node does NOT carry the fold (a clone
+/// the game positions itself) would then be rotated by the COM. Agent Free Ride
+/// 2's rider is exactly that — it sat 90 degrees across its jetski.
+pub fn idle_reference_motion<'a>(
+    scene: &'a W3dScene,
+    skeleton: &W3dSkeleton,
+) -> Option<&'a W3dMotion> {
+    let root = skeleton.bones.first()?.name;
+    let own = || scene.motions.iter()
+        .filter(move |m| m.tracks.iter().any(|t| t.bone_name == root));
+    own().find(|m| m.name.as_lower_str().contains("idle_rest"))
+        .or_else(|| own().find(|m| m.name.as_lower_str().contains("idle")))
+}
+
+/// Frame 0 of the motion Director samples to fold a skinned model's biped COM
+/// into its model node at import (`apply_root_com_to_model_nodes`).
+///
+/// `None` means "no clip for this rig in this member" — and frame 0 of no motion
+/// is the skeleton's REST pose, which is what the caller then samples. Director
+/// folds that too: AreaZero keeps each robot in its own cast member with zero
+/// MOTION_BLOCKs and every clip in a member of its own, and without the rest-pose
+/// fold `member("RobotGun").model("RobotGun").getWorldTransform()` — the transform
+/// the game copies onto every robot it spawns — comes back without the COM.
+pub fn import_root_com_motion<'a>(
+    scene: &'a W3dScene,
+    skeleton: &W3dSkeleton,
+) -> Option<&'a W3dMotion> {
+    let root = match skeleton.bones.first() { Some(b) => b.name, None => return None };
+    idle_reference_motion(scene, skeleton).or_else(|| scene.motions.iter()
+        .find(|m| m.name == skeleton.name && m.tracks.iter().any(|t| t.bone_name == root)))
 }
 
 pub fn has_meaningful_translation(x: f32, y: f32, z: f32) -> bool {

--- a/vm-rust/src/player/font/mod.rs
+++ b/vm-rust/src/player/font/mod.rs
@@ -1115,10 +1115,25 @@ pub fn pfr_strike_vertical_metrics(
 /// therefore stepped 25 px between 9 px lines, which is what blew Habbo v31's
 /// catalogue page text apart (`ctlg_header_text`: fls=0, char_h=26).
 ///
-/// Scan the strike's real vertical ink extent (cap top → descender bottom)
-/// instead — for a pixel font that IS ascent + descent. Falls back to the
-/// historical `min(cell, nominal × 1.5)` cap when the strike has no scannable
-/// ink (non-PFR atlases, or a font whose sample glyphs are all blank).
+/// Scan the strike instead — but measure from the LINE TOP to the descender
+/// bottom (`desc_bottom + 1`), not across the ink extent
+/// (`desc_bottom - cap_top + 1`). The renderer anchors each line's atlas CELL
+/// TOP at the line top and deliberately keeps the ascent-to-cap gap (see the
+/// anchoring rationale in `text.rs`), so a line's ink occupies
+/// `[cap_top, desc_bottom]` and the box has to reach `desc_bottom + 1`.
+///
+/// Measuring the extent dropped exactly `cap_top` rows PER LINE, which cut the
+/// descenders off `y p q j` in every Habbo chat bubble: Volter-9 scans
+/// `cap_top = 1, desc_bottom = 9`, so the bubble's auto-leading text member was
+/// sized 9 for ink that reaches row 9 inclusive. This is the same rule the
+/// outline path uses (`pfr_outline_auto_line_height`, ascender − descender) —
+/// both span the line box, not the ink.
+///
+/// Still well under the padded cell, so Habbo v31's catalogue text keeps its
+/// ~10 px lines rather than the 25 px `char_height - 1` produced.
+///
+/// Falls back to the historical `min(cell, nominal × 1.5)` cap when the strike
+/// has no scannable ink (non-PFR atlases, or all-blank sample glyphs).
 ///
 /// Shared by `.rect`, `.height` and both halves of `.image` (measure + render)
 /// so all four agree: Habbo's window Text-Wrapper bakes with
@@ -1137,13 +1152,80 @@ pub fn pfr_auto_line_height(
     if let Some(fb) = font_bitmap {
         if let (Some(cap_top), Some(desc_bottom)) = pfr_strike_vertical_metrics(font, fb) {
             if desc_bottom >= cap_top {
-                let extent = (desc_bottom - cap_top + 1) as u16;
-                return extent.clamp(1, cell_h.max(1));
+                let line = (desc_bottom + 1) as u16;
+                return line.clamp(1, cell_h.max(1));
             }
         }
     }
     let nominal_capped = (nominal as f32 * 1.5).round() as u16;
     cell_h.min(nominal_capped).max(1)
+}
+
+/// Paige auto leading as the OUTLINE renderer actually steps it: the font's own
+/// `ascender - descender`, scaled to the requested size.
+///
+/// This is the authoritative rule — "auto derives the line from the FONT's
+/// ascent + descent" — and `render_pfr_outline_text_to_bitmap` has always used
+/// it (`line_natural`). The measure side used a scanned strike ink extent
+/// instead, which is SHORTER by the gap above cap height, so every box came out
+/// `cap_top` per line too small and the last line was clipped. Spectral Wizard's
+/// speech bubbles lost the bottom of their final line that way: Comic Sans MS
+/// steps 17 px/line, the box was built on 14, and four lines needed 68 rows in a
+/// 59-row bitmap.
+///
+/// Returns `None` when the font has no usable outline metrics, in which case the
+/// caller falls back to `pfr_auto_line_height`'s strike scan.
+pub fn pfr_outline_auto_line_height(
+    parsed: &crate::director::chunks::pfr1::types::Pfr1ParsedFont,
+    font_size: u16,
+) -> Option<u16> {
+    let res = parsed.physical_font.outline_resolution as f64;
+    if res <= 0.0 || font_size == 0 {
+        return None;
+    }
+    let m = &parsed.physical_font.metrics;
+    let lh = (((m.ascender - m.descender) as f64) * (font_size as f64 / res)).round();
+    if lh >= 1.0 { Some(lh as u16) } else { None }
+}
+
+/// `pfr_outline_auto_line_height` for the font a text member names, resolved the
+/// same way `.image` resolves its outline font: a PFR with real outlines, no
+/// bitmap strikes, and not a pixel font (those stay on the crisp atlas path and
+/// keep the strike-scan rule).
+///
+/// Shared by `.rect`, `.height` and `.image` so all three size a box for the
+/// number of lines the renderer will actually draw.
+pub fn outline_auto_line_height_for_font(
+    player: &crate::player::DirPlayer,
+    font_name: &str,
+    font_size: u16,
+) -> Option<u16> {
+    if font_name.is_empty() {
+        return None;
+    }
+    let lc = font_name.to_ascii_lowercase();
+    let canon = FontManager::canonical_font_name(font_name);
+    for cast in &player.movie.cast_manager.casts {
+        for m in cast.members.values() {
+            let crate::player::cast_member::CastMemberType::Font(fd) = &m.member_type else {
+                continue;
+            };
+            let matches = fd.font_info.name.to_lowercase() == lc
+                || m.name.to_lowercase() == lc
+                || (!canon.is_empty()
+                    && (FontManager::canonical_font_name(&fd.font_info.name) == canon
+                        || FontManager::canonical_font_name(&m.name) == canon));
+            if !matches {
+                continue;
+            }
+            if let Some(p) = &fd.pfr_parsed {
+                if !p.glyphs.is_empty() && p.bitmap_glyphs.is_empty() && !p.is_pixel_font {
+                    return pfr_outline_auto_line_height(p, font_size);
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Extra rows a PFR text `.image`/`.rect` must reserve BELOW its

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -664,11 +664,13 @@ impl TextMemberHandlers {
                     let line_h = if text_data.fixed_line_space > 0 {
                         text_data.fixed_line_space
                     } else {
-                        crate::player::font::pfr_auto_line_height(
+                        crate::player::font::outline_auto_line_height_for_font(
+                            player, &text_data.font, nominal,
+                        ).unwrap_or_else(|| crate::player::font::pfr_auto_line_height(
                             &font,
                             player.bitmap_manager.get_bitmap(font.bitmap_ref),
                             nominal,
-                        )
+                        ))
                     };
                     // Match the renderer's per-line advance at font.rs:921 —
                     // it adds top_spacing AND bottom_spacing to the line step
@@ -873,11 +875,13 @@ impl TextMemberHandlers {
                         let line_h = if text_data.fixed_line_space > 0 {
                             text_data.fixed_line_space
                         } else {
-                            crate::player::font::pfr_auto_line_height(
+                            crate::player::font::outline_auto_line_height_for_font(
+                                player, &text_data.font, nominal,
+                            ).unwrap_or_else(|| crate::player::font::pfr_auto_line_height(
                                 &font,
                                 player.bitmap_manager.get_bitmap(font.bitmap_ref),
                                 nominal,
-                            )
+                            ))
                         };
                         // See `.rect` getter for rationale on folding
                         // top_spacing + bottom_spacing into line_step.
@@ -889,7 +893,7 @@ impl TextMemberHandlers {
                             + text_data.top_spacing as i32
                             + text_data.bottom_spacing as i32;
                         (text_data.top_spacing as i32
-                            + line_h as i32
+                                + line_h as i32
                             + (line_count as i32 - 1) * line_step)
                             .max(0) as u16
                     };
@@ -1459,11 +1463,13 @@ impl TextMemberHandlers {
                     let line_h = if text_data.fixed_line_space > 0 {
                         text_data.fixed_line_space
                     } else {
-                        crate::player::font::pfr_auto_line_height(
+                        crate::player::font::outline_auto_line_height_for_font(
+                            player, &text_data.font, nominal,
+                        ).unwrap_or_else(|| crate::player::font::pfr_auto_line_height(
                             &font,
                             player.bitmap_manager.get_bitmap(font.bitmap_ref),
                             nominal,
-                        )
+                        ))
                     };
                     // See `.rect` getter for rationale on folding
                     // top_spacing + bottom_spacing into line_step.
@@ -1844,9 +1850,13 @@ impl TextMemberHandlers {
                         } else {
                             font.char_height
                         };
-                        (crate::player::font::pfr_auto_line_height(
+                        // Same rule as the measure pass above, so the atlas path
+                        // can't drift from the box it was given.
+                        (crate::player::font::outline_auto_line_height_for_font(
+                            player, &text_data.font, nominal,
+                        ).unwrap_or_else(|| crate::player::font::pfr_auto_line_height(
                             &font, Some(font_bitmap), nominal,
-                        ) as i32).max(1)
+                        )) as i32).max(1)
                     };
 
                     // Get char_spacing from styled spans (XMED data)

--- a/vm-rust/src/player/xtra/multiuser/mod.rs
+++ b/vm-rust/src/player/xtra/multiuser/mod.rs
@@ -346,7 +346,28 @@ impl MultiuserXtraManager {
                         if let Some(instance) = manager.instances.get_mut(&instance_id) {
                             match instance.connection_mode {
                                 MultiuserConnectionMode::Text => {
-                                    let message_str = message_bytes.into_iter().map(|b| b as char).collect::<String>();
+                                    // A Unicode Director (11.5) Multiuser Xtra hands
+                                    // the movie UNICODE text — it decodes the wire
+                                    // itself. Habbo relies on that: `String Services
+                                    // Class.decodeUTF8` opens with
+                                    //   `if pUnicodeDirector and not tForceDecode then return tStr`
+                                    // and `pUnicodeDirector` is 1 whenever
+                                    // `_player.productVersion >= 11`, so the client
+                                    // deliberately does NOT decode incoming chat.
+                                    //
+                                    // Mapping each byte to a char (Latin-1) therefore
+                                    // surfaced the server's UTF-8 verbatim: `ö` came
+                                    // back as `C3 B6` and rendered as two characters,
+                                    // which is the `ÄÖÄÖ` garbling in v26/v31 chat.
+                                    // v7 predates all of this (`pUnicodeDirector = 0`,
+                                    // no `encodeUTF8`) and sends plain Latin-1, so it
+                                    // never showed the fault.
+                                    //
+                                    // `decode_text_auto` decodes valid UTF-8 as UTF-8
+                                    // and falls back to per-byte for anything else, so
+                                    // a Latin-1 server (v7) is untouched.
+                                    let message_str =
+                                        crate::io::encoding::decode_text_auto(&message_bytes);
                                     instance.dispatch_message(MultiuserMessage {
                                         error_code: 0,
                                         recipients: vec!["*".to_string()],
@@ -549,7 +570,13 @@ impl MultiuserXtraManager {
                         let msg_bytes = match instance.connection_mode {
                             MultiuserConnectionMode::Text => {
                                 let msg_data = player.get_datum(args.get(2).unwrap());
-                                msg_data.string_value()?.chars().map(|c| c as u8).collect::<Vec<u8>>()
+                                let s = msg_data.string_value()?;
+                                // Mirror of the receive side: a Unicode Director's
+                                // Multiuser Xtra puts UTF-8 on the wire. Truncating
+                                // each char to a byte (`c as u8`) silently mangled
+                                // anything outside Latin-1 and disagreed with what the
+                                // server sends back.
+                                s.into_bytes()
                             }
                             MultiuserConnectionMode::Binary => {
                                 let subject = player.get_datum(args.get(1).unwrap()).string_value()?;

--- a/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/scene3d.rs
@@ -4977,10 +4977,13 @@ void main() {
         // (the per-frame posed root removed the run's small turn too → bots looked
         // "slightly off while moving"). The bot mesh is authored at "Idle_Rest", so use
         // that motion's frame-0 root as the fixed reference; models with no idle motion
-        // (dino/frog) fall back to the per-frame posed root (idle-dominant → no residual).
-        let idle_root_mats = scene.motions.iter()
-            .find(|m| m.name.to_ascii_lowercase().contains("idle_rest"))
-            .or_else(|| scene.motions.iter().find(|m| m.name.to_ascii_lowercase().contains("idle")))
+        // (dino/frog) get no relativization at all.
+        //
+        // The idle MUST be one that drives THIS rig — `scene.motions` is a member-wide
+        // table and a game can clone several skeletons plus all their clips into one
+        // member. Keep this to an authored idle: it is a FALLBACK for models whose fold
+        // was not recorded, and widening it relativizes draws that never were.
+        let idle_root_mats = crate::director::chunks::w3d::skeleton::idle_reference_motion(scene, skeleton)
             .map(|im| crate::director::chunks::w3d::skeleton::build_bone_matrices(skeleton, Some(im), 0.0));
         // Only models with an idle-rest motion (the biped actors/bots) are relativized;
         // everything else (dino, frog01, ClubMarian, …) keeps the original skin — no

--- a/vm-rust/tests/browser_templates/dirplayer-js-api.js
+++ b/vm-rust/tests/browser_templates/dirplayer-js-api.js
@@ -8,6 +8,7 @@ export function onCastMemberChanged() {}
 export function onScoreChanged() {}
 export function onChannelChanged() {}
 export function onChannelDisplayNameChanged() {}
+export function onChannelDisplayNamesChanged() {}
 export function onFrameChanged() {}
 export function onScriptError(data) {
   const msg = data?.message || JSON.stringify(data);


### PR DESCRIPTION
7dddc2a5 | w3d — rest-pose COM fold; separate fold/strip priority lists; root-bone filter on reference motions
-- | --
56b44f52 | text — auto leading spans the line box (outline: ascender − descender; strike: desc_bottom + 1)
0606d5ae | multiuser — UTF-8 on the wire in both directions