### PR TITLE
Accept StringChunk where String is accepted: chunk setProp, script()/member(), arithmetic

### DIFF
--- a/vm-rust/src/player/cast_manager.rs
+++ b/vm-rust/src/player/cast_manager.rs
@@ -517,6 +517,18 @@ impl CastManager {
             (Datum::String(name), None) => self
                 .find_member_ref_by_name(name)
                 .map(|member_ref| Ok(Some(member_ref))),
+            // A string chunk (`str.item[k]`) names a member too.
+            (Datum::StringChunk(_, _, name), Some(cast_lib)) => {
+                cast_lib.find_member_by_name(name).map(|member| {
+                    Ok(Some(CastMemberRef {
+                        cast_lib: cast_lib.number as i32,
+                        cast_member: member.number as i32,
+                    }))
+                })
+            }
+            (Datum::StringChunk(_, _, name), None) => self
+                .find_member_ref_by_name(name)
+                .map(|member_ref| Ok(Some(member_ref))),
             (Datum::Int(num), Some(cast_lib)) => {
                 cast_lib.find_member_by_number(*num as u32).map(|member| {
                     Ok(Some(CastMemberRef {

--- a/vm-rust/src/player/datum_operations.rs
+++ b/vm-rust/src/player/datum_operations.rs
@@ -131,6 +131,8 @@ fn list_to_rect_vals(player: &DirPlayer, list: &VecDeque<DatumRef>) -> Result<([
 fn symbol_as_arithmetic_operand(datum: &Datum) -> Option<Datum> {
     match datum {
         Datum::Symbol(name) => Some(Datum::String(name.clone().to_string())),
+        // A string chunk (`str.item[k]`) is a string operand.
+        Datum::StringChunk(_, _, text) => Some(Datum::String(text.clone())),
         _ => None,
     }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
@@ -550,6 +550,55 @@ impl StringChunkUtils {
 }
 
 impl StringChunkHandlers {
+    /// `chunk.setProp(#char|#word|#item|#line, start[, end], value)` —
+    /// Director MX dot-syntax assignment into a sub-chunk of a chunk-typed
+    /// receiver. Resolves the inner range against the receiver's current
+    /// text, splices the value in, and writes the receiver back so the
+    /// change lands in the originating String or member. Mirrors
+    /// `get_prop_inner`'s argument parsing.
+    pub fn set_prop_call(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        if args.len() < 3 {
+            return Err(ScriptError::new(
+                "setProp on a string chunk requires (chunkType, index[, last], value)".to_string(),
+            ));
+        }
+        let datum = datum.clone();
+        reserve_player_mut(|player| {
+            let (source, outer_expr, text) = match player.get_datum(&datum) {
+                Datum::StringChunk(s, e, t) => (s.clone(), e.clone(), t.clone()),
+                _ => {
+                    return Err(ScriptError::new(
+                        "setProp: receiver is not a string chunk".to_string(),
+                    ))
+                }
+            };
+            let prop_name = player.get_datum(&args[0]).symbol_value()?;
+            let start = player.get_datum(&args[1]).int_value()?;
+            let (end, value_ref) = if args.len() >= 4 {
+                (player.get_datum(&args[2]).int_value()?, &args[3])
+            } else {
+                (start, &args[2])
+            };
+            let value = player.get_datum(value_ref).string_value()?;
+            let inner = StringChunkExpr {
+                chunk_type: StringChunkType::from(prop_name),
+                start,
+                end,
+                item_delimiter: player.movie.item_delimiter,
+            };
+            let (cs, ce) = Self::resolve_chunk_char_range(&text, &inner);
+            let (bs, be) = char_range_to_byte_range(&text, cs, ce);
+            let mut new_text = text.clone();
+            new_text.replace_range(bs..be, &value);
+            // `set_contents`, not `set_value`: `set_value` ignores the chunk
+            // expression and replaces the entire source, which would truncate
+            // the field to just the chunk being written. `set_contents`
+            // splices `new_text` into the outer chunk range of the full source.
+            StringChunkUtils::set_contents(player, &source, &outer_expr, new_text)?;
+            Ok(DatumRef::Void)
+        })
+    }
+
     pub fn count(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
         reserve_player_mut(|player| {
             let value = player.get_datum(datum).string_value()?;
@@ -1124,6 +1173,7 @@ impl StringChunkHandlers {
                 }
             }
             Some(BuiltInSymbol::GetPropRef) => Self::get_prop_ref(datum, args),
+            Some(BuiltInSymbol::SetProp) => Self::set_prop_call(datum, args),
             Some(BuiltInSymbol::Delete) => Self::delete(datum, args),
             Some(BuiltInSymbol::SetContents) => Self::set_contents(datum, args),
             Some(BuiltInSymbol::SetContentsBefore) => Self::set_contents_before(datum, args),

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -34,6 +34,12 @@ impl MovieHandlers {
                     .cast_manager
                     .find_member_ref_by_number(*script_num as u32)),
                 Datum::CastMember(cast_member_ref) => Ok(Some(cast_member_ref.clone())),
+                // A string chunk (e.g. `str.item[1]`) names a script just as
+                // a String does.
+                Datum::StringChunk(_, _, chunk_text) => Ok(player
+                    .movie
+                    .cast_manager
+                    .find_member_ref_by_name(chunk_text)),
                 _ => Err(ScriptError::new(format!(
                     "Invalid identifier for script: {}",
                     formatted_id


### PR DESCRIPTION
Implements the three fixes from #237. One commit per lettered part, so they can be reviewed or dropped independently.

**a) `setProp` on a string chunk.** Dispatches `SetProp` on `StringChunkHandlers` to a `set_prop_call` that resolves the `(chunkType, start[, end], value)` range the way `get_prop_inner` parses its args.

It writes through **`set_contents`, not `set_value`** as I suggested in the issue text. `set_value` ignores its `chunk_expr` and replaces the entire source, so writing the modified chunk back through it truncates the field to just that chunk. I hit this in a local build before catching it — Junk Food Jack marks a collected item with `member("roomN","screens").line[y].word[x] = "--"`, and with `set_value` the first pickup silently truncated that room's 19-line map to a single line. There is a comment at the call site.

**b) `script()` / `member()` identifiers.** `StringChunk` arms in `MovieHandlers::script()` and `CastManager::find_member_ref_by_identifiers`, mirroring the existing `String` arms.

**c) Arithmetic operand.** One arm in `symbol_as_arithmetic_operand()`, which all four ops already route through.

**Repros:** Junk Food Jack (Flashpoint `80cd4672-5b7c-46cb-bcb9-ea4adef35bdb`) — collect any item (a); change room or die (b). Samurai Jack in Cavern Raid (`36ec1007-0b46-4bb6-91bb-30ef37301189`) — start a game (c).

**Verified:** `cargo check --target wasm32-unknown-unknown` is clean on this branch against `main`. On a `wasm-pack` build of `main` with this plus my two companion PRs applied, Junk Food Jack collects items, changes rooms and re-enters previously-visited rooms with their maps intact.

Fixes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
