### PR TITLE
Coerce numeric strings in multiply, divide, inv, mod, abs and power

### DIFF
--- a/vm-rust/src/player/bytecode/arithmetics.rs
+++ b/vm-rust/src/player/bytecode/arithmetics.rs
@@ -129,6 +129,21 @@ impl ArithmeticsBytecodeHandler {
                 Datum::Void => &Datum::Int(0),
                 other => other,
             };
+            // Numeric strings coerce, as they do for the other operators.
+            let as_number = |d: &Datum| -> Datum {
+                match d {
+                    Datum::String(s) | Datum::StringChunk(_, _, s) => {
+                        let t = s.trim();
+                        if let Ok(i) = t.parse::<i32>() { Datum::Int(i) }
+                        else if let Ok(f) = t.parse::<f64>() { Datum::Float(f) }
+                        else { d.clone() }
+                    }
+                    other => other.clone(),
+                }
+            };
+            let left_num = as_number(left);
+            let right_num = as_number(right);
+            let (left, right) = (&left_num, &right_num);
 
             let result = match (left, right) {
                 (Datum::Int(left), Datum::Int(right)) => {
@@ -271,6 +286,16 @@ impl ArithmeticsBytecodeHandler {
                     Datum::List(list_type, negated_items, sorted)
                 }
                 Datum::Void => Datum::Int(0),
+                Datum::String(ref s) | Datum::StringChunk(_, _, ref s) => {
+                    let t = s.trim();
+                    if let Ok(i) = t.parse::<i32>() {
+                        Datum::Int(-i)
+                    } else if let Ok(f) = t.parse::<f64>() {
+                        Datum::Float(-f)
+                    } else {
+                        return Err(ScriptError::new(format!("Cannot inv non-numeric string: {:?}", s)));
+                    }
+                }
                 _ => {
                     return Err(ScriptError::new(format!(
                         "Cannot inv non-numeric value: {}",

--- a/vm-rust/src/player/datum_operations.rs
+++ b/vm-rust/src/player/datum_operations.rs
@@ -830,6 +830,15 @@ pub fn multiply_datums(
             }
             Datum::List(DatumType::List, ref_list, false)
         }
+        (Datum::String(left), Datum::String(right)) => {
+            match (left.trim().parse::<i32>(), right.trim().parse::<i32>()) {
+                (Ok(a), Ok(b)) => Datum::Int(a.wrapping_mul(b)),
+                _ => Datum::Float(
+                    TypeHandlers::float_impl(left).unwrap_or(0.0)
+                        * TypeHandlers::float_impl(right).unwrap_or(0.0),
+                ),
+            }
+        }
         (Datum::String(left), Datum::Int(right)) => {
             if *right == 0 {
                 Datum::Int(0)
@@ -1070,6 +1079,14 @@ pub fn divide_datums(
                 ScriptError::new(format!("Cannot divide float by string: {}", right))
             })?;
             Datum::Float(left / right_val)
+        }
+        (Datum::String(left), Datum::String(right)) => {
+            let l = TypeHandlers::float_impl(left).unwrap_or(0.0);
+            let r = TypeHandlers::float_impl(right).unwrap_or(0.0);
+            match (left.trim().parse::<i32>(), right.trim().parse::<i32>()) {
+                (Ok(a), Ok(b)) if b != 0 => Datum::Int(a / b),
+                _ => Datum::Float(l / r),
+            }
         }
         (Datum::String(left), Datum::Int(right)) => {
             let left_float = TypeHandlers::float_impl(left).unwrap_or(0.0);

--- a/vm-rust/src/player/handlers/types.rs
+++ b/vm-rust/src/player/handlers/types.rs
@@ -1360,6 +1360,12 @@ impl TypeHandlers {
                 // first physics step in spectral-wizard's colliPlayer) and
                 // pass them straight into abs(); Director tolerates this.
                 Datum::Void => Datum::Int(0),
+                Datum::String(s) | Datum::StringChunk(_, _, s) => {
+                    let t = s.trim();
+                    if let Ok(i) = t.parse::<i32>() { Datum::Int(i.abs()) }
+                    else if let Ok(f) = t.parse::<f64>() { Datum::Float(f.abs()) }
+                    else { return Err(ScriptError::new(format!("Cannot get abs of non-numeric string: {:?}", s))); }
+                }
                 _ => {
                     return Err(ScriptError::new(format!(
                         "Cannot get abs of type: {}",
@@ -1622,8 +1628,21 @@ impl TypeHandlers {
             if args.len() != 2 {
                 return Err(ScriptError::new("Power requires 2 arguments".to_string()));
             }
-            let base = player.get_datum(&args[0]);
-            let exponent = player.get_datum(&args[1]);
+            // Numeric strings coerce, as they do for the other operators.
+            let as_number = |d: &Datum| -> Datum {
+                match d {
+                    Datum::String(s) | Datum::StringChunk(_, _, s) => {
+                        let t = s.trim();
+                        if let Ok(i) = t.parse::<i32>() { Datum::Int(i) }
+                        else if let Ok(f) = t.parse::<f64>() { Datum::Float(f) }
+                        else { d.clone() }
+                    }
+                    other => other.clone(),
+                }
+            };
+            let base_num = as_number(player.get_datum(&args[0]));
+            let exponent_num = as_number(player.get_datum(&args[1]));
+            let (base, exponent) = (&base_num, &exponent_num);
 
             match (base, exponent) {
                 (Datum::Int(base), Datum::Int(exponent)) => {


### PR DESCRIPTION
Director coerces numeric strings in arithmetic; DirPlayer does so inconsistently. Comparisons, `int_value()`/`float_value()`, `integer()`, `float()` and `sqrt()` all coerce, and `subtract_datums` has a `(String, String)` arm — but six operations do not:

| Operation | File | Symptom |
|---|---|---|
| `*`, `/` | `datum_operations.rs` | `"-1" * "8"` → *Mul operator only works with ints and floats. Given: "-1", "8"* |
| `inv`, `mod` | `bytecode/arithmetics.rs` | `-"5"` → *Cannot inv non-numeric value: string* |
| `abs`, `power` | `handlers/types.rs` | `abs("-5")` → *Cannot get abs of type: string* |

Three separate code paths, so three commits — one each, independently revertible. `inv`, `mod`, `abs` and `power` accept `StringChunk` here too, since those paths do not route through `symbol_as_arithmetic_operand()` and so are not covered by the fix in #237.

**Repros** — Samurai Jack in Cavern Raid (Flashpoint `36ec1007-0b46-4bb6-91bb-30ef37301189`, entry `English/game.dcr`):

- `*` — walk through a door into the next room. Hard stop on the transition.
- `inv` — ride the minecart after the first door. Hard stop.

Non-numeric operands fall back to `float_impl(..).unwrap_or(0.0)`, matching `(String, Float)`, `(Float, String)`, `(Int, String)` and every arm in `divide_datums`. The `Int(123456789)` case in `(String, Int)` (e49e759b) covers that one operand order only — `5 * "abc"` already returns `0.0` — so I have not extended it to the new arm.

**Verified:** `cargo check --target wasm32-unknown-unknown` is clean on this branch against `main`. On a `wasm-pack` build of `main` with this plus my two companion PRs applied, Samurai Jack plays through the door transitions and the minecart section that previously stopped it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
