### PR TITLE
Add flushInputEvents() as a no-op builtin

### DIFF
--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1137,6 +1137,9 @@ impl BuiltInHandlerManager {
             // synchronously up front, so there is nothing to (un)cache. Accept
             // as no-ops (netjack startMovie calls preLoadCast).
             Some(BuiltInSymbol::MoveToFront | BuiltInSymbol::PreloadMember | BuiltInSymbol::PreloadBuffer | BuiltInSymbol::UnloadMember | BuiltInSymbol::Beep | BuiltInSymbol::PreLoadCast | BuiltInSymbol::UnLoadCast | BuiltInSymbol::PreLoadMovie | BuiltInSymbol::UnLoad) => Ok(DatumRef::Void),
+            // Director's flushInputEvents() discards queued mouse/key events;
+            // the browser player has no such queue to flush.
+            Some(BuiltInSymbol::FlushInputEvents) => Ok(DatumRef::Void),
             Some(BuiltInSymbol::PuppetTempo) => MovieHandlers::puppet_tempo(args),
             Some(BuiltInSymbol::Objectp) => TypeHandlers::objectp(args),
             Some(BuiltInSymbol::Voidp) => TypeHandlers::voidp(args),

--- a/vm-rust/src/player/symbols/builtin.rs
+++ b/vm-rust/src/player/symbols/builtin.rs
@@ -439,6 +439,7 @@ define_builtin_symbols! {
     "preloadBuffer" => PreloadBuffer,
     "unloadMember" => UnloadMember,
     "beep" => Beep,
+    "flushInputEvents" => FlushInputEvents,
     "offset" => Offset,
     "param" => Param,
     "createMask" => CreateMask,


### PR DESCRIPTION
Adds `flushInputEvents()` as a no-op, per #236.

Director's `flushInputEvents()` only discards queued mouse/key events, and a browser-hosted player has no such queue — so accepting and ignoring it is the whole fix. `define_builtin_symbols!` generates the enum variant from the table, so the symbol entry plus one dispatch arm is all that is needed.

I gave it its own arm rather than appending to the existing no-op arm, whose comment specifically describes cast/movie preload commands. Happy to fold it in there instead if you would prefer.

**Repro:** Samurai Jack in Cavern Raid (Flashpoint `36ec1007-0b46-4bb6-91bb-30ef37301189`, entry `English/game.dcr`) calls it exactly once at startup — bytecode-verified, a single `extCall` in the whole movie. Without the symbol the movie stops there with `Script error: No built-in handler: flushInputEvents()` and a black stage; with it, the game starts.

**Verified:** `cargo check --target wasm32-unknown-unknown` is clean on this branch against `main`. Gameplay was verified on a `wasm-pack` build of `main` with this plus my two companion PRs applied — Samurai Jack plays through startup, door/room transitions and the minecart section.

Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)
