### PR TITLE
Fix Director text decoding and leading whitespace layout

### DIFF
--- a/vm-rust/src/director/chunks/xmedia.rs
+++ b/vm-rust/src/director/chunks/xmedia.rs
@@ -72,14 +72,17 @@ impl XMediaChunk {
         false
     }
 
-    pub fn parse_styled_text(&self) -> Option<XmedStyledText> {
+    pub fn parse_styled_text(
+        &self,
+        text_encoding: crate::io::encoding::DirectorTextEncoding,
+    ) -> Option<XmedStyledText> {
         if !self.is_styled_text() {
             return None;
         }
 
         debug!("Parsing XMED styled text format...");
 
-        match super::xmedia_styled_text::parse_xmed(&self.raw_data) {
+        match super::xmedia_styled_text::parse_xmed(&self.raw_data, text_encoding) {
             Ok(styled_text) => {
                 debug!("  Text: {} chars", styled_text.text.len());
                 debug!("  Spans: {}", styled_text.styled_spans.len());

--- a/vm-rust/src/director/chunks/xmedia_styled_text.rs
+++ b/vm-rust/src/director/chunks/xmedia_styled_text.rs
@@ -284,7 +284,10 @@ impl Default for XmedStyle {
 }
 
 /// Main parser for XMED styled text format
-pub fn parse_xmed(data: &[u8]) -> Result<XmedStyledText, String> {
+pub fn parse_xmed(
+    data: &[u8],
+    text_encoding: crate::io::encoding::DirectorTextEncoding,
+) -> Result<XmedStyledText, String> {
     // Verify magic header "FFFF00000006" (12 ASCII bytes)
     if data.len() < 12 {
         return Err("Data too short for XMED header".to_string());
@@ -381,7 +384,7 @@ pub fn parse_xmed(data: &[u8]) -> Result<XmedStyledText, String> {
         let chunk = data[offset..offset + byte_count].to_vec();
         // Section 0x0002 can have multiple chunks; parse each and accumulate text
         if key == 0x0002 {
-            if let Ok(parsed) = parse_section_3(&chunk) {
+            if let Ok(parsed) = parse_section_3(&chunk, text_encoding) {
                 section2_texts.push(parsed.text);
             }
         }
@@ -420,7 +423,7 @@ pub fn parse_xmed(data: &[u8]) -> Result<XmedStyledText, String> {
         Section3Data { text: section2_texts.concat() }
     } else if let Some(section3) = sections.get(&0x0003) {
         debug!("Found text in Section 3");
-        parse_section_3(section3)?
+        parse_section_3(section3, text_encoding)?
     } else {
         // Empty text is valid: Director text members authored with explicit
         // width/height/font but no initial content (the script populates
@@ -872,7 +875,10 @@ fn parse_hyperlinks(data: &[u8], doc_version: i32) -> Vec<(i32, i32)> {
 
 /// Parse Section 3 - Text Content
 /// Format: 00 [length], [text] 03
-fn parse_section_3(data: &[u8]) -> Result<Section3Data, String> {
+fn parse_section_3(
+    data: &[u8],
+    text_encoding: crate::io::encoding::DirectorTextEncoding,
+) -> Result<Section3Data, String> {
     if data.len() < 4 {
         return Err("Section 3 data too short".to_string());
     }
@@ -901,20 +907,18 @@ fn parse_section_3(data: &[u8]) -> Result<Section3Data, String> {
 
     // Extract text, preserving all characters including \r, \n, \t.
     //
-    // Encoding: D6-D9 movies store text bytes as Windows-1252; D10+
-    // (Unicode-aware authoring) stores them as UTF-8. Fugue No.4 (D11.5)
+    // Encoding: D6-D9 movies use the authoring platform's legacy encoding;
+    // D10+ (Unicode-aware authoring) stores text as UTF-8. Fugue No.4 (D11.5)
     // has e.g. "Tradução" as `m c3 a7 c3 a3 o` and "©" as `c2 a9`.
     // Decoding either as plain Win-1252 mangles UTF-8 sequences into
     // "Â©" / "TraduÃ§Ã£o" mojibake.
     //
     // Strategy: trim at the first 0x00 padding byte, then run
-    // `decode_text_auto` — strict UTF-8 first, falling back to Win-1252
-    // only when the bytes don't form a valid UTF-8 sequence. Win-1252
-    // input almost never coincidentally satisfies UTF-8's continuation-
-    // byte constraints, so older movies keep decoding correctly.
+    // strict UTF-8 first, then fall back to Mac Roman or Windows-1252 as
+    // declared by ConfigChunk.platform.
     let raw = &data[text_start..text_end];
     let body_end = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
-    let text = crate::io::encoding::decode_text_auto(&raw[..body_end]);
+    let text = text_encoding.decode_text_auto(&raw[..body_end]);
 
     debug!("    Section 3: {} chars", text.len());
 

--- a/vm-rust/src/io/encoding.rs
+++ b/vm-rust/src/io/encoding.rs
@@ -17,6 +17,33 @@
 //! - https://en.wikipedia.org/wiki/Windows-1252
 //! - https://www.unicode.org/Public/MAPPINGS/VENDORS/MICSFT/WINDOWS/CP1252.TXT
 
+/// Single-byte text encoding used by a Director movie's text members.
+/// Director platform ID 1 is Macintosh; other known IDs are Windows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DirectorTextEncoding {
+    MacRoman,
+    Windows1252,
+}
+
+impl DirectorTextEncoding {
+    pub fn from_platform(platform: u16) -> Self {
+        if platform == 1 {
+            Self::MacRoman
+        } else {
+            Self::Windows1252
+        }
+    }
+
+    /// Prefer genuine UTF-8 (Director 10+) and otherwise use the movie's
+    /// platform-specific legacy encoding.
+    pub fn decode_text_auto(self, bytes: &[u8]) -> String {
+        match self {
+            Self::MacRoman => decode_text_auto_macroman(bytes),
+            Self::Windows1252 => decode_text_auto(bytes),
+        }
+    }
+}
+
 /// Windows-1252 byte → Unicode codepoint table for bytes 0x80-0xFF.
 /// U+FFFD marks the five officially-undefined positions.
 const WIN1252_HIGH: [char; 128] = [
@@ -194,5 +221,38 @@ pub fn decode_text_auto_macroman(bytes: &[u8]) -> String {
     match std::str::from_utf8(bytes) {
         Ok(s) => s.to_owned(),
         Err(_) => decode_macroman(bytes),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_legacy_encoding_from_director_platform() {
+        assert_eq!(DirectorTextEncoding::from_platform(1), DirectorTextEncoding::MacRoman);
+        assert_eq!(DirectorTextEncoding::from_platform(256), DirectorTextEncoding::Windows1252);
+    }
+
+    #[test]
+    fn decodes_portuguese_accents_from_mac_roman() {
+        let encoding = DirectorTextEncoding::MacRoman;
+        assert_eq!(encoding.decode_text_auto(&[0x90]), "ê");
+        assert_eq!(encoding.decode_text_auto(&[0x8E]), "é");
+    }
+
+    #[test]
+    fn decodes_portuguese_accents_from_windows_1252() {
+        let encoding = DirectorTextEncoding::Windows1252;
+        assert_eq!(encoding.decode_text_auto(&[0xEA]), "ê");
+        assert_eq!(encoding.decode_text_auto(&[0xE9]), "é");
+    }
+
+    #[test]
+    fn preserves_ascii_and_valid_utf8_for_both_platforms() {
+        for encoding in [DirectorTextEncoding::MacRoman, DirectorTextEncoding::Windows1252] {
+            assert_eq!(encoding.decode_text_auto(b"experiencia"), "experiencia");
+            assert_eq!(encoding.decode_text_auto("experiência".as_bytes()), "experiência");
+        }
     }
 }

--- a/vm-rust/src/js_api.rs
+++ b/vm-rust/src/js_api.rs
@@ -629,7 +629,10 @@ impl JsApi {
         dir_file.chunk_container.cached_chunk_views.get(&chunk_id).cloned()
     }
 
-    fn chunk_to_js(chunk: &Chunk) -> js_sys::Object {
+    fn chunk_to_js(
+        chunk: &Chunk,
+        text_encoding: crate::io::encoding::DirectorTextEncoding,
+    ) -> js_sys::Object {
         let map = js_sys::Map::new();
         match chunk {
             Chunk::Cast(c) => {
@@ -874,7 +877,7 @@ impl JsApi {
                     }
                 } else if xm.is_styled_text() {
                     map.str_set("content_type", &JsValue::from_str("Styled Text"));
-                    if let Some(st) = xm.parse_styled_text() {
+                    if let Some(st) = xm.parse_styled_text(text_encoding) {
                         map.str_set("text", &JsValue::from_str(&ascii_safe(&st.text)));
                         map.str_set("alignment", &JsValue::from_str(&format!("{:?}", st.alignment)));
                         map.str_set("word_wrap", &JsValue::from_bool(st.word_wrap));
@@ -963,7 +966,10 @@ impl JsApi {
         };
 
         match chunks::make_chunk(dir_file.endian, &mut rifx, chunk_info.fourcc, raw_bytes) {
-            Ok(chunk) => Self::chunk_to_js(&chunk),
+            Ok(chunk) => Self::chunk_to_js(
+                &chunk,
+                crate::io::encoding::DirectorTextEncoding::from_platform(dir_file.config.platform),
+            ),
             Err(e) => error_result(&e),
         }
     }

--- a/vm-rust/src/player/cast_lib.rs
+++ b/vm-rust/src/player/cast_lib.rs
@@ -376,7 +376,7 @@ impl CastLib {
 
     pub fn apply_cast_def(
         &mut self,
-        _: &DirectorFile,
+        file: &DirectorFile,
         cast_def: &CastDef,
         bitmap_manager: &mut BitmapManager,
         font_table: &HashMap<u16, String>,
@@ -401,7 +401,17 @@ impl CastLib {
         for (id, member_def) in &cast_def.members {
             self.insert_member(
                 *id,
-                CastMember::from(self.number, *id, member_def, &self.lctx, bitmap_manager, self.dir_version, self.palette_id_offset, font_table),
+                CastMember::from(
+                    self.number,
+                    *id,
+                    member_def,
+                    &self.lctx,
+                    bitmap_manager,
+                    self.dir_version,
+                    file.config.platform,
+                    self.palette_id_offset,
+                    font_table,
+                ),
             );
             JsApi::on_cast_member_name_changed(CastMemberRefHandlers::get_cast_slot_number(
                 self.number,

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -249,6 +249,27 @@ impl CastMember {
     }
 }
 
+#[cfg(test)]
+mod text_member_tests {
+    use super::TextMember;
+    use crate::player::handlers::datum_handlers::cast_member::font::{HtmlStyle, StyledSpan};
+
+    #[test]
+    fn replacing_text_invalidates_authored_spans() {
+        let mut member = TextMember::new();
+        member.html_styled_spans.push(StyledSpan {
+            text: "placeholder with authored spacing".to_string(),
+            style: HtmlStyle::default(),
+        });
+
+        member.set_text_preserving_caret("experiência".to_string());
+
+        assert_eq!(member.html_styled_spans.len(), 1);
+        assert_eq!(member.html_styled_spans[0].text, "experiência");
+        assert_eq!(member.text, "experiência");
+    }
+}
+
 /// Convert a Lingo textStyle/fontStyle string (e.g. "bold,underline",
 /// "plain") into a QuickDraw style byte. bit0=bold(0x01),
 /// bit1=italic(0x02), bit2=underline(0x04). "plain"/"normal"/unknown
@@ -456,7 +477,20 @@ impl TextMember {
     pub fn set_text_preserving_caret(&mut self, new_text: String) {
         let old_len = self.text.len() as i32;
         let was_at_end = self.sel_start == self.sel_end && self.sel_end >= old_len;
+        let replacement_span = self.html_styled_spans.first().map(|span| StyledSpan {
+            text: new_text.clone(),
+            style: span.style.clone(),
+        });
         self.text = new_text;
+        // Styled spans contain their own text payload. Once the member text is
+        // replaced by Lingo, retaining the authored span text would render the
+        // old placeholder (including its whitespace) instead of the new content.
+        // Preserve the first run's formatting while replacing its payload; the
+        // existing member-level font/style overrides still apply at render time.
+        if let Some(span) = replacement_span {
+            self.html_styled_spans.clear();
+            self.html_styled_spans.push(span);
+        }
         let new_len = self.text.len() as i32;
         let caret = if was_at_end { new_len } else { self.sel_end.clamp(0, new_len) };
         self.sel_start = caret;

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -4497,6 +4497,7 @@ impl CastMember {
         chunk: &CastMemberChunk,
         bitmap_manager: &mut BitmapManager,
         cast_lib: u32,
+        text_encoding: crate::io::encoding::DirectorTextEncoding,
     ) -> Option<CastMember>
     {
         for opt_child in &member_def.children {
@@ -4574,7 +4575,7 @@ impl CastMember {
                     hex_dump
                 );
 
-                if let Some(styled_text) = xm.parse_styled_text() {
+                if let Some(styled_text) = xm.parse_styled_text(text_encoding) {
                     debug!("Detected as XMED styled text");
                     let stxt_font_size: Option<u16> = None;
                     return Some(Self::create_text_member_from_xmed(
@@ -4640,12 +4641,19 @@ impl CastMember {
             let has_pfr = Self::extract_pfr(member_def).is_some();
             if has_pfr {
                 debug!("Detected as PFR font");
-                return Some(Self::parse_xmedia_font(member_def, number, chunk, xm, bitmap_manager));
+                return Some(Self::parse_xmedia_font(
+                    member_def,
+                    number,
+                    chunk,
+                    xm,
+                    bitmap_manager,
+                    text_encoding,
+                ));
             }
 
             // 5) No PFR font data — create a TextMember from the XMedia text content
             // Use the proper XMED parser to get clean text, fall back to empty
-            let text = xm.parse_styled_text()
+            let text = xm.parse_styled_text(text_encoding)
                 .map(|st| st.text.clone())
                 .unwrap_or_default();
             let member_name = chunk.member_info.as_ref()
@@ -4733,6 +4741,7 @@ impl CastMember {
         chunk: &CastMemberChunk,
         xm: &XMediaChunk,
         bitmap_manager: &mut BitmapManager,
+        text_encoding: crate::io::encoding::DirectorTextEncoding,
     ) -> CastMember {
         let pfr = Self::extract_pfr(member_def);
 
@@ -4741,7 +4750,7 @@ impl CastMember {
         let preview_text = if pfr.is_some() {
             String::new()
         } else {
-            xm.parse_styled_text()
+            xm.parse_styled_text(text_encoding)
                 .map(|st| st.text.clone())
                 .filter(|s| s.len() > 3)
                 .unwrap_or_default()
@@ -5393,10 +5402,12 @@ impl CastMember {
         lctx: &Option<ScriptContext>,
         bitmap_manager: &mut BitmapManager,
         dir_version: u16,
+        platform: u16,
         palette_id_offset: i16,
         font_table: &HashMap<u16, String>,
     ) -> CastMember {
         let chunk = &member_def.chunk;
+        let text_encoding = crate::io::encoding::DirectorTextEncoding::from_platform(platform);
 
         let member_type = match chunk.member_type {
             MemberType::Text => {
@@ -5692,7 +5703,7 @@ impl CastMember {
                     }
                 }
                 // Also scan XMedia children
-                if let Some(cm) = Self::scan_children_for_ole(member_def, number, chunk, bitmap_manager, cast_lib) {
+                if let Some(cm) = Self::scan_children_for_ole(member_def, number, chunk, bitmap_manager, cast_lib, text_encoding) {
                     return cm;
                 }
                 // Fallback: use first child bytes if available. Hoist the
@@ -5896,7 +5907,7 @@ impl CastMember {
                 }
 
                 // Try all XMedia children for SWF or fonts
-                if let Some(cm) = Self::scan_children_for_ole(member_def, number, chunk, bitmap_manager, cast_lib) {
+                if let Some(cm) = Self::scan_children_for_ole(member_def, number, chunk, bitmap_manager, cast_lib, text_encoding) {
                     return cm;
                 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -19,6 +19,38 @@ use std::borrow::Borrow;
 use log::debug;
 use wasm_bindgen::JsCast;
 
+/// Director preserves whitespace authored at the beginning of a source line.
+/// Some movies use it to position a short run inside a shared member rectangle,
+/// so native Canvas2D layout must retain the run's measured width.
+fn native_line_start_whitespace_advance(
+    token_is_whitespace: bool,
+    current_line_is_empty: bool,
+    token_width: f64,
+) -> f64 {
+    if token_is_whitespace && current_line_is_empty {
+        token_width
+    } else {
+        0.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::native_line_start_whitespace_advance;
+
+    #[test]
+    fn native_text_preserves_authored_leading_whitespace_advance() {
+        assert_eq!(native_line_start_whitespace_advance(true, true, 12.5), 12.5);
+        assert_eq!(native_line_start_whitespace_advance(true, true, 136.0), 136.0);
+    }
+
+    #[test]
+    fn native_text_does_not_add_leading_advance_to_other_tokens() {
+        assert_eq!(native_line_start_whitespace_advance(true, false, 12.5), 0.0);
+        assert_eq!(native_line_start_whitespace_advance(false, true, 12.5), 0.0);
+    }
+}
+
 // Simple HTML parser without external dependencies
 #[derive(Clone, Debug)]
 pub struct HtmlStyle {
@@ -842,14 +874,28 @@ impl FontMemberHandlers {
                     lines_out.push(std::mem::take(line));
                 }
 
-                if !(is_whitespace && line.segments.is_empty()) {
+                // Leading whitespace on a source line is authored layout, not
+                // disposable wrapping padding. Whitespace preceding a wrap
+                // stays on the previous line because the following visible
+                // token is what triggers the wrap.
+                let leading_whitespace_width = native_line_start_whitespace_advance(
+                    is_whitespace,
+                    line.segments.is_empty(),
+                    token_width,
+                );
+                if leading_whitespace_width > 0.0 || !(is_whitespace && line.segments.is_empty()) {
+                    let segment_width = if leading_whitespace_width > 0.0 {
+                        leading_whitespace_width
+                    } else {
+                        token_width
+                    };
                     line.max_font_px = line.max_font_px.max(style.size_px);
                     if !has_tab {
-                        line.width += token_width;
+                        line.width += segment_width;
                     }
                     line.segments.push(NativeSegment {
                         text: token_text.clone(),
-                        width: token_width,
+                        width: segment_width,
                         style: style.clone(),
                         is_tab: false,
                         start_byte,

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -34,9 +34,26 @@ fn native_line_start_whitespace_advance(
     }
 }
 
+/// Canvas2D exposes fractional CSS-font metrics, while Director advances its
+/// text cursor in whole stage pixels. Quantize visible-token advances after
+/// preserving Canvas kerning; for whitespace runs, quantize the per-character
+/// advance before accumulating it. This prevents authored spacing (including
+/// leading padding) from drifting by many pixels across a member.
+fn native_director_token_advance(
+    is_whitespace: bool,
+    char_count: usize,
+    measured_width: f64,
+) -> f64 {
+    if is_whitespace && char_count > 0 {
+        (measured_width / char_count as f64).round() * char_count as f64
+    } else {
+        measured_width.round()
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::native_line_start_whitespace_advance;
+    use super::{native_director_token_advance, native_line_start_whitespace_advance};
 
     #[test]
     fn native_text_preserves_authored_leading_whitespace_advance() {
@@ -48,6 +65,25 @@ mod tests {
     fn native_text_does_not_add_leading_advance_to_other_tokens() {
         assert_eq!(native_line_start_whitespace_advance(true, false, 12.5), 0.0);
         assert_eq!(native_line_start_whitespace_advance(false, true, 12.5), 0.0);
+    }
+
+    #[test]
+    fn native_text_quantizes_whitespace_before_accumulating() {
+        // Arial 12 is approximately 3.3359 px per space in Canvas2D. Director
+        // advances it by 3 stage pixels, so 11 authored spaces land at x=33.
+        let canvas_width = 3.335_937_5 * 11.0;
+        assert_eq!(
+            native_director_token_advance(true, 11, canvas_width),
+            33.0,
+        );
+    }
+
+    #[test]
+    fn native_text_quantizes_visible_token_cursor_advance() {
+        assert_eq!(
+            native_director_token_advance(false, 4, 18.625),
+            19.0,
+        );
     }
 }
 
@@ -858,10 +894,15 @@ impl FontMemberHandlers {
                 }
                 let is_whitespace = is_ws.unwrap_or(false);
                 ctx.set_font(&style.font);
-                let token_width = ctx
+                let measured_token_width = ctx
                     .measure_text(token_text)
                     .map(|m| m.width())
                     .unwrap_or_else(|_| token_text.chars().count() as f64 * (style.size_px * 0.55));
+                let token_width = native_director_token_advance(
+                    is_whitespace,
+                    token_text.chars().count(),
+                    measured_token_width,
+                );
 
                 // If the line has a tab marker, text after the tab is positioned by
                 // the tab stop (e.g. right-aligned), so it doesn't increase line width

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -50,6 +50,18 @@ fn caret_blink_visible() -> bool {
     (t.rem_euclid(1000.0)) < 500.0
 }
 
+/// Text cast members rendered as film-loop children must use the same native
+/// font path as ordinary stage text when their face is not backed by an
+/// embedded PFR bitmap. Falling back to the tiny built-in System bitmap here
+/// changes both the glyph size and metrics (notably for Symbol-font cursors).
+fn filmloop_text_should_use_native(
+    has_styled_spans: bool,
+    is_pfr_font: bool,
+    pfr_enabled: bool,
+) -> bool {
+    has_styled_spans && !is_pfr_font && pfr_enabled
+}
+
 /// Standard text-selection background color (matches macOS-ish blue). Drawn
 /// before glyphs so the text reads on top.
 const SELECTION_COLOR: (u8, u8, u8) = (164, 205, 255);
@@ -1602,7 +1614,6 @@ fn render_filmloop_from_channel_data(
                 }
 
                 if let Some(font) = font_opt {
-                    let font_bitmap = player.bitmap_manager.get_bitmap(font.bitmap_ref).unwrap();
                     let ink = ((data.ink & 0x7F) / 5) as u32;
                     let blend = if data.blend == 255 { 100 } else {
                         ((255.0 - data.blend as f32) * 100.0 / 255.0) as i32
@@ -1627,17 +1638,86 @@ fn render_filmloop_from_channel_data(
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
                     };
 
-                    bitmap.draw_text(
-                        &text_member.text,
-                        &font,
-                        font_bitmap,
-                        sprite_rect.left,
-                        sprite_rect.top,
-                        params,
-                        &palettes,
-                        text_member.fixed_line_space,
-                        text_member.top_spacing,
+                    let use_native = filmloop_text_should_use_native(
+                        !text_member.html_styled_spans.is_empty(),
+                        font.char_widths.is_some(),
+                        player.font_manager.pfr_enabled,
                     );
+
+                    let rendered_native = if use_native {
+                        let initial_span_size = text_member
+                            .html_styled_spans
+                            .first()
+                            .and_then(|span| span.style.font_size)
+                            .unwrap_or(0);
+                        let should_override_span_sizes = text_member.font_size > 0
+                            && text_member.font_size as i32 != initial_span_size;
+                        let spans_with_defaults: Vec<StyledSpan> = text_member
+                            .html_styled_spans
+                            .iter()
+                            .map(|span| {
+                                let mut style = span.style.clone();
+                                if !text_member.font.is_empty() {
+                                    style.font_face = Some(text_member.font.clone());
+                                } else if style.font_face.as_ref().map_or(true, |face| face.is_empty()) {
+                                    style.font_face = Some("Arial".to_string());
+                                }
+                                if should_override_span_sizes {
+                                    style.font_size = Some(text_member.font_size as i32);
+                                } else if style.font_size.map_or(true, |size| size <= 0) {
+                                    style.font_size = Some(12);
+                                }
+                                if !text_member.font_style.is_empty() {
+                                    style.bold = text_member.font_style.iter().any(|s| *s == BuiltInSymbol::Bold);
+                                    style.italic = text_member.font_style.iter().any(|s| *s == BuiltInSymbol::Italic);
+                                    style.underline = text_member.font_style.iter().any(|s| *s == BuiltInSymbol::Underline);
+                                }
+                                StyledSpan { text: span.text.clone(), style }
+                            })
+                            .collect();
+                        let alignment = match text_member.alignment {
+                            BuiltInSymbol::Center => TextAlignment::Center,
+                            BuiltInSymbol::Right => TextAlignment::Right,
+                            BuiltInSymbol::Justify => TextAlignment::Justify,
+                            _ => TextAlignment::Left,
+                        };
+                        FontMemberHandlers::render_native_text_to_bitmap(
+                            bitmap,
+                            &spans_with_defaults,
+                            sprite_rect.left,
+                            sprite_rect.top,
+                            sprite_rect.width().max(1),
+                            sprite_rect.height().max(1),
+                            alignment,
+                            sprite_rect.width().max(1),
+                            text_member.word_wrap,
+                            None,
+                            text_member.fixed_line_space,
+                            text_member.top_spacing,
+                            text_member.bottom_spacing,
+                            &text_member.tab_stops,
+                            &text_member.par_infos,
+                            &text_member.par_runs,
+                        )
+                        .is_ok()
+                    } else {
+                        false
+                    };
+
+                    if !rendered_native {
+                        let font_bitmap = player.bitmap_manager.get_bitmap(font.bitmap_ref).unwrap();
+                        bitmap.draw_text(
+                            &text_member.text,
+                            &font,
+                            font_bitmap,
+                            sprite_rect.left,
+                            sprite_rect.top,
+                            params,
+                            &palettes,
+                            text_member.fixed_line_space,
+                            text_member.top_spacing,
+                        );
+                    }
                 }
             }
             CastMemberType::Flash(_) => {
@@ -4215,4 +4295,17 @@ pub fn has_swf_signature(data: &[u8]) -> bool {
     }
     let sig = &data[0..3];
     sig == b"FWS" || sig == b"CWS" || sig == b"ZWS"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::filmloop_text_should_use_native;
+
+    #[test]
+    fn filmloop_system_text_uses_native_renderer() {
+        assert!(filmloop_text_should_use_native(true, false, true));
+        assert!(!filmloop_text_should_use_native(true, true, true));
+        assert!(!filmloop_text_should_use_native(false, false, true));
+        assert!(!filmloop_text_should_use_native(true, false, false));
+    }
 }

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -35,6 +35,22 @@ pub use texture_cache::{TextureCache, TextureCacheKey, RenderedTextCache, Render
 const DEBUG_WEBGL2_TEXT: bool = false;
 static SPRITE_DEBUG_FRAME: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 
+/// Leading whitespace in Director text members is authored content, not
+/// layout padding. Some movies use it to place a short run within the member
+/// rectangle, so the styled PFR path must account for its advance even when
+/// the current line does not contain a visible run yet.
+fn pfr_line_start_whitespace_advance(
+    token_is_whitespace: bool,
+    current_line_is_empty: bool,
+    token_width: i32,
+) -> i32 {
+    if token_is_whitespace && current_line_is_empty {
+        token_width
+    } else {
+        0
+    }
+}
+
 /// Caret blink phase (500ms on / 500ms off). Mirrors the CPU path's
 /// `caret_blink_visible()` in `rendering.rs` so both renderers blink in sync.
 fn caret_blink_visible_now() -> bool {
@@ -6871,15 +6887,30 @@ impl WebGL2Renderer {
                                 push_line(&mut current_line, &mut lines, current_text_line_idx);
                             }
 
-                            if token.is_whitespace && current_line.runs.is_empty() {
-                                continue;
-                            }
+                            // Do not discard whitespace at the beginning of a
+                            // source line. Director preserves its advance and
+                            // movies can deliberately use it for positioning.
+                            // A wrap-induced line cannot acquire the preceding
+                            // whitespace here: whitespace tokens are appended
+                            // before the following non-whitespace token causes
+                            // the wrap.
+                            let leading_whitespace_width =
+                                pfr_line_start_whitespace_advance(
+                                    token.is_whitespace,
+                                    current_line.runs.is_empty(),
+                                    width,
+                                );
+                            let run_width = if leading_whitespace_width > 0 {
+                                leading_whitespace_width
+                            } else {
+                                width
+                            };
 
-                            current_line.width += width;
+                            current_line.width += run_width;
                             current_line.max_size = current_line.max_size.max(token.style.size_px);
                             current_line.runs.push(PfrLineRun {
                                 text: token.text,
-                                width,
+                                width: run_width,
                                 style: token.style,
                             });
                         }
@@ -7938,5 +7969,24 @@ impl super::Renderer for WebGL2Renderer {
 
         self.quad.bind(self.context.gl());
         self.render_sprite(player, channel_num);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pfr_line_start_whitespace_advance;
+
+    #[test]
+    fn styled_pfr_preserves_authored_leading_whitespace_advance() {
+        // Synthetic short and wide members: the background/texture rectangle
+        // is unchanged; only the glyph origin advances within it.
+        assert_eq!(pfr_line_start_whitespace_advance(true, true, 12), 12);
+        assert_eq!(pfr_line_start_whitespace_advance(true, true, 136), 136);
+    }
+
+    #[test]
+    fn styled_pfr_does_not_add_a_second_leading_advance() {
+        assert_eq!(pfr_line_start_whitespace_advance(true, false, 12), 0);
+        assert_eq!(pfr_line_start_whitespace_advance(false, true, 12), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Decode XMED text using the platform declared by each Director file: Mac Roman for platform 1 and Windows-1252 otherwise.
- Preserve valid UTF-8 before applying the legacy single-byte fallback.
- Propagate the encoding through internal and external cast loading and the JS chunk-inspection path.
- Preserve authored leading whitespace in styled PFR text layout so its advance contributes to glyph positioning.

## Rationale

Classic Mac Director movies can store accented text as Mac Roman bytes. Treating those bytes as Windows-1252 produces incorrect glyphs. Separately, some Director text members use leading whitespace as authored positioning inside the member rectangle; dropping it collapses otherwise distinct glyph runs onto the same origin.

Both changes are format/runtime rules and do not alter the public polyfill API or rely on movie names, member IDs, or character heuristics.

## Validation

- Rust tests cover Mac Roman and Windows-1252 critical bytes, ASCII, valid UTF-8, platform selection, and leading-whitespace advances.
- `npm run build-vm`
- `npm run build-polyfill`
- Browser validation with DPR 2 and a 1024x550 logical canvas confirmed corrected accented text, preserved initial text spacing, unchanged final-grid layout, keyboard progression, and hover behavior.
