### PR TITLE
Director fixes from a title the engine had not seen: GIF Xtra, chunk writes, cursors, sampling, fades

### DIFF
--- a/scripts/run-browser-tests.mjs
+++ b/scripts/run-browser-tests.mjs
@@ -24,8 +24,15 @@ const loadedEnv = {
   ...process.env,
 };
 
+// Through the Windows shell an argument with a space splits in two, so a
+// checkout under "C:\Users\Some Name\..." handed wasm-bindgen half a path.
+function quoted(args) {
+  if (!IS_WIN) return args;
+  return args.map((a) => (/\s/.test(a) && !/^"/.test(a) ? `"${a}"` : a));
+}
+
 function run(cmd, args, opts = {}) {
-  const res = spawnSync(cmd, args, {
+  const res = spawnSync(cmd, quoted(args), {
     stdio: "inherit",
     shell: IS_WIN,
     ...opts,
@@ -211,11 +218,11 @@ const pw = spawnSync("npx", ["playwright", "test", ...forwardArgs], {
 // 9. Always generate the HTML snapshot report regardless of test outcome.
 spawnSync(
   "node",
-  [
+  quoted([
     path.join(__dirname, "generate-snapshot-report.mjs"),
     path.join(VM_RUST_DIR, "tests", "snapshots"),
     path.join(REPO_ROOT, "test-results", "snapshot-report"),
-  ],
+  ]),
   { cwd: REPO_ROOT, stdio: "inherit", shell: IS_WIN },
 );
 

--- a/vm-rust/src/cursor.rs
+++ b/vm-rust/src/cursor.rs
@@ -6,8 +6,36 @@ use crate::player::{
     DirPlayer,
 };
 
-/// Cache key for the native cursor: (bitmap_ref, mask_bitmap_ref, reg_point).
-pub type NativeCursorCache = Option<(Option<u32>, Option<u32>, (i16, i16))>;
+/// Cache key for the native cursor: either a cast-member cursor
+/// (bitmap_ref, mask_bitmap_ref, reg_point) or one of Director's numbered
+/// built-ins. Kept so the CSS property is only written when it changes.
+#[derive(PartialEq, Clone, Debug)]
+pub enum CursorCacheKey {
+    Member(Option<u32>, Option<u32>, (i16, i16)),
+    System(i32),
+}
+pub type NativeCursorCache = Option<CursorCacheKey>;
+
+/// Director's numbered cursors, as the CSS keyword that looks the same.
+///
+/// A movie sets these from rollover behaviours: `cursor(280)` on entering a
+/// button and `cursor(0)` on leaving it. Checked against the Windows
+/// projector's live cursor handle: over a button it is a pointing hand from
+/// Director's own bitmap, matching no stock Windows cursor, and over the
+/// backdrop the plain arrow. An unknown number falls back to the arrow.
+fn system_cursor_css(id: i32) -> Option<&'static str> {
+    match id {
+        -1 | 0 => Some("default"),
+        1 => Some("text"),        // I-Beam
+        2 => Some("crosshair"),   // Crosshair
+        3 => Some("cell"),        // Crossbar
+        4 => Some("wait"),        // Watch
+        200 => Some("none"),      // Blank
+        254 => Some("help"),      // Help
+        280 => Some("pointer"),   // Finger
+        _ => Some("default"),
+    }
+}
 
 /// Resolve and apply the custom cursor as a native CSS cursor on `canvas` (and
 /// `document.body` so it persists during pointer-capture drag). Returns without
@@ -25,6 +53,30 @@ pub fn update_native_cursor(
         None
     };
     let cursor_ref = cursor_ref.as_ref().unwrap_or(&player.cursor);
+    // A numbered cursor is a CSS keyword; only a member cursor needs a bitmap
+    // built into a data URL below.
+    if let CursorRef::System(id) = cursor_ref {
+        let key = CursorCacheKey::System(*id);
+        if cache.as_ref() == Some(&key) {
+            return;
+        }
+        match system_cursor_css(*id) {
+            Some("default") => {
+                let _ = canvas.style().remove_property("cursor");
+                set_body_cursor(None);
+            }
+            Some(css) => {
+                let _ = canvas.style().set_property("cursor", css);
+                set_body_cursor(Some(css));
+            }
+            None => {
+                let _ = canvas.style().remove_property("cursor");
+                set_body_cursor(None);
+            }
+        }
+        *cache = Some(key);
+        return;
+    }
     let cursor_list = match cursor_ref {
         CursorRef::Member(ids) => Some(ids),
         _ => None,
@@ -52,7 +104,7 @@ pub fn update_native_cursor(
         }
     };
 
-    let cache_key = (
+    let cache_key = CursorCacheKey::Member(
         Some(cursor_bitmap_member.image_ref),
         cursor_mask_member.as_ref().map(|m| m.image_ref),
         cursor_bitmap_member.reg_point,

--- a/vm-rust/src/player/bitmap/bitmap.rs
+++ b/vm-rust/src/player/bitmap/bitmap.rs
@@ -188,6 +188,36 @@ pub struct Bitmap {
 }
 
 impl Bitmap {
+    /// The `rect` of this 32-bit bitmap as a new 32-bit bitmap, RGBA copied
+    /// byte for byte. A crop keeps the alpha channel; going through an ink
+    /// path does not, since ink Copy skips fully transparent source pixels
+    /// and leaves the destination's initial fill behind them. A rect that
+    /// runs past the source is padded with transparent pixels when the image
+    /// has an alpha channel; Bitmap::new's white showed as a bar under a claw
+    /// a movie cropped taller than its image.
+    pub fn crop_rgba(&self, left: i32, top: i32, width: u16, height: u16) -> Bitmap {
+        let mut out = Bitmap::new(width, height, 32, 32, if self.use_alpha { 8 } else { 0 }, self.palette_ref.clone());
+        if self.use_alpha {
+            out.data.fill(0);
+        }
+        out.use_alpha = self.use_alpha;
+        out.trim_white_space = self.trim_white_space;
+        let sw = self.width as i32;
+        let sh = self.height as i32;
+        for dy in 0..height as i32 {
+            let sy = top + dy;
+            if sy < 0 || sy >= sh { continue; }
+            for dx in 0..width as i32 {
+                let sx = left + dx;
+                if sx < 0 || sx >= sw { continue; }
+                let si = ((sy * sw + sx) * 4) as usize;
+                let di = ((dy * width as i32 + dx) * 4) as usize;
+                out.data[di..di + 4].copy_from_slice(&self.data[si..si + 4]);
+            }
+        }
+        out
+    }
+
     pub fn new(
         width: u16,
         height: u16,
@@ -1659,4 +1689,33 @@ pub fn decode_jpeg_bitmap(data: &[u8], info: &BitmapInfo, alfa_data: Option<&Vec
         was_trimmed: false,
         version: 0,
     })
+}
+
+#[cfg(test)]
+mod crop_tests {
+    use super::*;
+
+    #[test]
+    fn crop_keeps_the_alpha_channel() {
+        // 3x3, opaque red centre, everything else fully transparent.
+        let mut src = Bitmap::new(3, 3, 32, 32, 8, PaletteRef::BuiltIn(BuiltInPalette::SystemWin));
+        src.use_alpha = true;
+        for i in 0..9 { src.data[i * 4..i * 4 + 4].copy_from_slice(&[0, 0, 0, 0]); }
+        src.data[4 * 4..4 * 4 + 4].copy_from_slice(&[255, 0, 0, 255]);
+        let out = src.crop_rgba(1, 0, 2, 2); // columns 1..2, rows 0..1
+        assert!(out.use_alpha);
+        assert_eq!(&out.data[0..4], &[0, 0, 0, 0], "top-left of the crop is transparent");
+        assert_eq!(&out.data[(1 * 2 + 0) * 4..(1 * 2 + 0) * 4 + 4], &[255, 0, 0, 255], "the red pixel lands at (0,1)");
+        assert_eq!(&out.data[(1 * 2 + 1) * 4..(1 * 2 + 1) * 4 + 4], &[0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn crop_outside_the_source_is_transparent() {
+        let mut src = Bitmap::new(2, 2, 32, 32, 8, PaletteRef::BuiltIn(BuiltInPalette::SystemWin));
+        src.use_alpha = true;
+        for i in 0..4 { src.data[i * 4..i * 4 + 4].copy_from_slice(&[9, 9, 9, 255]); }
+        let out = src.crop_rgba(1, 1, 3, 3); // runs past the right and bottom edge
+        assert_eq!(&out.data[0..4], &[9, 9, 9, 255]);
+        assert_eq!(&out.data[(2 * 3 + 2) * 4..(2 * 3 + 2) * 4 + 4], &[0, 0, 0, 0], "padding past the source is transparent");
+    }
 }

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -45,6 +45,11 @@ pub struct CopyPixelsParams<'a> {
     /// (mask_reg - src_reg). Director allows mask bitmaps to be larger or
     /// smaller than the source — alignment is by registration point.
     pub ink9_mask_offset: (i32, i32),
+    /// Sample a shrunk source at floor(d * src / dst), as Director does for
+    /// an authored bitmap (measured on klods.dcr's ruler). Off for text, field
+    /// and shape blits, which keep the pixel-centre rule; see the shader's
+    /// u_floor_rule.
+    pub floor_rule: bool,
 }
 
 impl CopyPixelsParams<'_> {
@@ -65,6 +70,7 @@ impl CopyPixelsParams<'_> {
             original_dst_rect: None,
             ink9_mask_bitmap: None,
             ink9_mask_offset: (0, 0),
+            floor_rule: false,
         }
     }
 }
@@ -1879,6 +1885,7 @@ impl Bitmap {
             original_dst_rect,
             ink9_mask_bitmap: None,
             ink9_mask_offset: (0, 0),
+            floor_rule: false,
         };
         self.copy_pixels_with_params(palettes, src, dst_rect, src_rect, &params);
     }
@@ -2632,9 +2639,20 @@ impl Bitmap {
                     continue;
                 }
 
-                // Map destination pixel to source coordinate with scaling
-                let src_f_x = src_left_f + (dst_x_idx + 0.5) * scale_x;
-                let src_f_y = src_top_f + (dst_y_idx + 0.5) * scale_y;
+                // Map destination pixel to source coordinate with scaling.
+                // Director samples a stretched bitmap at floor(d * src / dst),
+                // the top-left of the destination pixel, not its centre.
+                // Measured on klods.dcr's ruler (member 82, 239x46 drawn at
+                // 166x32): the floor rule reproduces the projector's pixels
+                // 100%, the centre rule 88%, and the difference is the digit
+                // rows the centre rule skips. Rotation and skew keep the
+                // centre so their resampling stays symmetric.
+                // Floor rule (phase 0) only for an authored bitmap scaling down;
+                // see the shader.
+                let scaling_up = scale_x < 1.0 || scale_y < 1.0;
+                let phase = if has_sprite_rotation || has_skew_flip || scaling_up || !params.floor_rule { 0.5 } else { 0.0 };
+                let src_f_x = src_left_f + (dst_x_idx + phase) * scale_x;
+                let src_f_y = src_top_f + (dst_y_idx + phase) * scale_y;
 
                 // Handle horizontal flip
                 let src_mapped_x = if flip_x {
@@ -4275,5 +4293,35 @@ impl Bitmap {
             line_direction: 0,
         };
         self.draw_shape_with_sprite(sprite, &default_shape, dst_rect, palettes, palette_ref);
+    }
+}
+
+#[cfg(test)]
+mod shrink_sampling_tests {
+    use super::*;
+    use crate::player::bitmap::bitmap::{BuiltInPalette, PaletteRef};
+    use crate::player::bitmap::palette_map::PaletteMap;
+
+    // Three source columns with distinct reds, drawn into two: the floor rule
+    // keeps columns 0 and 1 (floor(0 * 1.5), floor(1 * 1.5)); the centre rule
+    // keeps 0 and 2 (floor(0.75), floor(2.25)).
+    fn shrink(floor_rule: bool) -> Vec<u8> {
+        let mut src = Bitmap::new(3, 1, 32, 32, 0, PaletteRef::BuiltIn(BuiltInPalette::SystemWin));
+        for x in 0..3 { src.data[x * 4..x * 4 + 4].copy_from_slice(&[10 * (x as u8 + 1), 0, 0, 255]); }
+        let mut dst = Bitmap::new(2, 1, 32, 32, 0, PaletteRef::BuiltIn(BuiltInPalette::SystemWin));
+        let mut params = CopyPixelsParams::default(&src);
+        params.floor_rule = floor_rule;
+        dst.copy_pixels_with_params(&PaletteMap::new(), &src, IntRect::from(0, 0, 2, 1), IntRect::from(0, 0, 3, 1), &params);
+        vec![dst.data[0], dst.data[4]]
+    }
+
+    #[test]
+    fn an_authored_bitmap_shrinks_by_the_floor_rule() {
+        assert_eq!(shrink(true), vec![10, 20]);
+    }
+
+    #[test]
+    fn everything_else_keeps_the_centre_rule() {
+        assert_eq!(shrink(false), vec![10, 30]);
     }
 }

--- a/vm-rust/src/player/bitmap/drawing.rs
+++ b/vm-rust/src/player/bitmap/drawing.rs
@@ -132,6 +132,8 @@ fn blend_pixel(
     src: (u8, u8, u8),
     ink: u32,
     bg_color: (u8, u8, u8),
+    fg_color: (u8, u8, u8),
+    src_indexed: bool, // an indexed (1 to 8 bit) source keeps its colours under Lighten
     blend_alpha: f32, // This is params.blend / 100.0
     src_alpha: f32,   // Alpha from the source pixel (0.0 to 1.0)
 ) -> (u8, u8, u8) {
@@ -281,22 +283,37 @@ fn blend_pixel(
                 }
             }
         }
-        // 40 = Lighten
+        // 40 = Lighten: the sprite's foreColor is added to the image
+        // (Using Director, "Using sprite inks"). A sprite on the default
+        // black foreColor is unchanged, which is what the earlier
+        // pass-through measured.
         40 => {
             if src == bg_color {
                 dst
-            } else {
+            } else if src_indexed {
                 blend_color_alpha(dst, src, effective_alpha)
+            } else {
+                let lit = (
+                    src.0.saturating_add(fg_color.0),
+                    src.1.saturating_add(fg_color.1),
+                    src.2.saturating_add(fg_color.2),
+                );
+                blend_color_alpha(dst, lit, effective_alpha)
             }
         }
+        // 41 = Darken: a foreColor/bgColor remap per channel, black to
+        // foreColor and white to bgColor, the same mix the WebGL2 shader
+        // draws. The defaults (black, white) leave the image unchanged.
         41 => {
-            // Darken
-            // TODO
-            // bg_color
-            let r = (src.0 as f32 / 255.0) * (bg_color.0 as f32 / 255.0) * 255.0;
-            let g = (src.1 as f32 / 255.0) * (bg_color.1 as f32 / 255.0) * 255.0;
-            let b = (src.2 as f32 / 255.0) * (bg_color.2 as f32 / 255.0) * 255.0;
-            let color = (r as u8, g as u8, b as u8);
+            let mix = |s: u8, fg: u8, bg: u8| {
+                let t = s as f32 / 255.0;
+                (fg as f32 * (1.0 - t) + bg as f32 * t).round().clamp(0.0, 255.0) as u8
+            };
+            let color = (
+                mix(src.0, fg_color.0, bg_color.0),
+                mix(src.1, fg_color.1, bg_color.1),
+                mix(src.2, fg_color.2, bg_color.2),
+            );
             blend_color_alpha(dst, color, effective_alpha)
         }
         _ => blend_color_alpha(dst, src, effective_alpha),
@@ -3466,6 +3483,8 @@ impl Bitmap {
                             fg_color_resolved,
                             ink,
                             bg_color_resolved,
+                            fg_color_resolved,
+                            is_indexed,
                             alpha,
                             sa as f32 / 255.0,
                         );
@@ -3522,6 +3541,8 @@ impl Bitmap {
                     src_color,
                     ink,
                     bg_color_resolved,
+                    fg_color_resolved,
+                    is_indexed,
                     alpha,
                     src_alpha,
                 );
@@ -4323,5 +4344,36 @@ mod shrink_sampling_tests {
     #[test]
     fn everything_else_keeps_the_centre_rule() {
         assert_eq!(shrink(false), vec![10, 30]);
+    }
+}
+
+mod ink_colour_tests {
+    use super::blend_pixel;
+
+    const WHITE: (u8, u8, u8) = (255, 255, 255);
+    const BLACK: (u8, u8, u8) = (0, 0, 0);
+
+    #[test]
+    fn lighten_adds_the_fore_colour() {
+        let src = (100, 100, 100);
+        assert_eq!(blend_pixel((0, 0, 0), src, 40, WHITE, (50, 25, 0), false, 1.0, 1.0), (150, 125, 100));
+        assert_eq!(blend_pixel((0, 0, 0), src, 40, WHITE, BLACK, false, 1.0, 1.0), src, "the default foreColor changes nothing");
+        assert_eq!(blend_pixel((0, 0, 0), (250, 250, 250), 40, WHITE, (50, 25, 0), false, 1.0, 1.0), (255, 255, 250), "pinned at 255");
+        assert_eq!(blend_pixel((0, 0, 0), src, 40, WHITE, (50, 25, 0), true, 1.0, 1.0), src, "an indexed bitmap keeps its palette colours");
+    }
+
+    #[test]
+    fn lighten_still_keys_the_background_colour() {
+        let dst = (7, 8, 9);
+        assert_eq!(blend_pixel(dst, WHITE, 40, WHITE, (50, 25, 0), false, 1.0, 1.0), dst);
+    }
+
+    #[test]
+    fn darken_remaps_black_to_fore_and_white_to_back() {
+        let fg = (50, 25, 0);
+        let bg = (200, 220, 240);
+        assert_eq!(blend_pixel((0, 0, 0), (0, 0, 0), 41, bg, fg, false, 1.0, 1.0), fg);
+        assert_eq!(blend_pixel((0, 0, 0), (255, 255, 255), 41, bg, fg, false, 1.0, 1.0), bg);
+        assert_eq!(blend_pixel((0, 0, 0), (100, 100, 100), 41, WHITE, BLACK, false, 1.0, 1.0), (100, 100, 100), "defaults are the identity");
     }
 }

--- a/vm-rust/src/player/cast_member.rs
+++ b/vm-rust/src/player/cast_member.rs
@@ -4546,6 +4546,45 @@ impl CastMember {
                 });
             }
 
+            // 1c) Animated GIF. Director's "Animated GIF Asset" Xtra stores
+            // the whole .gif file as the XMED payload. Decode the frames and
+            // hand back a plain Bitmap member on frame 0, so every ink and
+            // stretch path treats it as an ordinary bitmap;
+            // `player.gif_animations` swaps the frame as time passes. Without
+            // this the payload fell through to the text parser below.
+            if crate::player::gif::is_gif(&xm.raw_data) {
+                if let Some(anim) = crate::player::gif::decode_gif(&xm.raw_data, bitmap_manager) {
+                    debug!(
+                        "GIF member #{} '{}': {} frames, {}x{}",
+                        number,
+                        chunk.member_info.as_ref().map(|x| x.name.as_str()).unwrap_or(""),
+                        anim.frames.len(), anim.width, anim.height
+                    );
+                    let info = crate::player::gif::gif_bitmap_info(anim.width, anim.height);
+                    let first = anim.frames[0];
+                    // Carry the GIF's own background colour so a sprite drawn
+                    // with ink 36 keys out the right thing.
+                    let bg = crate::player::gif::background_color(&xm.raw_data)
+                        .map(|(r, g, b)| ColorRef::Rgb(r, g, b))
+                        .unwrap_or(ColorRef::PaletteIndex(0));
+                    crate::player::gif::register_pending(cast_lib, number, anim);
+                    return Some(CastMember {
+                        number,
+                        name: chunk.member_info.as_ref().map(|x| x.name.to_owned()).unwrap_or_default(),
+                        comments: chunk.member_info.as_ref().map(|x| x.comments.to_owned()).unwrap_or_default(),
+                        member_type: CastMemberType::Bitmap(BitmapMember {
+                            image_ref: first,
+                            reg_point: (info.reg_x, info.reg_y),
+                            script_id: 0,
+                            member_script_ref: None,
+                            info,
+                        }),
+                        color: ColorRef::PaletteIndex(255),
+                        bg_color: bg,
+                        reg_point: (0, 0),
+                    });
+                }
+            }
             // 2) Check if styled text (XMED format)
             // Only parse as styled text if the Ole type string is "text" or empty
             // (avoid mis-parsing raw binary data like lightmap coordinates as text)

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -552,6 +552,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             });
         }
         PlayerVMCommand::MouseDown((x, y)) => {
+            crate::player::wait_for_handler_gap().await;
             crate::player::hold_draw_for_input_handler();
             if !player_is_playing().await {
                 return Ok(DatumRef::Void);
@@ -953,6 +954,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             return Ok(DatumRef::Void);
         }
         PlayerVMCommand::MouseUp((x, y)) => {
+            crate::player::wait_for_handler_gap().await;
             crate::player::hold_draw_for_input_handler();
             if !player_is_playing().await {
                 return Ok(DatumRef::Void);
@@ -1293,6 +1295,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             }
         }
         PlayerVMCommand::KeyDown(key, code) => {
+            crate::player::wait_for_handler_gap().await;
             crate::player::hold_draw_for_input_handler();
             // Set command_handler_yielding so that:
             // 1. updateStage() always yields (bypasses is_yield_safe check),
@@ -1313,6 +1316,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             return result;
         }
         PlayerVMCommand::KeyUp(key, code) => {
+            crate::player::wait_for_handler_gap().await;
             crate::player::hold_draw_for_input_handler();
             return player_key_up(key, code).await;
         }

--- a/vm-rust/src/player/commands.rs
+++ b/vm-rust/src/player/commands.rs
@@ -552,6 +552,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             });
         }
         PlayerVMCommand::MouseDown((x, y)) => {
+            crate::player::hold_draw_for_input_handler();
             if !player_is_playing().await {
                 return Ok(DatumRef::Void);
             }
@@ -952,6 +953,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             return Ok(DatumRef::Void);
         }
         PlayerVMCommand::MouseUp((x, y)) => {
+            crate::player::hold_draw_for_input_handler();
             if !player_is_playing().await {
                 return Ok(DatumRef::Void);
             }
@@ -1291,6 +1293,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             }
         }
         PlayerVMCommand::KeyDown(key, code) => {
+            crate::player::hold_draw_for_input_handler();
             // Set command_handler_yielding so that:
             // 1. updateStage() always yields (bypasses is_yield_safe check),
             //    letting the browser process keyUp events during repeat-while-
@@ -1310,6 +1313,7 @@ pub async fn run_player_command(command: PlayerVMCommand) -> Result<DatumRef, Sc
             return result;
         }
         PlayerVMCommand::KeyUp(key, code) => {
+            crate::player::hold_draw_for_input_handler();
             return player_key_up(key, code).await;
         }
         PlayerVMCommand::TriggerAlertHook => {

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -1454,6 +1454,7 @@ pub async fn run_event_loop(rx: Receiver<PlayerVMEvent>) {
         if skip {
             continue;
         }
+        crate::player::wait_for_handler_gap().await;
         let result = match item {
             PlayerVMEvent::Global(name, args) => player_invoke_global_event(name, &args).await,
             PlayerVMEvent::Targeted(name, args, instances) => {

--- a/vm-rust/src/player/events.rs
+++ b/vm-rust/src/player/events.rs
@@ -108,35 +108,21 @@ pub fn player_dispatch_event_to_sprite(
 /// so with mouseWithin only on movement, a click on a stationary cursor was
 /// never seen.
 ///
-/// The hovered set is narrowed to sprites that can actually respond, plus the
-/// front-most one whatever it is. Dispatching to a sprite with no matching
-/// behaviour falls through to the frame and movie scripts, so sending to every
-/// overlapping sprite would invoke a movie-level `on mouseWithin` once per
-/// layer; keeping the front-most as the sole fall-through preserves exactly one
-/// invocation.
+/// Only the front-most sprite under the pointer is hovered, as in Director,
+/// where these events follow `the rollover`: a sprite covered by another does
+/// not see the pointer at all. Sending them to every overlapping sprite that
+/// had a handler let a lower sprite's mouseEnter run after the front-most
+/// sprite's and undo it (Matematik i Maaneby's map: a ground patch carrying
+/// one house's behaviour sits under another house, and a pointer landing on
+/// the house lit it and then unlit it in the same event).
 pub fn dispatch_rollover_events() {
     let (now_hovered, prev_hovered) = reserve_player_mut(|player| {
         let (x, y) = player.mouse_loc;
         let prev_hovered = std::mem::take(&mut player.hovered_sprites);
         let now_hovered: Vec<i16> = crate::player::score::get_sprites_at(player, x, y)
-            .iter()
-            .enumerate()
-            .filter(|(idx, num)| {
-                *idx == 0
-                    || player
-                        .movie
-                        .score
-                        .get_sprite(**num as i16)
-                        .map(|sprite| {
-                            crate::player::score::sprite_has_handler(
-                                player,
-                                sprite,
-                                &["mouseEnter", "mouseWithin", "mouseLeave"],
-                            )
-                        })
-                        .unwrap_or(false)
-            })
-            .map(|(_, num)| *num as i16)
+            .first()
+            .map(|num| *num as i16)
+            .into_iter()
             .collect();
         player.hovered_sprites = now_hovered.clone();
         (now_hovered, prev_hovered)

--- a/vm-rust/src/player/gif.rs
+++ b/vm-rust/src/player/gif.rs
@@ -1,0 +1,452 @@
+//! Animated GIF cast members.
+//!
+//! Director shipped an "Animated GIF Asset" Xtra, and a movie that uses it
+//! stores the whole `.gif` file as the XMED payload of a type-15 (Xtra media)
+//! cast member. Movies reach for it for things that move but are not film
+//! loops: flowing liquid, smoke plumes, a shooting star.
+//!
+//! Without this the payload fell through to the styled-text parser, which
+//! found no text and drew an empty white box where the animation belonged.
+//!
+//! Every frame is decoded once, up front, into its own `Bitmap`, so inks,
+//! stretching and matte apply to a GIF as they do to any other bitmap; the
+//! member just points at a different frame as time passes. That costs memory
+//! for a large GIF and leaves the drawing path untouched.
+
+use crate::director::enums::BitmapInfo;
+use crate::player::bitmap::bitmap::{Bitmap, BuiltInPalette, PaletteRef};
+use crate::player::bitmap::manager::BitmapRef;
+use crate::player::bitmap::manager::BitmapManager;
+
+/// One decoded GIF: its frames as bitmaps, and how long each is shown.
+#[derive(Clone, Debug)]
+pub struct GifAnimation {
+    pub frames: Vec<BitmapRef>,
+    /// Milliseconds per frame, same length as `frames`.
+    pub delays_ms: Vec<u32>,
+    pub width: u16,
+    pub height: u16,
+    /// Index currently shown by the cast member.
+    pub current: usize,
+    /// `performance.now()` reading when the current frame was put up.
+    pub last_switch_ms: f64,
+    /// Cleared by `sprite(n).pause()`, set again by `resume()`.
+    pub running: bool,
+}
+
+impl GifAnimation {
+    /// Which frame should be showing at `now_ms`, advancing `current` past as
+    /// many frames as the elapsed time covers. Returns true when it changed.
+    pub fn advance(&mut self, now_ms: f64) -> bool {
+        if !self.running || self.frames.len() < 2 {
+            return false;
+        }
+        if self.last_switch_ms <= 0.0 {
+            self.last_switch_ms = now_ms;
+            return false;
+        }
+        let mut changed = false;
+        // A delay of 0 means "as fast as possible"; clamped like browsers and
+        // Director do, so a broken file cannot burn the frame budget.
+        let mut guard = 0;
+        loop {
+            let delay = (*self.delays_ms.get(self.current).unwrap_or(&100)).max(20) as f64;
+            if now_ms - self.last_switch_ms < delay {
+                break;
+            }
+            self.last_switch_ms += delay;
+            self.current = (self.current + 1) % self.frames.len();
+            changed = true;
+            guard += 1;
+            if guard > 64 {
+                // Long pause (tab hidden): resync instead of catching up frame
+                // by frame.
+                self.last_switch_ms = now_ms;
+                break;
+            }
+        }
+        changed
+    }
+
+    pub fn current_ref(&self) -> BitmapRef {
+        self.frames[self.current.min(self.frames.len() - 1)]
+    }
+}
+
+/// The GIF's declared background colour, from the Logical Screen Descriptor's
+/// background-colour index into the global colour table. Director's GIF Xtra
+/// leaves that colour in the pixels, and a movie hides it by drawing the
+/// sprite with ink 36 (Background Transparent), which keys out the MEMBER's
+/// background colour. So the member has to carry it, or a GIF whose
+/// background is not white draws as a solid box.
+///
+/// None when the GIF has no global colour table.
+pub fn background_color(data: &[u8]) -> Option<(u8, u8, u8)> {
+    if data.len() < 13 {
+        return None;
+    }
+    let flags = data[10];
+    let has_global_table = flags & 0x80 != 0;
+    if !has_global_table {
+        return None;
+    }
+    let table_size = 2usize << (flags & 0x07);
+    let bg_index = data[11] as usize;
+    let table_start = 13;
+    if bg_index >= table_size || table_start + table_size * 3 > data.len() {
+        return None;
+    }
+    let o = table_start + bg_index * 3;
+    Some((data[o], data[o + 1], data[o + 2]))
+}
+
+/// True when these bytes are a GIF file.
+pub fn is_gif(data: &[u8]) -> bool {
+    data.len() >= 6 && (&data[0..6] == b"GIF87a" || &data[0..6] == b"GIF89a")
+}
+
+/// Decode every frame into the bitmap manager. Returns None if the data is not
+/// a GIF the decoder accepts.
+pub fn decode_gif(data: &[u8], bitmap_manager: &mut BitmapManager) -> Option<GifAnimation> {
+    use image::AnimationDecoder;
+    use image::codecs::gif::GifDecoder;
+
+    if !is_gif(data) {
+        return None;
+    }
+    let decoder = match GifDecoder::new(std::io::Cursor::new(data)) {
+        Ok(d) => d,
+        Err(e) => {
+            log::warn!("[gif] decoder refused {} bytes: {}", data.len(), e);
+            return None;
+        }
+    };
+    let mut frames = Vec::new();
+    let mut delays_ms = Vec::new();
+    let mut width = 0u16;
+    let mut height = 0u16;
+    for (i, frame) in decoder.into_frames().enumerate() {
+        let frame = match frame {
+            Ok(f) => f,
+            Err(e) => {
+                log::warn!("[gif] frame {} failed: {}", i, e);
+                break;
+            }
+        };
+        let (num, den) = frame.delay().numer_denom_ms();
+        let delay = if den == 0 { 100 } else { num / den.max(1) };
+        let buf = frame.into_buffer();
+        let (w, h) = (buf.width() as u16, buf.height() as u16);
+        if w == 0 || h == 0 {
+            continue;
+        }
+        width = width.max(w);
+        height = height.max(h);
+        let mut bitmap = Bitmap::new(w, h, 32, 32, 8, PaletteRef::BuiltIn(BuiltInPalette::SystemWin));
+        bitmap.data = buf.into_raw();
+        bitmap.use_alpha = true;
+        frames.push(bitmap_manager.add_bitmap(bitmap));
+        delays_ms.push(delay.max(20));
+        // A runaway file must not exhaust memory.
+        if frames.len() >= 240 {
+            log::warn!("[gif] stopping at 240 frames");
+            break;
+        }
+    }
+    if frames.is_empty() {
+        return None;
+    }
+    Some(GifAnimation {
+        frames,
+        delays_ms,
+        width,
+        height,
+        current: 0,
+        last_switch_ms: 0.0,
+        running: true,
+    })
+}
+
+/// The BitmapInfo a GIF frame should report: its own size, no palette of its
+/// own (the frames are already RGBA), registration in the centre like
+/// Director's own imported bitmaps.
+pub fn gif_bitmap_info(width: u16, height: u16) -> BitmapInfo {
+    BitmapInfo {
+        width,
+        height,
+        reg_x: (width / 2) as i16,
+        reg_y: (height / 2) as i16,
+        bit_depth: 32,
+        palette_id: 0,
+        clut_cast_lib: -1,
+        pitch: width.saturating_mul(4),
+        use_alpha: true,
+        trim_white_space: false,
+        center_reg_point: true,
+    }
+}
+
+/// Decoding happens while the cast is being built, before the player exists,
+/// so finished animations wait here until `take_pending` moves them onto the
+/// player. Keyed by (cast_lib, member number).
+static PENDING: std::sync::Mutex<Option<Vec<((u32, u32), GifAnimation)>>> =
+    std::sync::Mutex::new(None);
+
+pub fn register_pending(cast_lib: u32, number: u32, anim: GifAnimation) {
+    if let Ok(mut guard) = PENDING.lock() {
+        guard.get_or_insert_with(Vec::new).push(((cast_lib, number), anim));
+    }
+}
+
+pub fn take_pending() -> Vec<((u32, u32), GifAnimation)> {
+    match PENDING.lock() {
+        Ok(mut guard) => guard.take().unwrap_or_default(),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// Advance every animation and point its cast member at the current frame.
+/// Called once per frame from the movie loop.
+pub fn tick_gif_animations() {
+    crate::player::reserve_player_mut(|player| {
+        // The same clock the movie's own `the milliSeconds` reads, so a GIF
+        // keeps step with the Lingo that drives the rest of the scene.
+        let now = (chrono::Local::now().timestamp_millis()
+            - player.system_start_time.timestamp_millis()) as f64;
+        if player.gif_animations.is_empty() {
+            return;
+        }
+        let mut moved: Vec<((u32, u32), BitmapRef)> = Vec::new();
+        for (key, anim) in player.gif_animations.iter_mut() {
+            if anim.advance(now) {
+                moved.push((*key, anim.current_ref()));
+            }
+        }
+        for ((cast_lib, number), image_ref) in moved {
+            let member_ref = crate::CastMemberRef { cast_lib: cast_lib as i32, cast_member: number as i32 };
+            if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+                if let crate::player::cast_member::CastMemberType::Bitmap(b) = &mut member.member_type {
+                    b.image_ref = image_ref;
+                }
+            }
+        }
+    });
+}
+
+/// Move animations decoded during cast loading onto the player.
+pub fn install_pending() {
+    let pending = take_pending();
+    if pending.is_empty() {
+        return;
+    }
+    crate::player::reserve_player_mut(|player| {
+        for (key, anim) in pending {
+            player.gif_animations.insert(key, anim);
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::player::bitmap::manager::BitmapManager;
+
+    /// A two-frame GIF, 2x2, built by hand: red frame then green frame.
+    fn tiny_gif() -> Vec<u8> {
+        let mut g = Vec::new();
+        g.extend_from_slice(b"GIF89a");
+        g.extend_from_slice(&[2, 0, 2, 0]);          // 2x2
+        g.extend_from_slice(&[0x80, 0, 0]);           // global table, 2 colours
+        g.extend_from_slice(&[255, 0, 0, 0, 255, 0]); // red, green
+        for idx in [0u8, 1u8] {
+            g.extend_from_slice(&[0x21, 0xF9, 4, 0, 5, 0, 0, 0]); // 50 ms delay
+            g.extend_from_slice(&[0x2C, 0, 0, 0, 0, 2, 0, 2, 0, 0]);
+            // LZW, 2-bit codes: clear, idx x4, end
+            g.push(2);
+            let data: Vec<u8> = match idx {
+                0 => vec![0x84, 0x8F, 0xA9, 0xCB, 0xED, 0x0F, 0x00],
+                _ => vec![0x8C, 0x2D, 0x99, 0x87, 0x2A, 0x1C, 0xDC, 0x33, 0xA0, 0x02, 0x75, 0xEC, 0x95, 0xFA, 0xA8, 0xDE, 0x60, 0x8C, 0x04, 0x91, 0x4C, 0x01, 0x00],
+            };
+            g.push(data.len() as u8);
+            g.extend_from_slice(&data);
+            g.push(0);
+        }
+        g.push(0x3B);
+        g
+    }
+
+    #[test]
+    fn recognises_both_gif_signatures() {
+        assert!(is_gif(b"GIF87a....."));
+        assert!(is_gif(b"GIF89a....."));
+        assert!(!is_gif(b"FFFF000000060004"));   // a styled-text XMED payload
+        assert!(!is_gif(b"3DGM"));
+        assert!(!is_gif(b"GIF"));
+    }
+
+    #[test]
+    fn decodes_frames_into_bitmaps() {
+        let mut mgr = BitmapManager::new();
+        let anim = decode_gif(&tiny_gif(), &mut mgr).expect("tiny gif should decode");
+        assert!(anim.frames.len() >= 1, "at least one frame");
+        assert_eq!(anim.width, 2);
+        assert_eq!(anim.height, 2);
+        let bmp = mgr.get_bitmap(anim.frames[0]).expect("frame 0 in manager");
+        assert_eq!((bmp.width, bmp.height), (2, 2));
+        assert_eq!(bmp.data.len(), 2 * 2 * 4, "RGBA");
+    }
+
+    #[test]
+    fn advances_on_its_own_delays_and_wraps() {
+        let mut anim = GifAnimation {
+            frames: vec![1, 2, 3],
+            delays_ms: vec![100, 100, 100],
+            width: 4, height: 4, current: 0, last_switch_ms: 0.0, running: true,
+        };
+        // First call only starts the clock.
+        assert!(!anim.advance(1000.0));
+        assert_eq!(anim.current, 0);
+        assert!(!anim.advance(1050.0), "half a delay is not a frame");
+        assert!(anim.advance(1100.0));
+        assert_eq!(anim.current, 1);
+        assert!(anim.advance(1300.0), "two delays at once");
+        assert_eq!(anim.current, 0, "wraps back to the start");
+    }
+
+    #[test]
+    fn single_frame_never_advances() {
+        let mut anim = GifAnimation {
+            frames: vec![7], delays_ms: vec![100],
+            width: 1, height: 1, current: 0, last_switch_ms: 0.0, running: true,
+        };
+        assert!(!anim.advance(9999.0));
+        assert_eq!(anim.current_ref(), 7);
+    }
+
+    #[test]
+    fn a_long_pause_resyncs_instead_of_catching_up() {
+        let mut anim = GifAnimation {
+            frames: vec![1, 2], delays_ms: vec![20, 20],
+            width: 1, height: 1, current: 0, last_switch_ms: 0.0, running: true,
+        };
+        anim.advance(0.0);
+        // Tab hidden for a minute: 3000 frames' worth of delay.
+        anim.advance(60_000.0);
+        assert_eq!(anim.last_switch_ms, 60_000.0, "clock resynced");
+    }
+}
+
+/// True when this member number is a GIF the player has loaded.
+pub fn is_gif_member(player: &crate::player::DirPlayer, cast_lib: i32, number: i32) -> bool {
+    cast_lib >= 0 && number >= 0
+        && player.gif_animations.contains_key(&(cast_lib as u32, number as u32))
+}
+
+/// True when this sprite's member is an animated GIF.
+pub fn sprite_has_gif(datum: &crate::player::datum_ref::DatumRef) -> bool {
+    crate::player::reserve_player_ref(|player| {
+        let sprite_num = match player.get_datum(datum) {
+            crate::director::lingo::datum::Datum::SpriteRef(n) => *n,
+            _ => return false,
+        };
+        player
+            .movie
+            .score
+            .get_sprite(sprite_num)
+            .and_then(|s| s.member.as_ref())
+            .is_some_and(|m| is_gif_member(player, m.cast_lib, m.cast_member))
+    })
+}
+
+/// `pause`, `resume`, `rewind`, `play` and `stop` on a sprite showing a GIF.
+/// Director's Animated GIF Xtra treats play and resume alike, and stop like
+/// pause; rewind returns to the first frame and leaves the running state as it
+/// was, which is why movies pair `rewind()` with `pause()`.
+pub fn control_sprite_gif(
+    datum: &crate::player::datum_ref::DatumRef,
+    handler: &str,
+) -> Result<crate::player::datum_ref::DatumRef, crate::player::ScriptError> {
+    use crate::player::datum_ref::DatumRef;
+    crate::player::reserve_player_mut(|player| {
+        let sprite_num = match player.get_datum(datum) {
+            crate::director::lingo::datum::Datum::SpriteRef(n) => *n,
+            _ => return Ok(DatumRef::Void),
+        };
+        let key = match player
+            .movie
+            .score
+            .get_sprite(sprite_num)
+            .and_then(|s| s.member.as_ref())
+        {
+            Some(m) if m.cast_lib >= 0 && m.cast_member >= 0 => {
+                (m.cast_lib as u32, m.cast_member as u32)
+            }
+            _ => return Ok(DatumRef::Void),
+        };
+        let image_ref = {
+            let Some(anim) = player.gif_animations.get_mut(&key) else {
+                return Ok(DatumRef::Void);
+            };
+            match handler {
+                "pause" | "stop" => anim.running = false,
+                "resume" | "play" => {
+                    anim.running = true;
+                    anim.last_switch_ms = 0.0;
+                }
+                "rewind" => {
+                    anim.current = 0;
+                    anim.last_switch_ms = 0.0;
+                }
+                _ => {}
+            }
+            anim.current_ref()
+        };
+        let member_ref = crate::CastMemberRef {
+            cast_lib: key.0 as i32,
+            cast_member: key.1 as i32,
+        };
+        if let Some(member) = player.movie.cast_manager.find_mut_member_by_ref(&member_ref) {
+            if let crate::player::cast_member::CastMemberType::Bitmap(b) = &mut member.member_type {
+                b.image_ref = image_ref;
+            }
+        }
+        Ok(DatumRef::Void)
+    })
+}
+
+#[cfg(test)]
+mod control_tests {
+    use super::*;
+
+    fn anim() -> GifAnimation {
+        GifAnimation {
+            frames: vec![1, 2, 3],
+            delays_ms: vec![100, 100, 100],
+            width: 4, height: 4, current: 0, last_switch_ms: 0.0, running: true,
+        }
+    }
+
+    #[test]
+    fn a_paused_animation_holds_its_frame() {
+        let mut a = anim();
+        a.advance(1000.0);
+        assert!(a.advance(1100.0));
+        assert_eq!(a.current, 1);
+        a.running = false;
+        assert!(!a.advance(5000.0), "paused, so no frame change");
+        assert_eq!(a.current, 1);
+    }
+
+    #[test]
+    fn resuming_restarts_the_clock_rather_than_jumping() {
+        let mut a = anim();
+        a.running = false;
+        a.last_switch_ms = 0.0;
+        a.running = true;
+        // First advance after a resume only seeds the clock.
+        assert!(!a.advance(60_000.0));
+        assert_eq!(a.current, 0, "no catch-up burst");
+        assert!(a.advance(60_100.0));
+        assert_eq!(a.current, 1);
+    }
+}

--- a/vm-rust/src/player/gif.rs
+++ b/vm-rust/src/player/gif.rs
@@ -205,6 +205,14 @@ pub fn take_pending() -> Vec<((u32, u32), GifAnimation)> {
     }
 }
 
+/// A movie is being replaced: drop every animation, installed or pending.
+/// The keys are (cast, member) numbers, which the next movie reuses for
+/// members of its own.
+pub fn forget_all(player: &mut crate::player::DirPlayer) {
+    player.gif_animations.clear();
+    let _ = take_pending();
+}
+
 /// Advance every animation and point its cast member at the current frame.
 /// Called once per frame from the movie loop.
 pub fn tick_gif_animations() {
@@ -435,6 +443,23 @@ mod control_tests {
         a.running = false;
         assert!(!a.advance(5000.0), "paused, so no frame change");
         assert_eq!(a.current, 1);
+    }
+
+    #[test]
+    fn a_movie_change_forgets_every_animation() {
+        crate::player::init_symbol_table();
+        crate::player::testing::run_test(async {
+            let _p = crate::player::testing::TestPlayer::new();
+            register_pending(1, 2, anim());
+            install_pending();
+            register_pending(1, 3, anim());
+            crate::player::reserve_player_mut(|player| {
+                assert!(player.gif_animations.contains_key(&(1, 2)));
+                forget_all(player);
+                assert!(player.gif_animations.is_empty());
+            });
+            assert!(take_pending().is_empty(), "a pending one is dropped too");
+        });
     }
 
     #[test]

--- a/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/bitmap.rs
@@ -286,25 +286,24 @@ impl BitmapDatumHandlers {
             );
             cropped_bitmap.use_alpha = src_bitmap.use_alpha;
             cropped_bitmap.trim_white_space = src_bitmap.trim_white_space;
-
-            let palettes = player.movie.cast_manager.palettes();
-
-            // Copy pixels from source rect to destination (0,0 to crop_width, crop_height)
-            let src_rect = IntRect::from(left, top, right, bottom);
-            let dst_rect = IntRect::from(0, 0, crop_width as i32, crop_height as i32);
-
-            let params = crate::player::bitmap::drawing::CopyPixelsParams::default(&src_bitmap);
-
-            // Need to clone src_bitmap to avoid borrow issues
-            let src_bitmap_clone = src_bitmap.clone();
-
-            cropped_bitmap.copy_pixels_with_params(
-                &palettes,
-                &src_bitmap_clone,
-                dst_rect,
-                src_rect,
-                &params,
-            );
+            // Same depth: copy the rows straight, so the alpha channel survives.
+            // Anything else still goes through the ink path.
+            if src_bitmap.bit_depth == 32 && cropped_bitmap.bit_depth == 32 {
+                cropped_bitmap = src_bitmap.crop_rgba(left, top, crop_width, crop_height);
+            } else {
+                let palettes = player.movie.cast_manager.palettes();
+                let src_rect = IntRect::from(left, top, right, bottom);
+                let dst_rect = IntRect::from(0, 0, crop_width as i32, crop_height as i32);
+                let params = crate::player::bitmap::drawing::CopyPixelsParams::default(&src_bitmap);
+                let src_bitmap_clone = src_bitmap.clone();
+                cropped_bitmap.copy_pixels_with_params(
+                    &palettes,
+                    &src_bitmap_clone,
+                    dst_rect,
+                    src_rect,
+                    &params,
+                );
+            }
 
             // Ephemeral: `bitmap.duplicate(rect)` produces a fresh bitmap not
             // owned by any cast member. Free when the wrapping DatumRef drops.

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/field.rs
@@ -518,6 +518,7 @@ impl FieldMemberHandlers {
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                            floor_rule: false,
                         };
 
                         bitmap.draw_text(

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/font.rs
@@ -2332,6 +2332,7 @@ impl FontMemberHandlers {
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     bitmap.draw_text(
@@ -2502,6 +2503,7 @@ impl FontMemberHandlers {
                                     bg_color_explicit: false,
                                     fore_color_explicit: false,
                                     ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                                    floor_rule: false,
                                 };
 
                                 if let Some(mask) = mask {

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member/text.rs
@@ -1767,6 +1767,7 @@ impl TextMemberHandlers {
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     use crate::player::bitmap::bitmap::resolve_color_ref;
@@ -2049,6 +2050,7 @@ impl TextMemberHandlers {
                                 bg_color_explicit: false,
                                 fore_color_explicit: false,
                                 ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                                floor_rule: false,
                             };
                             if use_tight {
                                 bitmap_font_copy_char_tight(

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -225,6 +225,13 @@ impl CastMemberRefHandlers {
     ) -> Result<DatumRef, ScriptError> {
         let handler_name_str = handler_name.as_str();
         match handler_name.into_builtin() {
+            // `member(x).char[a..b] = v` compiles to an object call
+            // setProp(member, #char, a, b, v). Director writes just that range
+            // of the member's text and leaves the rest; without this the call
+            // errored and the member kept whatever the author had typed.
+            Some(BuiltInSymbol::SetProp) => {
+                crate::player::handlers::manager::BuiltInHandlerManager::set_member_chunk(datum, args)
+            }
             Some(BuiltInSymbol::Duplicate) => Self::duplicate(datum, args),
             Some(BuiltInSymbol::Erase) => Self::erase(datum, args),
             Some(BuiltInSymbol::Move) => Self::move_member(datum, args),

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -121,6 +121,9 @@ impl SoundChannelDatumHandlers {
         // Mutably borrow the channel
         {
             let mut channel = channel_rc.borrow_mut();
+            // A new sound is not part of the old one's fade.
+            channel.is_fading = false;
+            channel.stop_after_fade = false;
             channel.playlist.clear();
             channel.current_segment_index = None;
             channel.stop_playback_nodes();
@@ -746,6 +749,10 @@ impl SoundChannelDatumHandlers {
         let channel_rc = Self::get_sound_channel(player, datum)?;
         // borrow mutably to access fields and methods
         let mut channel = channel_rc.borrow_mut();
+        // An explicit volume ends any fade in progress; otherwise the fade's
+        // next step overwrote the value the script just set.
+        channel.is_fading = false;
+        channel.stop_after_fade = false;
         channel.set_volume(vol);
         Ok(())
     }
@@ -1131,6 +1138,8 @@ pub struct SoundChannel {
 
     // Fade state
     pub is_fading: bool,
+    /// The fade came from fadeOut(): the channel stops when it reaches silence.
+    pub stop_after_fade: bool,
     pub fade_start_volume: f64,
     pub fade_target_volume: f64,
     pub fade_duration: f64,
@@ -1419,6 +1428,7 @@ impl SoundChannel {
             channel_count: 0,
             elapsed_time: 0.0,
             is_fading: false,
+            stop_after_fade: false,
             fade_start_volume: 0.0,
             fade_target_volume: 0.0,
             fade_duration: 0.0,
@@ -3694,8 +3704,13 @@ impl SoundChannel {
         self.volume = 0.0;
     }
 
+    /// fadeOut({ms}): fade to silence and then stop, as Director does. Left
+    /// playing at volume 0 the channel stayed busy, and Matematik i Maaneby's
+    /// map, which fades the previous house's voice out and sets the volume
+    /// back to 255 for the next, had every voice after the first swallowed.
     pub fn fade_out(&mut self, ms: i32) {
         self.fade_to(ms, 0.0);
+        self.stop_after_fade = true;
     }
 
     /// Fade this channel to `to_volume` over `ms` MILLISECONDS.
@@ -3706,6 +3721,7 @@ impl SoundChannel {
     pub fn fade_to(&mut self, ms: i32, to_volume: f64) {
         let duration = (ms as f64 / 1000.0).max(0.0);
         self.is_fading = true;
+        self.stop_after_fade = false;
         self.fade_start_volume = self.volume;
         self.fade_target_volume = to_volume;
         self.fade_duration = duration;
@@ -3729,20 +3745,29 @@ impl SoundChannel {
         self.sample_count as f64 / self.sample_rate as f64
     }
 
-    pub fn update(&mut self, delta_time: f64, player: &mut DirPlayer) -> Result<(), ScriptError> {
-        // Handle fading
-        if self.is_fading {
-            self.fade_elapsed += delta_time;
-            if self.fade_elapsed >= self.fade_duration {
-                self.set_volume(self.fade_target_volume);
-                self.is_fading = false;
-            } else {
-                let t = self.fade_elapsed / self.fade_duration;
-                let new_volume =
-                    self.fade_start_volume + (self.fade_target_volume - self.fade_start_volume) * t;
-                self.set_volume(new_volume);
-            }
+    /// Advance a fade in progress by `delta_time` seconds.
+    pub fn step_fade(&mut self, delta_time: f64) {
+        if !self.is_fading {
+            return;
         }
+        self.fade_elapsed += delta_time;
+        if self.fade_elapsed >= self.fade_duration {
+            self.set_volume(self.fade_target_volume);
+            self.is_fading = false;
+            if self.stop_after_fade {
+                self.stop_after_fade = false;
+                self.stop();
+            }
+        } else {
+            let t = self.fade_elapsed / self.fade_duration;
+            let new_volume =
+                self.fade_start_volume + (self.fade_target_volume - self.fade_start_volume) * t;
+            self.set_volume(new_volume);
+        }
+    }
+
+    pub fn update(&mut self, delta_time: f64, player: &mut DirPlayer) -> Result<(), ScriptError> {
+        self.step_fade(delta_time);
 
         // ⭐ Remove the playback advancement logic - it's handled by onended callback now
         // Audio plays asynchronously in Web Audio thread
@@ -4593,6 +4618,19 @@ mod pcm_guard_tests {
 #[cfg(test)]
 mod fade_tests {
     use super::SoundChannel;
+
+    #[test]
+    fn fade_out_stops_the_channel_when_silent() {
+        let mut ch = SoundChannel::new(4, None);
+        ch.set_volume(255.0);
+        ch.fade_out(1000);
+        assert!(ch.is_fading && ch.stop_after_fade);
+        ch.step_fade(0.5);
+        assert!(ch.is_fading, "half way through the fade");
+        ch.step_fade(0.6);
+        assert!(!ch.is_fading && !ch.stop_after_fade);
+        assert!(!ch.is_busy(), "fadeOut ends in a stopped channel");
+    }
 
     #[test]
     fn fades_are_in_milliseconds() {

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -524,8 +524,20 @@ impl SoundChannelDatumHandlers {
         datum: &DatumRef,
         member: &DatumRef,
     ) -> Result<(), ScriptError> {
+        // Director takes a bare member as well as a [#member: m, ...] list;
+        // `sound(4).queue(member("Tal - 30"))` is the form a movie uses to
+        // string spoken numbers together.
+        let entry = match player.get_datum(member) {
+            Datum::CastMember(_) => {
+                let key = player.alloc_datum(Datum::Symbol(Symbol::builtin(BuiltInSymbol::Member)));
+                let mut props = VecDeque::new();
+                props.push_back((key, member.clone()));
+                player.alloc_datum(Datum::PropList(props, false))
+            }
+            _ => member.clone(),
+        };
         let channel = Self::get_sound_channel_mut(player, datum)?;
-        channel.borrow_mut().queue(member.clone(), player); // <-- pass player here
+        channel.borrow_mut().queue(entry, player);
         Ok(())
     }
 

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -2692,6 +2692,12 @@ impl SoundChannel {
         self.elapsed_time = 0.0;
         self.loops_remaining = 0;
         self.is_fading = false;
+        // A stopped channel keeps nothing queued. Matematik i Maaneby's
+        // Gentag button stops channel 4 and queues the narration again; with
+        // the old entries left in place they played before the new ones.
+        self.playlist_segments.clear();
+        self.playlist.clear();
+        self.current_segment_index = None;
 
         if let Some(ref source) = self.source_node {
             let _ = source.stop_with_when(0.0);
@@ -4548,6 +4554,24 @@ impl SoundChannel {
         }
 
         Ok((buffer, num_channels, buffer_sample_rate))
+    }
+}
+
+#[cfg(test)]
+mod stop_tests {
+    use super::{SoundChannel, SoundSegment};
+    use crate::player::DatumRef;
+
+    #[test]
+    fn stop_empties_the_playlist() {
+        let mut ch = SoundChannel::new(4, None);
+        ch.playlist_segments.push(SoundSegment { member_ref: DatumRef::Void, loop_count: 1, loops_remaining: 1 });
+        ch.playlist.push(DatumRef::Void);
+        ch.current_segment_index = Some(0);
+        ch.stop();
+        assert!(ch.playlist_segments.is_empty());
+        assert!(ch.playlist.is_empty());
+        assert_eq!(ch.current_segment_index, None);
     }
 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -191,8 +191,9 @@ impl SoundChannelDatumHandlers {
                 Ok(datum.clone())
             }
             Some(BuiltInSymbol::FadeIn) => {
-                let ticks = if args.is_empty() {
-                    60
+                // fadeIn({milliseconds}). One argument, and it is a duration.
+                let ms = if args.is_empty() {
+                    1000
                 } else {
                     player.get_datum(&args[0]).int_value()?
                 };
@@ -201,27 +202,34 @@ impl SoundChannelDatumHandlers {
                 } else {
                     255.0
                 };
-                Self::handle_fade_in(player, datum, ticks, to_volume)?;
+                Self::handle_fade_in(player, datum, ms, to_volume)?;
                 Ok(datum.clone())
             }
             Some(BuiltInSymbol::FadeOut) => {
-                let ticks = if args.is_empty() {
-                    60
+                // fadeOut({milliseconds}). Read as ticks, a fadeOut(1000) took
+                // 16 seconds instead of one.
+                let ms = if args.is_empty() {
+                    1000
                 } else {
                     player.get_datum(&args[0]).int_value()?
                 };
-                Self::handle_fade_out(player, datum, ticks)?;
+                Self::handle_fade_out(player, datum, ms)?;
                 Ok(datum.clone())
             }
             Some(BuiltInSymbol::FadeTo) => {
                 if args.len() < 2 {
                     return Err(ScriptError::new(
-                        "fadeTo requires ticks and volume arguments".to_string(),
+                        "fadeTo requires volume and duration arguments".to_string(),
                     ));
                 }
-                let ticks = player.get_datum(&args[0]).int_value()?;
-                let to_volume = player.get_datum(&args[1]).float_value()?;
-                Self::handle_fade_to(player, datum, ticks, to_volume)?;
+                // Director's order is fadeTo(volume, milliseconds). Read the
+                // other way round, Matematik i Maaneby's music button,
+                // `sound(1).fadeTo(200 * musik, 1500)`, turned the music OFF by
+                // fading to 1500 over 0 ticks: 1500 clamps to 255, so the button
+                // meant to silence the music set it to full, instantly.
+                let to_volume = player.get_datum(&args[0]).float_value()?;
+                let ms = player.get_datum(&args[1]).int_value()?;
+                Self::handle_fade_to(player, datum, ms, to_volume)?;
                 Ok(datum.clone())
             }
             Some(BuiltInSymbol::SetPlaylist) => {
@@ -530,32 +538,32 @@ impl SoundChannelDatumHandlers {
     fn handle_fade_in(
         player: &mut DirPlayer,
         datum: &DatumRef,
-        ticks: i32,
+        ms: i32,
         to_volume: f64,
     ) -> Result<(), ScriptError> {
         let channel = Self::get_sound_channel_mut(player, datum)?;
-        channel.borrow_mut().fade_in(ticks, to_volume);
+        channel.borrow_mut().fade_in(ms, to_volume);
         Ok(())
     }
 
     fn handle_fade_out(
         player: &mut DirPlayer,
         datum: &DatumRef,
-        ticks: i32,
+        ms: i32,
     ) -> Result<(), ScriptError> {
         let channel = Self::get_sound_channel_mut(player, datum)?;
-        channel.borrow_mut().fade_out(ticks);
+        channel.borrow_mut().fade_out(ms);
         Ok(())
     }
 
     fn handle_fade_to(
         player: &mut DirPlayer,
         datum: &DatumRef,
-        ticks: i32,
+        ms: i32,
         to_volume: f64,
     ) -> Result<(), ScriptError> {
         let channel = Self::get_sound_channel_mut(player, datum)?;
-        channel.borrow_mut().fade_to(ticks, to_volume);
+        channel.borrow_mut().fade_to(ms, to_volume);
         Ok(())
     }
 
@@ -3862,8 +3870,9 @@ impl SoundChannel {
         }
     }
 
-    pub fn fade_in(&mut self, ticks: i32, to_volume: f64) {
-        let duration = ticks as f64 / 60.0;
+    /// Fade in over `ms` MILLISECONDS, same unit as `fade_to`.
+    pub fn fade_in(&mut self, ms: i32, to_volume: f64) {
+        let duration = (ms as f64 / 1000.0).max(0.0);
         self.is_fading = true;
         self.fade_start_volume = 0.0;
         self.fade_target_volume = to_volume;
@@ -3872,12 +3881,17 @@ impl SoundChannel {
         self.volume = 0.0;
     }
 
-    pub fn fade_out(&mut self, ticks: i32) {
-        self.fade_to(ticks, 0.0);
+    pub fn fade_out(&mut self, ms: i32) {
+        self.fade_to(ms, 0.0);
     }
 
-    pub fn fade_to(&mut self, ticks: i32, to_volume: f64) {
-        let duration = ticks as f64 / 60.0;
+    /// Fade this channel to `to_volume` over `ms` MILLISECONDS.
+    ///
+    /// Director's sound-channel fades are in milliseconds, not ticks. Treating
+    /// them as ticks stretched every fade by 16.7x, so a `fadeOut(1000)` took
+    /// 16 seconds instead of one.
+    pub fn fade_to(&mut self, ms: i32, to_volume: f64) {
+        let duration = (ms as f64 / 1000.0).max(0.0);
         self.is_fading = true;
         self.fade_start_volume = self.volume;
         self.fade_target_volume = to_volume;
@@ -4727,5 +4741,21 @@ impl SoundChannel {
         }
 
         Ok((buffer, num_channels, buffer_sample_rate))
+    }
+}
+
+#[cfg(test)]
+mod fade_tests {
+    use super::SoundChannel;
+
+    #[test]
+    fn fades_are_in_milliseconds() {
+        let mut ch = SoundChannel::new(1, None);
+        ch.fade_to(1500, 0.0);
+        assert!((ch.fade_duration - 1.5).abs() < 1e-9, "1500 ms is 1.5 s, not 1500 ticks");
+        ch.fade_out(1000);
+        assert!((ch.fade_duration - 1.0).abs() < 1e-9);
+        ch.fade_in(250, 1.0);
+        assert!((ch.fade_duration - 0.25).abs() < 1e-9);
     }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sound_channel.rs
@@ -1869,6 +1869,10 @@ impl SoundChannel {
 
         // Retrieve datum
         let datum = player.get_datum(&member_ref);
+        let member_name = match &datum {
+            Datum::CastMember(r) => player.movie.cast_manager.find_member_by_ref(r).map(|m| m.name.clone()).unwrap_or_default(),
+            _ => String::new(),
+        };
 
         if let Some(sound_member) = Self::resolve_sound_member(player, &datum) {
             // Update expected sample rate
@@ -1937,15 +1941,19 @@ impl SoundChannel {
                         ch.status = SoundStatus::Loading;
                     }
 
+                    // No PCM reading of these bytes exists: this branch is only
+                    // reached once the sniff found a chain of valid MPEG frames (or
+                    // an Ogg stream), and the cast's own codec field says nothing
+                    // more, since it reports "raw_pcm" for an MP3 behind an ID3 tag.
+                    // Playing the frames as samples was seconds of noise, and a zero
+                    // sample size on the way divided by zero. The channel goes idle
+                    // and the console names the member, so a decoder refusal can be
+                    // traced rather than heard.
                     if let Err(e) = Self::start_sound_mp3_async(self_rc_clone.clone(), mp3_data.clone(), mp3_sound_member).await {
-                        error!("❌ MP3 playback failed: {:?}", e);
-                        debug!("📊 MP3 data size: {} bytes, first bytes: {:02X?}",
-                            mp3_data.len(), &mp3_data[0..32.min(mp3_data.len())]);
-                        {
-                            let mut ch = self_rc_clone.borrow_mut();
-                            ch.status = SoundStatus::Idle;
-                        }
-                        Self::start_sound_pcm_fallback(self_rc_clone, member_ref);
+                        error!("❌ MP3 playback failed for \"{}\": {:?} ({} bytes, first bytes {:02X?})",
+                            member_name, e, mp3_data.len(), &mp3_data[0..16.min(mp3_data.len())]);
+                        let mut ch = self_rc_clone.borrow_mut();
+                        ch.status = SoundStatus::Idle;
                     }
                 });
                 debug!("🚀 Spawned MP3 decode task (start_sound)");
@@ -2597,223 +2605,6 @@ impl SoundChannel {
         Ok(())
     }
 
-    /// PCM fallback when MP3 decoding fails
-    fn start_sound_pcm_fallback(self_rc: Rc<RefCell<Self>>, member_ref: DatumRef) {
-        debug!("🔄 Starting PCM fallback playback");
-
-        let mut this = self_rc.borrow_mut();
-
-        // Get global player
-        // Resolve the member against the ACTIVE player, not always the host: a
-        // nested `#movie` sub-player's `puppetSound` runs under its own active id
-        // and its member_ref/datum + sound cast member live in the SUB's
-        // allocator/cast. Using PLAYER_OPT (host) looked up a different datum at
-        // that id (the "datum type: string/symbol/int" mismatch) and never found
-        // the sound member.
-        let player_opt = unsafe {
-            if crate::player::ACTIVE_PLAYER_ID == 0 {
-                crate::PLAYER_OPT.as_mut()
-            } else {
-                crate::player::NESTED_PLAYERS
-                    .get_mut(crate::player::ACTIVE_PLAYER_ID - 1)
-                    .and_then(|o| o.as_mut())
-            }
-        };
-        let player = match player_opt {
-            Some(p) => p,
-            None => {
-                error!("❌ No active player found");
-                return;
-            }
-        };
-
-        // Retrieve datum
-        let datum = player.get_datum(&member_ref);
-
-        if let Some(sound_member) = Self::resolve_sound_member(player, &datum) {
-            let audio_context = this.audio_context.clone().unwrap();
-
-            // CRITICAL FIX: Don't check for MP3 patterns here!
-            // If MP3 decoding failed and we're in fallback, just try PCM.
-            // The false positive MP3 detection was preventing any sound playback.
-
-            debug!("🔧 Forcing PCM decoding (ignoring any MP3-like patterns)");
-
-            // Force PCM decoding by treating as raw PCM (NOT MP3)
-            let pcm_wav = match Self::load_director_sound_from_bytes(
-                &sound_member.sound.data(),
-                sound_member.info.channels,
-                sound_member.info.sample_rate,
-                sound_member.info.sample_size,
-                "raw_pcm", // ← Force raw_pcm codec to avoid MP3 detection
-                Some(sound_member.info.sample_count),
-                sound_member.sound.big_endian_data(),
-            ) {
-                Ok(wav) => wav,
-                Err(e) => {
-                    error!("❌ PCM fallback failed: {}", e);
-                    this.status = SoundStatus::Idle;
-                    return;
-                }
-            };
-
-            // Decode WAV to AudioData
-            let audio_data = match AudioData::from_wav_bytes(&pcm_wav) {
-                Ok(data) => data,
-                Err(e) => {
-                    error!("❌ WAV decode failed: {}", e);
-                    this.status = SoundStatus::Idle;
-                    return;
-                }
-            };
-
-            debug!(
-                    "✅ PCM fallback: {} samples, {} Hz, {} channels",
-                    audio_data.samples.len(),
-                    audio_data.sample_rate,
-                    audio_data.num_channels
-                );
-
-            // Handle empty samples
-            if audio_data.samples.is_empty() {
-                error!("❌ Audio data has no samples");
-                this.status = SoundStatus::Idle;
-                return;
-            }
-
-            let num_frames = audio_data.samples.len() / audio_data.num_channels as usize;
-            let target_sample_rate = audio_context.sample_rate();
-            let source_sample_rate = audio_data.sample_rate as f32;
-
-            // Calculate resampling
-            let resample_ratio = target_sample_rate / source_sample_rate;
-            let resampled_frames = (num_frames as f32 * resample_ratio).round() as usize;
-
-            debug!(
-                    "🔄 Resampling {} frames -> {} frames (ratio: {:.3})",
-                    num_frames, resampled_frames, resample_ratio
-                );
-
-            // Create buffer at target sample rate
-            let buffer = match audio_context.create_buffer(
-                audio_data.num_channels as u32,
-                resampled_frames as u32,
-                target_sample_rate as f32,
-            ) {
-                Ok(buf) => buf,
-                Err(_) => {
-                    error!("❌ Failed to create AudioBuffer");
-                    this.status = SoundStatus::Idle;
-                    return;
-                }
-            };
-
-            // Resample and copy data
-            for ch in 0..audio_data.num_channels {
-                let mut channel_data = vec![0.0f32; resampled_frames];
-
-                for frame in 0..resampled_frames {
-                    let source_pos = frame as f32 / resample_ratio;
-                    let source_frame = source_pos.floor() as usize;
-                    let frac = source_pos - source_frame as f32;
-
-                    let idx1 = (source_frame * audio_data.num_channels as usize + ch as usize)
-                        .min(audio_data.samples.len() - 1);
-                    let idx2 = ((source_frame + 1) * audio_data.num_channels as usize
-                        + ch as usize)
-                        .min(audio_data.samples.len() - 1);
-
-                    let sample1 = audio_data.samples[idx1] as f32;
-                    let sample2 = audio_data.samples[idx2] as f32;
-                    channel_data[frame] = sample1 + (sample2 - sample1) * frac;
-                }
-
-                let _ = buffer.copy_to_channel(&channel_data, ch as i32);
-            }
-
-            // CRITICAL FIX: Wrap in Rc::new() for Rc<AudioBuffer>
-            this.current_audio_buffer = Some(Rc::new(buffer.clone()));
-
-            // Create and connect source node
-            let source = match audio_context.create_buffer_source() {
-                Ok(s) => s,
-                Err(_) => {
-                    error!("❌ Failed to create buffer source");
-                    this.status = SoundStatus::Idle;
-                    return;
-                }
-            };
-
-            source.set_buffer(Some(&buffer));
-            
-            // Set up looping if needed
-            let loop_count = this.loop_count;
-            if loop_count == 0 {
-                source.set_loop(true);
-            } else {
-                source.set_loop(false);
-            }
-
-            // Create gain node
-            let gain = match audio_context.create_gain() {
-                Ok(g) => g,
-                Err(_) => {
-                    error!("❌ Failed to create gain node");
-                    this.status = SoundStatus::Idle;
-                    return;
-                }
-            };
-
-            let volume = this.volume;
-            gain.gain().set_value((volume / 255.0) as f32);
-
-            // Create pan node
-            let pan = match audio_context.create_stereo_panner() {
-                Ok(p) => p,
-                Err(_) => {
-                    error!("❌ Failed to create pan node");
-                    this.status = SoundStatus::Idle;
-                    return;
-                }
-            };
-
-            let pan_value = this.pan;
-            pan.pan().set_value(pan_value as f32);
-
-            // Connect the audio graph
-            let _ = source.connect_with_audio_node(&gain);
-            let _ = gain.connect_with_audio_node(&pan);
-            let _ = pan.connect_with_audio_node(&audio_context.destination());
-
-            // Set up the onended callback before starting
-            let channel_index = this.channel_num;
-            let closure = Closure::<dyn FnMut()>::new(move || {
-                SoundChannel::handle_end_of_sound(channel_index);
-            });
-            source.add_event_listener_with_callback("ended", closure.as_ref().unchecked_ref())
-                .unwrap_or_else(|e| {
-                    warn!("⚠️ Failed to add ended listener: {:?}", e);
-                });
-            closure.forget();
-
-            // Start playback
-            let _ = source.start();
-
-            debug!("✅ PCM fallback playback started successfully");
-
-            // CRITICAL FIX: Wrap all nodes in Rc::new()
-            this.source_node = Some(Rc::new(source));
-            this.gain_node = Some(Rc::new(gain));
-            this.pan_node = Some(Rc::new(pan));
-            this.status = SoundStatus::Playing;
-            this.playback_start_context_time = this.context_time();
-        } else {
-            error!("❌ Could not resolve sound member");
-            this.status = SoundStatus::Idle;
-        }
-    }
-
-    /// Validates MP3 frame headers and calculates frame size
     fn get_mp3_frame_info(header: &[u8; 4]) -> Option<(usize, u32)> {
         if header[0] != 0xFF || (header[1] & 0xE0) != 0xE0 {
             return None;
@@ -3232,7 +3023,11 @@ impl SoundChannel {
         } else {
             bits_per_sample
         };
-        let sample_count = (pcm_data.len() / (channels as usize * (bits as usize / 8))) as u32;
+        let bytes_per_frame = channels as usize * (bits as usize / 8);
+        if bytes_per_frame == 0 {
+            return Err(format!("cannot build PCM from {} channels at {} bits", channels, bits));
+        }
+        let sample_count = (pcm_data.len() / bytes_per_frame) as u32;
         let byte_rate = sample_rate * channels as u32 * bits as u32 / 8;
         let block_align = (channels * bits / 8) as u16;
         let data_len = pcm_data.len() as u32;
@@ -4753,6 +4548,21 @@ impl SoundChannel {
         }
 
         Ok((buffer, num_channels, buffer_sample_rate))
+    }
+}
+
+#[cfg(test)]
+mod pcm_guard_tests {
+    use super::SoundChannel;
+
+    #[test]
+    fn a_zero_frame_size_is_an_error_not_a_panic() {
+        // A member with no sample size (an MP3 whose decode failed) used to
+        // reach the WAV builder and divide by zero.
+        let r = SoundChannel::load_director_sound_from_bytes(&[0x49, 0x44, 0x33, 0x03, 0, 0, 0, 0], 1, 22050, 0, "raw_pcm", None, false);
+        assert!(r.is_err());
+        let r = SoundChannel::load_director_sound_from_bytes(&[1, 2, 3, 4, 5, 6, 7, 8], 0, 22050, 16, "raw_pcm", None, false);
+        assert!(r.is_err());
     }
 }
 

--- a/vm-rust/src/player/handlers/datum_handlers/sprite.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/sprite.rs
@@ -307,6 +307,15 @@ impl SpriteDatumHandlers {
         if is_sync_handler {
             return Ok(false);
         }
+        // pause and resume are not built-ins on an ordinary sprite, so they stay
+        // on the async path where a behaviour may define them. On a sprite
+        // showing an animated GIF they drive the animation.
+        if matches!(name_lower.as_str(), "pause" | "resume")
+            && crate::player::gif::sprite_has_gif(datum)
+        {
+            return Ok(false);
+        }
+
 
         // For all other handlers, use the async path which will:
         // 1. Try sprite's attached scripts
@@ -321,6 +330,15 @@ impl SpriteDatumHandlers {
     ) -> Result<DatumRef, ScriptError> {
         let name_lower = handler_name.to_lowercase();
         match name_lower.as_str() {
+            // A movie drives an animated GIF through its sprite:
+            // `sprite(n).pause()` freezes it, `rewind()` returns it to frame 1
+            // and `resume()` starts it again. Without these the animation runs
+            // continuously, so a plume meant to puff at intervals never stops.
+            "pause" | "resume" | "rewind" | "play" | "stop"
+                if crate::player::gif::sprite_has_gif(datum) =>
+            {
+                crate::player::gif::control_sprite_gif(datum, &name_lower)
+            }
             // `sprite(N).pointToChar(point)` — 1-based char index at a stage
             // coordinate within the sprite's text/field member, or -1 if the
             // point isn't within the text (Director 11.5 Scripting Dictionary).

--- a/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/string_chunk.rs
@@ -1352,3 +1352,26 @@ mod tests {
         assert_eq!(del_word("a   b   c", 2, 0), "a   c");
     }
 }
+
+#[cfg(test)]
+mod chunk_write_tests {
+    use super::StringChunkUtils;
+    use crate::director::lingo::datum::{StringChunkExpr, StringChunkType};
+
+    fn chars(start: i32, end: i32) -> StringChunkExpr {
+        StringChunkExpr { chunk_type: StringChunkType::Char, start, end, item_delimiter: ',' }
+    }
+
+    #[test]
+    fn a_range_past_the_end_replaces_to_the_end() {
+        // The form a movie uses to relabel a field: char[1..10] on a shorter text.
+        assert_eq!(StringChunkUtils::string_by_putting_into_chunk("100 x 8", &chars(1, 10), "10 x 6").unwrap(), "10 x 6");
+        assert_eq!(StringChunkUtils::string_by_putting_into_chunk("", &chars(1, 10), "10 x 6").unwrap(), "10 x 6");
+    }
+
+    #[test]
+    fn a_range_inside_keeps_both_sides() {
+        assert_eq!(StringChunkUtils::string_by_putting_into_chunk("ABCDEFGH", &chars(3, 5), "xy").unwrap(), "ABxyFGH");
+        assert_eq!(StringChunkUtils::string_by_putting_into_chunk("ABCDEFGHIJKLMNOP", &chars(1, 10), "4 x 8").unwrap(), "4 x 8KLMNOP");
+    }
+}

--- a/vm-rust/src/player/handlers/manager.rs
+++ b/vm-rust/src/player/handlers/manager.rs
@@ -1723,6 +1723,10 @@ impl BuiltInHandlerManager {
                 match datum_type {
                     DatumType::PropList => PropListDatumHandlers::set_opt_prop(datum, args),
                     DatumType::ScriptInstanceRef => ScriptInstanceDatumHandlers::set_prop(datum, args),
+                    // `member(x).char[a..b] = v` compiles to
+                    // setProp(member, #char, a, b, v) â€” a chunk write into the
+                    // member's text, keeping everything outside the range.
+                    DatumType::CastMemberRef => Self::set_member_chunk(datum, args),
                     _ => Err(ScriptError::new(
                         "Cannot setProp on non-prop list or child object".to_string(),
                     )),
@@ -3017,6 +3021,60 @@ impl BuiltInHandlerManager {
             }
         })
     }
+    /// `setProp(member, #char|#word|#item|#line, first, last, value)` â€” the
+    /// compiled form of `member(x).char[a..b] = value`. Replaces exactly that
+    /// range of the member's text and leaves the rest alone. `last` is
+    /// optional: `member(x).char[a] = v` compiles with four arguments.
+    pub fn set_member_chunk(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        use crate::director::lingo::datum::{StringChunkExpr, StringChunkType};
+        use crate::player::handlers::datum_handlers::string_chunk::StringChunkUtils;
+        use crate::player::handlers::datum_handlers::cast_member_ref::CastMemberRefHandlers;
+        if args.len() < 3 {
+            return Err(ScriptError::new(format!(
+                "setProp on a member needs a chunk kind, a range and a value (got {} args)",
+                args.len()
+            )));
+        }
+        let (member_ref, chunk_type, first, last, replacement) = reserve_player_ref(|player| {
+            let member_ref = match player.get_datum(datum) {
+                Datum::CastMember(r) => r.to_owned(),
+                other => {
+                    return Err(ScriptError::new(format!(
+                        "setProp: expected a cast member, got {}", other.type_str()
+                    )))
+                }
+            };
+            let kind = match player.get_datum(&args[0]) {
+                Datum::Symbol(sym) => sym.clone(),
+                other => {
+                    return Err(ScriptError::new(format!(
+                        "setProp: expected a chunk symbol, got {}", other.type_str()
+                    )))
+                }
+            };
+            let chunk_type = StringChunkType::from(kind);
+            let first = player.get_datum(&args[1]).int_value()?;
+            let (last, value_ref) = if args.len() >= 4 {
+                (player.get_datum(&args[2]).int_value()?, &args[3])
+            } else {
+                (first, &args[2])
+            };
+            let replacement = player.get_datum(value_ref).string_value()?;
+            Ok((member_ref, chunk_type, first, last, replacement))
+        })?;
+        let current = reserve_player_mut(|player| {
+            CastMemberRefHandlers::get_prop(player, &member_ref, Symbol::from_str("text"))
+                .ok()
+                .and_then(|d| d.string_value().ok())
+                .unwrap_or_default()
+        });
+        let item_delimiter = reserve_player_ref(|player| player.movie.item_delimiter);
+        let chunk_expr = StringChunkExpr { chunk_type, start: first, end: last, item_delimiter };
+        let new_text = StringChunkUtils::string_by_putting_into_chunk(&current, &chunk_expr, &replacement)?;
+        CastMemberRefHandlers::set_prop(&member_ref, Symbol::from_str("text"), Datum::String(new_text))?;
+        Ok(DatumRef::Void)
+    }
+
 }
 
 

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -1295,6 +1295,8 @@ impl MovieHandlers {
     }
 
     pub async fn update_stage(_: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        // An explicit updateStage draws now, handler or not.
+        reserve_player_mut(|player| player.draw_hold_since_ms = None);
         let should_yield = reserve_player_ref(|player| {
             // Yield when: mouse handler context, command handler yielding,
             // yield-safe state, OR mouse is currently down (covers

--- a/vm-rust/src/player/handlers/movie.rs
+++ b/vm-rust/src/player/handlers/movie.rs
@@ -1219,6 +1219,11 @@ impl MovieHandlers {
         // cursor is still.
         crate::player::events::dispatch_rollover_events();
 
+        // Animated GIF members: put up whichever frame the elapsed time calls
+        // for. Done here, once per frame, so an animation runs at its own
+        // delays regardless of the movie's tempo.
+        crate::player::gif::tick_gif_animations();
+
         // Relay prepareFrame to timeout targets
         dispatch_system_event_to_timeouts(BuiltInSymbol::PrepareFrame, &vec![]).await;
 

--- a/vm-rust/src/player/keyboard.rs
+++ b/vm-rust/src/player/keyboard.rs
@@ -9,6 +9,10 @@ pub struct KeyboardKey {
 
 pub struct KeyboardManager {
     pub down_keys: Vec<KeyboardKey>,
+    /// The key most recently pressed, kept after its release: `the key` and
+    /// `the keyCode` report it inside `on keyUp`, when the key is no longer
+    /// down. Cleared by nothing but the next key press.
+    pub last_key: Option<KeyboardKey>,
     /// Timestamp of the most recent `key_down`; `None` if no key has been
     /// pressed since the movie started. Used by `the lastKey` to compute
     /// ticks since the last key event.
@@ -19,6 +23,7 @@ impl KeyboardManager {
     pub fn new() -> Self {
         Self {
             down_keys: Vec::new(),
+            last_key: None,
             last_key_time: None,
         }
     }
@@ -37,6 +42,11 @@ impl KeyboardManager {
             _ => key,
         };
 
+        self.last_key = Some(KeyboardKey {
+            key: mapped_key.clone(),
+            code: mapped_code,
+        });
+
         // Check if this code is already in the down_keys list
         if !self.down_keys.iter().any(|x| x.code == mapped_code) {
             self.down_keys.push(KeyboardKey {
@@ -44,6 +54,12 @@ impl KeyboardManager {
                 code: mapped_code,
             });
         }
+    }
+
+    /// The key `the key` and `the keyCode` describe: the one most recently
+    /// pressed among those still down, else the last one pressed.
+    fn current_key(&self) -> Option<&KeyboardKey> {
+        self.down_keys.last().or(self.last_key.as_ref())
     }
 
     pub fn key_up(&mut self, _: &str, code: u16) {
@@ -86,12 +102,7 @@ impl KeyboardManager {
     }
 
     pub fn key_code(&self) -> u16 {
-        if self.down_keys.len() == 0 {
-            return 0;
-        }
-
-        let key = self.down_keys.last().unwrap();
-        key.code
+        self.current_key().map_or(0, |key| key.code)
     }
 
     /// Translate a stored browser key name (e.g. `e.key` = "ArrowLeft") to the
@@ -112,10 +123,9 @@ impl KeyboardManager {
     }
 
     pub fn key(&self) -> String {
-        if self.down_keys.is_empty() {
+        let Some(key) = self.current_key().map(|key| &key.key) else {
             return "".to_string();
-        }
-        let key = &self.down_keys.last().unwrap().key;
+        };
         if let Some(ch) = Self::director_char_for(key) {
             return ch.to_string();
         }
@@ -137,3 +147,33 @@ impl KeyboardManager {
         key.clone()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::KeyboardManager;
+
+    #[test]
+    fn the_key_survives_the_release() {
+        // `on keyUp` runs after the key has left the down list, and Director
+        // still reports the released key there.
+        let mut kb = KeyboardManager::new();
+        kb.key_down(" ".to_string(), 32);
+        let code = kb.key_code();
+        assert_eq!(kb.key(), " ");
+        kb.key_up(" ", 32);
+        assert_eq!(kb.key(), " ");
+        assert_eq!(kb.key_code(), code);
+        assert!(!kb.is_key_down(" "));
+        assert_eq!(kb.key_pressed(), "", "keyPressed is about keys still down");
+    }
+
+    #[test]
+    fn a_key_still_down_wins_over_the_last_release() {
+        let mut kb = KeyboardManager::new();
+        kb.key_down("a".to_string(), 65);
+        kb.key_down("b".to_string(), 66);
+        kb.key_up("b", 66);
+        assert_eq!(kb.key(), "a");
+    }
+}
+

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -26,6 +26,7 @@ pub mod eval;
 pub mod events;
 pub mod font;
 pub mod geometry;
+pub mod gif;
 pub mod handlers;
 pub mod interp_stats;
 pub mod js_lingo;
@@ -368,6 +369,10 @@ pub struct DirPlayer {
     /// events are per-sprite (see `get_sprites_at`), so this has to be a set
     /// rather than just the front-most sprite.
     pub hovered_sprites: Vec<i16>,
+    /// Animated GIF cast members, keyed by (cast_lib, member number). Each
+    /// holds its decoded frames; the frame loop swaps the member's image_ref
+    /// as the delays elapse. See player::gif.
+    pub gif_animations: std::collections::HashMap<(u32, u32), crate::player::gif::GifAnimation>,
     pub picking_mode: bool,
     pub allocator: DatumAllocator,
     pub dir_cache: HashMap<Box<str>, DirectorFile>,
@@ -779,6 +784,7 @@ impl DirPlayer {
             float_precision: 4,
             last_handler_result: DatumRef::Void,
             hovered_sprites: Vec::new(),
+            gif_animations: std::collections::HashMap::new(),
             picking_mode: false,
             allocator: DatumAllocator::default(),
             dir_cache: HashMap::new(),
@@ -5370,6 +5376,10 @@ async fn eval_startup_payload(code: Option<String>, flag: &str) {
 /// stepFrame, prepareFrame, startMovie, enterFrame, exitFrame.
 /// Shared by `play()` and `transition_to_net_movie`.
 async fn run_movie_init_sequence() {
+    // Animated GIF members were decoded while the cast was built, before the
+    // player could be borrowed; hand them over now so the frame loop can run
+    // them. See player::gif.
+    crate::player::gif::install_pending();
     // The projector's `--do` argument, evaluated before the movie's own code
     // gets a turn. See `DirPlayer::startup_do`.
     run_startup_do().await;

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -519,6 +519,15 @@ pub struct DirPlayer {
     pub current_frame_tempo: u32,  // Cached tempo for the current frame
     pub has_player_frame_changed: bool,
     pub stage_dirty: bool, // Set when any sprite property changes; cleared after render
+    /// Set when an input handler (mouse or key) starts running, cleared once
+    /// the next exitFrame has run. While it is set the stage is not redrawn:
+    /// Director draws once per frame, after the handlers of that frame and
+    /// its exitFrame have both run, so a handler's half-finished state is
+    /// never on screen. Matematik i Maaneby's crane shows a claw sprite from
+    /// mouseUp and moves it into place in exitFrame; drawing in between put
+    /// the claw where that sprite last was for one frame. A timestamp, so a
+    /// hold can never outlive a stalled frame loop.
+    pub draw_hold_since_ms: Option<i64>,
     pub preview_dirty: bool, // Set when preview member/settings change; cleared after preview render
     pub has_frame_changed_in_go: bool,
     pub go_same_frame: bool,
@@ -834,6 +843,7 @@ impl DirPlayer {
             current_frame_tempo: 30,  // Default to 30 fps
             has_player_frame_changed: false,
             stage_dirty: true,
+            draw_hold_since_ms: None,
             preview_dirty: true,
             has_frame_changed_in_go: false,
             go_same_frame: false,
@@ -4323,6 +4333,16 @@ where
 }
 
 #[inline(always)]
+/// An input handler is about to run: hold the stage redraw until the next
+/// exitFrame has settled what it changes (`DirPlayer::draw_hold_since_ms`).
+pub fn hold_draw_for_input_handler() {
+    reserve_player_mut(|player| {
+        if player.draw_hold_since_ms.is_none() {
+            player.draw_hold_since_ms = Some(chrono::Utc::now().timestamp_millis());
+        }
+    });
+}
+
 pub fn reserve_player_mut<T, F>(callback: F) -> T
 where
     F: FnOnce(&mut DirPlayer) -> T,
@@ -6236,6 +6256,13 @@ pub async fn run_single_frame() -> (bool, bool) {
     }
 
     player_wait_available().await;
+
+    // exitFrame has run: whatever the input handlers changed is settled. A
+    // frame that had a handler is drawn right here, Director's draw point, so
+    // no further handler can slip in before the picture.
+    if reserve_player_mut(|player| player.draw_hold_since_ms.take().is_some()) {
+        crate::rendering::draw_frame_at_frame_end();
+    }
 
     // Eager movie mount anywhere in the exitFrame dispatches above: hand the
     // rest of the cycle to the frame loop's pending-init path.

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -1402,6 +1402,15 @@ impl DirPlayer {
         }
     }
 
+    /// The `cursor` setting belongs to the movie that made it: a new movie
+    /// starts with the system arrow. A task movie that hid the cursor for a
+    /// drag otherwise left the next movie without one.
+    pub fn reset_cursor_for_new_movie(&mut self) {
+        self.cursor = CursorRef::System(0);
+        self.cursor_is_hidden = false;
+        self.wants_pointer_lock = false;
+    }
+
     pub(crate) async fn load_movie_from_dir(&mut self, dir: DirectorFile) {
         // Start this movie from the builtin display-spelling baseline. A cast's
         // name table claims the spelling for symbols it defines
@@ -1421,6 +1430,7 @@ impl DirPlayer {
         // member numbers: the map's planet and smoke frames turned up on a
         // task scene's craftsman and plank piles.
         crate::player::gif::forget_all(self);
+        self.reset_cursor_for_new_movie();
         self.movie
             .load_from_file(
                 dir,
@@ -8067,6 +8077,29 @@ mod interp_bench {
             let report = crate::player::run_bytecode_benchmark();
             println!("{report}");
             assert!(report.contains("ops/sec"));
+        });
+    }
+}
+
+#[cfg(test)]
+mod cursor_reset_tests {
+    use super::*;
+    use crate::player::testing::{run_test, TestPlayer};
+
+    #[test]
+    fn a_new_movie_starts_with_the_arrow() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|p| {
+                p.cursor = CursorRef::System(200);
+                p.cursor_is_hidden = true;
+                p.wants_pointer_lock = true;
+                p.reset_cursor_for_new_movie();
+                assert!(matches!(p.cursor, CursorRef::System(0)));
+                assert!(!p.cursor_is_hidden);
+                assert!(!p.wants_pointer_lock);
+            });
         });
     }
 }

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -1416,6 +1416,11 @@ impl DirPlayer {
         // movies to System-Win; these differ at high indices and decide how
         // indexed bitmaps / shape pattern fills resolve. Read before `dir` moves.
         crate::player::bitmap::bitmap::set_default_system_palette_from_platform(dir.config.platform);
+        // The GIF animations belong to the cast that is going away. Left in
+        // place, their keys land on whatever the next movie keeps at those
+        // member numbers: the map's planet and smoke frames turned up on a
+        // task scene's craftsman and plank piles.
+        crate::player::gif::forget_all(self);
         self.movie
             .load_from_file(
                 dir,

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -5885,7 +5885,7 @@ async fn restart_current_movie() {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(js_name = "dirplayer_isFlashLoading", catch)]
-    fn is_flash_loading() -> Result<bool, wasm_bindgen::JsValue>;
+    pub(crate) fn is_flash_loading() -> Result<bool, wasm_bindgen::JsValue>;
 
     /// Resize a live Ruffle instance so it re-renders the vector sharp at the
     /// sprite's current on-stage size (splashes grow, arm swaps dims).

--- a/vm-rust/src/player/mod.rs
+++ b/vm-rust/src/player/mod.rs
@@ -4343,6 +4343,27 @@ pub fn hold_draw_for_input_handler() {
     });
 }
 
+/// Director runs one handler at a time: input that arrives while a frame
+/// handler is busy-waiting (`repeat while ... updateStage()`) is queued until
+/// the handler returns. The busy-wait yield lets the command and event loops
+/// run inside that wait, so a mouseEnter fired mid-animation on Maaneby's map
+/// build sequence, where the original ignores the mouse until it is over.
+/// Waits for the gap; never drops the input.
+pub async fn wait_for_handler_gap() {
+    loop {
+        let busy = reserve_player_ref(|player| {
+            player.is_playing
+                && !player.is_yield_safe()
+                && !player.in_mouse_command
+                && !player.command_handler_yielding
+        });
+        if !busy {
+            return;
+        }
+        let _ = timeout(Duration::from_millis(4), future::pending::<()>()).await;
+    }
+}
+
 pub fn reserve_player_mut<T, F>(callback: F) -> T
 where
     F: FnOnce(&mut DirPlayer) -> T,
@@ -8041,6 +8062,44 @@ mod interp_bench {
             let report = crate::player::run_bytecode_benchmark();
             println!("{report}");
             assert!(report.contains("ops/sec"));
+        });
+    }
+}
+
+#[cfg(test)]
+mod handler_gap_tests {
+    use super::*;
+    use crate::player::testing::{run_test, TestPlayer};
+
+    #[test]
+    fn input_waits_until_the_frame_handler_returns() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|p| {
+                p.is_playing = true;
+                p.in_frame_script = true;
+            });
+            let held = timeout(Duration::from_millis(30), wait_for_handler_gap()).await;
+            assert!(held.is_err(), "input ran inside the frame handler");
+            reserve_player_mut(|p| p.in_frame_script = false);
+            let released = timeout(Duration::from_millis(200), wait_for_handler_gap()).await;
+            assert!(released.is_ok(), "input never ran after the handler returned");
+        });
+    }
+
+    #[test]
+    fn a_mouse_handler_does_not_hold_input() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|p| {
+                p.is_playing = true;
+                p.in_frame_script = true;
+                p.in_mouse_command = true;
+            });
+            let released = timeout(Duration::from_millis(200), wait_for_handler_gap()).await;
+            assert!(released.is_ok());
         });
     }
 }

--- a/vm-rust/src/player/net_task.rs
+++ b/vm-rust/src/player/net_task.rs
@@ -229,6 +229,14 @@ async fn maybe_hold_dcr_for_preloader(url: &str) {
     if crate::player::reserve_player_ref(|p| p.goto_wait_active || !p.is_playing) {
         return;
     }
+    // Only while a Flash preloader is actually loading. The hold is for DGS,
+    // and unqualified it delayed every movie in every game by three seconds:
+    // in Matematik i Maaneby a scene took 3.4 to 4.7 s to open with its movie
+    // already in Cache Storage, where the bytes come back in about 20 ms, and
+    // `netDone` stayed false for exactly this timeout.
+    if !crate::player::is_flash_loading().unwrap_or(false) {
+        return;
+    }
     let _ = async_std::future::timeout(
         std::time::Duration::from_millis(3000),
         std::future::pending::<()>(),

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -4437,6 +4437,13 @@ fn sprite_set_prop_is_noop(
     })
 }
 
+
+/// A rect with its corners the right way round, as Director keeps them:
+/// rect(10, 50, 12, 20) and rect(10, 20, 12, 50) are the same rect.
+pub fn normalise_rect([l, t, r, b]: [i32; 4]) -> [i32; 4] {
+    [l.min(r), t.min(b), l.max(r), t.max(b)]
+}
+
 pub fn sprite_set_prop(sprite_id: i16, prop_name: Symbol, value: Datum) -> Result<(), ScriptError> {
     // Director silently ignores property writes to invalid sprite refs. A
     // script doing `sprite(N).prop = X` where N came from a list-lookup
@@ -5065,6 +5072,14 @@ pub fn sprite_set_prop(sprite_id: i16, prop_name: Symbol, value: Datum) -> Resul
             };
             let [left, top, right, bottom] = rect_values
                 .ok_or_else(|| ScriptError::new("rect parse failed".to_string()))?;
+            // Director normalises a rect whose corners arrive the wrong way
+            // round. Movies rely on it when they draw a line between two
+            // moving points: a crane wire written as
+            //   rect(x, yClaw, x + 2, yArm)
+            // has its top below its bottom whenever the claw hangs under the
+            // arm. Taken literally that sprite got a height of -541 and drew
+            // as a full-height line.
+            let [left, top, right, bottom] = normalise_rect([left, top, right, bottom]);
             let new_width = right - left;
             let new_height = bottom - top;
 
@@ -6931,4 +6946,21 @@ pub fn get_score_sprite_mut<'a>(
 ) -> Option<&'a mut Sprite> {
     let score = get_score_mut(movie, score_source)?;
     Some(score.get_sprite_mut(channel_num))
+}
+
+#[cfg(test)]
+mod rect_tests {
+    use super::normalise_rect;
+
+    #[test]
+    fn inverted_corners_are_swapped() {
+        assert_eq!(normalise_rect([10, 50, 12, 20]), [10, 20, 12, 50]);
+        assert_eq!(normalise_rect([12, 20, 10, 50]), [10, 20, 12, 50]);
+    }
+
+    #[test]
+    fn a_normal_rect_is_untouched() {
+        assert_eq!(normalise_rect([10, 20, 12, 50]), [10, 20, 12, 50]);
+        assert_eq!(normalise_rect([0, 0, 0, 0]), [0, 0, 0, 0]);
+    }
 }

--- a/vm-rust/src/player/score.rs
+++ b/vm-rust/src/player/score.rs
@@ -1947,11 +1947,10 @@ impl Score {
                     continue;
                 }
 
-                let (detail_info_opt, _details_count) = reserve_player_ref(|player| {
-                    let info = player.movie.score.sprite_details.get(&sprite_list_idx).cloned();
-                    let count = player.movie.score.sprite_details.len();
-                    (info, count)
-                });
+                // The index names an entry in THIS score's table. A film loop
+                // carries its own; read through the stage's and the index lands
+                // on whatever the main score keeps there, frame scripts included.
+                let detail_info_opt = self.sprite_details.get(&sprite_list_idx).cloned();
 
                 if let Some(detail_info) = detail_info_opt {
                     if detail_info.behaviors.is_empty() {
@@ -2241,9 +2240,7 @@ impl Score {
                     continue;
                 }
 
-                let detail_info_opt = reserve_player_ref(|player| {
-                    player.movie.score.sprite_details.get(&sprite_list_idx).cloned()
-                });
+                let detail_info_opt = self.sprite_details.get(&sprite_list_idx).cloned();
 
                 if let Some(detail_info) = detail_info_opt {
                     if detail_info.behaviors.is_empty() {

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -636,6 +636,7 @@ pub fn render_preview_bitmap(
                 bg_color_explicit: false,
                 fore_color_explicit: false,
                 ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                floor_rule: false,
             };
 
             for char_code in 0u16..256 {
@@ -663,6 +664,7 @@ pub fn render_preview_bitmap(
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                            floor_rule: false,
                         };
                         bitmap.draw_text(
                             &label,
@@ -1471,6 +1473,7 @@ fn render_filmloop_from_channel_data(
                     fore_color_explicit: false,
                     ink9_mask_bitmap: ink9_mask.as_ref().map(|(bmp, _)| bmp),
                     ink9_mask_offset: ink9_mask.as_ref().map(|(_, off)| *off).unwrap_or((0, 0)),
+                    floor_rule: true,
                 };
 
                 bitmap.copy_pixels_with_params(
@@ -1547,6 +1550,7 @@ fn render_filmloop_from_channel_data(
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     bitmap.draw_text(
@@ -1625,6 +1629,7 @@ fn render_filmloop_from_channel_data(
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     bitmap.draw_text(
@@ -1674,6 +1679,7 @@ fn render_filmloop_from_channel_data(
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                            floor_rule: false,
                         };
 
                         bitmap.copy_pixels_with_params(
@@ -1761,6 +1767,7 @@ fn render_filmloop_from_channel_data(
                     bg_color_explicit: false,
                     fore_color_explicit: false,
                     ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                    floor_rule: false,
                 };
 
                 bitmap.copy_pixels_with_params(
@@ -2125,6 +2132,7 @@ pub fn render_score_to_bitmap_with_offset(
                     original_dst_rect: Some(logical_rect),
                     ink9_mask_bitmap: ink9_mask.as_ref().map(|(bmp, _)| bmp),
                     ink9_mask_offset: ink9_mask.as_ref().map(|(_, off)| *off).unwrap_or((0, 0)),
+                    floor_rule: true,
                 };
 
                 if let Some(mask) = mask {
@@ -2307,6 +2315,7 @@ pub fn render_score_to_bitmap_with_offset(
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     let is_focused = player.keyboard_focus_sprite == sprite.number as i16;
@@ -2510,6 +2519,7 @@ pub fn render_score_to_bitmap_with_offset(
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     let wrap_w = if field.word_wrap { text_area_w } else { 0 };
@@ -2678,6 +2688,7 @@ pub fn render_score_to_bitmap_with_offset(
                     bg_color_explicit: false,
                     fore_color_explicit: false,
                     ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                    floor_rule: false,
                 };
 
                 if let Some(mask) = mask {
@@ -2817,6 +2828,7 @@ pub fn render_score_to_bitmap_with_offset(
                         bg_color_explicit: false,
                         fore_color_explicit: false,
                         ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                        floor_rule: false,
                     };
 
                     // Use styled text rendering if html_styled_spans is populated
@@ -3085,6 +3097,7 @@ pub fn render_score_to_bitmap_with_offset(
                     bg_color_explicit: false,
                     fore_color_explicit: false,
                     ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                    floor_rule: false,
                 };
 
                 // Debug: log filmloop bitmap properties before compositing
@@ -3160,6 +3173,7 @@ pub fn render_score_to_bitmap_with_offset(
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                            floor_rule: false,
                         };
 
                         bitmap.copy_pixels_with_params(
@@ -3498,6 +3512,7 @@ impl PlayerCanvasRenderer {
                 bg_color_explicit: false,
                 fore_color_explicit: false,
                 ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                floor_rule: false,
             };
 
             bitmap.draw_text(

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -1485,8 +1485,15 @@ fn render_filmloop_from_channel_data(
                 );
             }
             CastMemberType::Shape(shape_member) => {
-                // Skip rendering shapes with tiny dimensions (blank placeholders or zero-size)
-                if data.width <= 1 || data.height <= 1 {
+                // Skip blank placeholders and zero-size shapes, but NOT a #line: a line
+                // is 1 px in one dimension by nature, so "width <= 1 || height <= 1"
+                // dropped every horizontal and vertical line before it reached the
+                // draw code (which explicitly promises a line "never vanishes"). The
+                // divider under the ruler on klods.dcr's working drawing went missing
+                // this way; measured against the projector, S8. A line is skipped
+                // only when BOTH dimensions collapse.
+                let is_line = matches!(shape_member.shape_info.shape_type, crate::director::enums::ShapeType::Line);
+                if (data.width <= 1 || data.height <= 1) && !(is_line && (data.width > 1 || data.height > 1)) {
                     continue;
                 }
 
@@ -2164,8 +2171,15 @@ pub fn render_score_to_bitmap_with_offset(
             CastMemberType::Shape(shape_member) => {
                 let sprite = get_score_sprite(&player.movie, score_source, channel_num).unwrap();
 
-                // Skip rendering shapes with tiny dimensions (blank placeholders or zero-size)
-                if sprite.width <= 1 || sprite.height <= 1 {
+                // Skip blank placeholders and zero-size shapes, but NOT a #line: a line
+                // is 1 px in one dimension by nature, so "width <= 1 || height <= 1"
+                // dropped every horizontal and vertical line before it reached the
+                // draw code (which explicitly promises a line "never vanishes"). The
+                // divider under the ruler on klods.dcr's working drawing went missing
+                // this way; measured against the projector, S8. A line is skipped
+                // only when BOTH dimensions collapse.
+                let is_line = matches!(shape_member.shape_info.shape_type, crate::director::enums::ShapeType::Line);
+                if (sprite.width <= 1 || sprite.height <= 1) && !(is_line && (sprite.width > 1 || sprite.height > 1)) {
                     continue;
                 }
 

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -3745,6 +3745,27 @@ pub fn draw_frame_immediate() {
     }
 }
 
+/// Draw the stage at the end of a frame cycle whose input handlers held the
+/// redraw (see `DirPlayer::draw_hold_since_ms`). Unpaced: this is the one
+/// draw Director makes for that frame.
+pub fn draw_frame_at_frame_end() {
+    if unsafe { crate::player::ACTIVE_PLAYER_ID } != 0 {
+        return;
+    }
+    if should_skip_stage_draw() {
+        return;
+    }
+    with_renderer_mut(|renderer_lock| {
+        if let Some(renderer) = renderer_lock {
+            reserve_player_mut(|player| {
+                renderer.draw_frame(player);
+                player.stage_dirty = false;
+            });
+        }
+        mark_frame_drawn();
+    });
+}
+
 /// Helper to access Canvas2D renderer for Canvas2D-specific operations
 #[allow(dead_code)]
 pub fn with_canvas2d_renderer<F, R>(f: F) -> Option<R>
@@ -4227,7 +4248,13 @@ async fn run_draw_loop() {
             let skip_stage = should_skip_stage_draw();
             with_renderer_mut(|renderer_lock| {
                 if let Some(renderer) = renderer_lock {
-                    if !skip_stage && (player.is_playing || player.stage_dirty) && !was_frame_drawn_recently(frame_interval) {
+                    // Between an input handler and the exitFrame that follows it the
+                    // stage is not redrawn (see `draw_hold_since_ms`). Bounded by
+                    // time so a paused or stalled frame loop cannot hold it forever.
+                    let held = player.draw_hold_since_ms.map_or(false, |since| {
+                        player.is_playing && chrono::Utc::now().timestamp_millis() - since < 250
+                    });
+                    if !skip_stage && !held && (player.is_playing || player.stage_dirty) && !was_frame_drawn_recently(frame_interval) {
                         renderer.draw_frame(&mut player);
                         player.stage_dirty = false;
                     }

--- a/vm-rust/src/rendering.rs
+++ b/vm-rust/src/rendering.rs
@@ -2027,6 +2027,19 @@ pub fn render_score_to_bitmap_with_offset(
                     None
                 };
 
+                // A GIF carries the background colour the file declares, and
+                // a movie hides it with ink 36, which keys out the background
+                // colour. The score's bgColor for such a sprite is whatever
+                // the author left there, usually white, so a GIF with any
+                // other background drew as a solid box. Prefer the member's.
+                let bg_color = match sprite.member.as_ref() {
+                    Some(m) if crate::player::gif::is_gif_member(player, m.cast_lib, m.cast_member) => {
+                        player.movie.cast_manager.find_member_by_ref(m)
+                            .map(|mem| mem.bg_color.clone())
+                            .unwrap_or_else(|| sprite.bg_color.clone())
+                    }
+                    _ => sprite.bg_color.clone(),
+                };
                 let sprite_bitmap = player
                     .bitmap_manager
                     .get_bitmap_mut(bitmap_member.image_ref);

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -2013,8 +2013,15 @@ impl WebGL2Renderer {
                     TextureSource::Bitmap { image_ref: bitmap_member.image_ref, is_flash: false }
                 }
                 CastMemberType::Shape(shape_member) => {
-                    // Skip rendering shapes with tiny dimensions (blank placeholders or zero-size)
-                    if sprite_width <= 1 || sprite_height <= 1 {
+                    // Skip blank placeholders and zero-size shapes, but NOT a
+                    // #line: a line is 1 px in one dimension by nature, so
+                    // "width <= 1 || height <= 1" dropped every horizontal and
+                    // vertical line before the Line arm below ever ran. The
+                    // divider under the ruler on klods.dcr's working drawing
+                    // went missing this way (S8, measured against the
+                    // projector). A line is skipped only when BOTH collapse.
+                    let is_line = matches!(shape_member.shape_info.shape_type, crate::director::enums::ShapeType::Line);
+                    if (sprite_width <= 1 || sprite_height <= 1) && !(is_line && (sprite_width > 1 || sprite_height > 1)) {
                         return;
                     }
 

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -1555,6 +1555,18 @@ impl WebGL2Renderer {
                     channel_num, w3d_cam, w3d_extra_cams
                 );
             }
+            // A GIF carries the background colour the file declares, and a
+            // movie hides it with ink 36, which keys out the background
+            // colour. The score's bgColor for such a sprite is whatever the
+            // author left there, usually white, so a GIF with any other
+            // background drew as a solid box.
+            let bg_color = if crate::player::gif::is_gif_member(player, member_ref.cast_lib, member_ref.cast_member) {
+                player.movie.cast_manager.find_member_by_ref(&member_ref)
+                    .map(|m| m.bg_color.clone())
+                    .unwrap_or_else(|| sprite.bg_color.clone())
+            } else {
+                sprite.bg_color.clone()
+            };
             (
                 member_ref,
                 rect,

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -4613,15 +4613,25 @@ impl WebGL2Renderer {
             }
         }
 
-        // Darken (ink 41) is a foreColor/bgColor duotone — feed the shader the
-        // sprite's foreColor as well as the bgColor set above.
-        if effective_ink == InkMode::Darken {
+        // Darken (ink 41) is a foreColor/bgColor duotone and Lighten (ink 40)
+        // adds the foreColor: feed the shader the sprite's foreColor as well
+        // as the bgColor set above. Lighten adds it to TRUE-COLOUR bitmaps
+        // only. An indexed bitmap under Lighten keeps its palette colours
+        // (Habbo's navigator buttons: 8-bit, ink 40, foreColor light grey, and
+        // the real client leaves their black outlines black), while a 32-bit
+        // one is lifted by the foreColor (Matematik i Maaneby's stones).
+        if effective_ink == InkMode::Darken || effective_ink == InkMode::Lighten {
+            let fg = if effective_ink == InkMode::Lighten && bitmap_bit_depth <= 8 {
+                (0, 0, 0)
+            } else {
+                fg_color_rgb
+            };
             if let Some(ref loc) = u_fg_color {
                 gl.uniform4f(
                     Some(loc),
-                    fg_color_rgb.0 as f32 / 255.0,
-                    fg_color_rgb.1 as f32 / 255.0,
-                    fg_color_rgb.2 as f32 / 255.0,
+                    fg.0 as f32 / 255.0,
+                    fg.1 as f32 / 255.0,
+                    fg.2 as f32 / 255.0,
                     1.0,
                 );
             }

--- a/vm-rust/src/rendering_gpu/webgl2/mod.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/mod.rs
@@ -514,6 +514,9 @@ impl WebGL2Renderer {
         if let Some(ref loc) = program.u_skew_flip {
             gl.uniform1f(Some(loc), 0.0);
         }
+        if let Some(ref loc) = program.u_floor_rule {
+            gl.uniform1f(Some(loc), 0.0);
+        }
         if let Some(ref loc) = program.u_skew {
             gl.uniform1f(Some(loc), 0.0);
         }
@@ -589,6 +592,9 @@ impl WebGL2Renderer {
             gl.uniform1f(Some(loc), 0.0);
         }
         if let Some(ref loc) = program.u_skew_flip {
+            gl.uniform1f(Some(loc), 0.0);
+        }
+        if let Some(ref loc) = program.u_floor_rule {
             gl.uniform1f(Some(loc), 0.0);
         }
         if let Some(ref loc) = program.u_skew {
@@ -677,6 +683,9 @@ impl WebGL2Renderer {
             gl.uniform1f(Some(loc), 0.0);
         }
         if let Some(ref loc) = program.u_skew_flip {
+            gl.uniform1f(Some(loc), 0.0);
+        }
+        if let Some(ref loc) = program.u_floor_rule {
             gl.uniform1f(Some(loc), 0.0);
         }
         if let Some(ref loc) = program.u_skew {
@@ -1202,6 +1211,7 @@ impl WebGL2Renderer {
             bg_color_explicit: false,
             fore_color_explicit: false,
             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+            floor_rule: false,
         };
 
         // Render text to the bitmap
@@ -1285,6 +1295,9 @@ impl WebGL2Renderer {
         }
         // No skew flip
         if let Some(ref loc) = program.u_skew_flip {
+            gl.uniform1f(Some(loc), 0.0);
+        }
+        if let Some(ref loc) = program.u_floor_rule {
             gl.uniform1f(Some(loc), 0.0);
         }
         if let Some(ref loc) = program.u_skew {
@@ -3558,6 +3571,10 @@ impl WebGL2Renderer {
         // Colorize is also baked into the texture when has_fore_color or has_back_color is set
 
         let is_rendered_text = matches!(texture_source, TextureSource::RenderedText { .. });
+        // The floor sampling rule was measured on authored bitmaps; a text,
+        // field or shape texture whose sprite rect is a pixel short keeps the
+        // centre rule it always had.
+        let floor_rule = matches!(texture_source, TextureSource::Bitmap { is_flash: false, .. });
         let is_button_alpha_matte = matches!(texture_source, TextureSource::ButtonBitmap { ink: i, .. } if i == 2 || i == 36 || i == 8 || i == 7);
 
         // These sources rasterize a FRESH texture here every frame and, unlike
@@ -3961,6 +3978,7 @@ impl WebGL2Renderer {
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                            floor_rule: false,
                         };
                         btn_bitmap.draw_text_wrapped(
                             &text, font, font_bmp,
@@ -4493,6 +4511,9 @@ impl WebGL2Renderer {
         // Set skew flip (vertex space y-negation before rotation)
         if let Some(ref loc) = program.u_skew_flip {
             gl.uniform1f(Some(loc), if has_skew_flip { 1.0 } else { 0.0 });
+        }
+        if let Some(ref loc) = program.u_floor_rule {
+            gl.uniform1f(Some(loc), if floor_rule { 1.0 } else { 0.0 });
         }
 
         // Continuous skew (`the skew of sprite`) — applied as a horizontal
@@ -6239,6 +6260,7 @@ impl WebGL2Renderer {
             bg_color_explicit: false,
             fore_color_explicit: false,
             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+            floor_rule: false,
         };
 
         let pfr_multi_span_styled = is_pfr_font && styled_spans.map_or(false, |s| s.len() > 1);
@@ -7041,6 +7063,7 @@ impl WebGL2Renderer {
                             bg_color_explicit: false,
                             fore_color_explicit: false,
                             ink9_mask_bitmap: None, ink9_mask_offset: (0, 0),
+                            floor_rule: false,
                         };
 
                         // Pick the run's atlas. When the run names a variant

--- a/vm-rust/src/rendering_gpu/webgl2/shaders.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/shaders.rs
@@ -836,6 +836,7 @@ in vec2 v_texcoord;
 uniform sampler2D u_texture;
 uniform float u_blend;
 uniform vec4 u_bg_color;
+uniform vec4 u_fg_color;
 uniform float u_color_tolerance;
 
 out vec4 fragColor;
@@ -894,9 +895,11 @@ void main() {
     float dist = max(max(diff.r, diff.g), diff.b);
     if (dist < u_color_tolerance) discard;
 
-    // Lighten: output color, actual MAX blending done via blend equation
+    // Lighten: the sprite's foreColor is added to the image (Using
+    // Director, "Using sprite inks"); the default black foreColor leaves
+    // it unchanged.
     float alpha = src.a * u_blend;
-    fragColor = vec4(src.rgb, alpha);
+    fragColor = vec4(min(src.rgb + u_fg_color.rgb, 1.0), alpha);
 }
 "#;
 

--- a/vm-rust/src/rendering_gpu/webgl2/shaders.rs
+++ b/vm-rust/src/rendering_gpu/webgl2/shaders.rs
@@ -127,6 +127,8 @@ pub struct ShaderProgram {
     pub u_rotation: Option<WebGlUniformLocation>,
     pub u_rotation_center: Option<WebGlUniformLocation>,
     pub u_skew_flip: Option<WebGlUniformLocation>,
+    /// 1.0 = sample a shrunk sprite at floor(d * src / dst) (see sampleSprite).
+    pub u_floor_rule: Option<WebGlUniformLocation>,
     /// Continuous skew shear, in radians. The vertex shader applies a
     /// horizontal shear `x += y * tan(skew)` around the registration point
     /// before rotation. The special `skew_flip` (±180°) is handled
@@ -283,8 +285,51 @@ uniform float u_blend;  // 0.0 to 1.0
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (matte info baked into alpha)
     if (src.a < 0.01) discard;
@@ -312,8 +357,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (bgColor already baked as alpha=0 in texture)
     if (src.a < 0.01) discard;
@@ -346,8 +434,51 @@ uniform vec4 u_bg_color;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Color-key transparency: discard pixels matching bgColor
     // Use small threshold for floating point comparison
@@ -387,8 +518,51 @@ uniform vec4 u_bg_color;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Color-key transparency: discard pixels matching bgColor
     // Use small threshold for floating point comparison
@@ -425,8 +599,51 @@ uniform vec4 u_bg_color;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
@@ -468,8 +685,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
@@ -504,8 +764,51 @@ uniform float u_blend;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Matte: transparency comes from alpha channel (flood-fill matte baked in)
     // Discard fully transparent pixels (edge-connected background)
@@ -537,8 +840,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
@@ -574,8 +920,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     if (src.a < 0.01) discard;
 
@@ -609,8 +998,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
@@ -645,8 +1077,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
@@ -682,8 +1157,51 @@ uniform float u_color_tolerance;
 
 out vec4 fragColor;
 
+// Director picks the source texel of a scaled sprite as floor(d * src / dst),
+// the top-left corner of the destination pixel, where GPU nearest sampling
+// picks the texel under the pixel CENTRE. Measured on klods.dcr's ruler
+// (239x46 drawn at 166x32): the floor rule reproduces the projector's
+// pixels 100%, the centre rule 88%, and the difference is the digit rows
+// the centre rule skips. At 1:1 both rules pick the same texel.
+//
+// src and dst sizes come from the same uniforms the vertex shader placed
+// the quad with, so they are exact. A first version derived the step from
+// texcoord derivatives; those carry about 1e-5 relative error, which at
+// row 196 of a 1024x768 backdrop already rounded to the texel above.
+// A rotated or skewed sprite keeps the centre rule so its resampling
+// stays symmetric.
+uniform vec4 u_sprite_rect;
+uniform vec4 u_tex_rect;
+uniform float u_rotation;
+uniform float u_skew_flip;
+uniform float u_skew;
+uniform float u_floor_rule;
+vec4 sampleSprite(vec2 tc) {
+    if (abs(u_rotation) > 0.001 || u_skew_flip > 0.5 || abs(u_skew) > 0.001) {
+        return texture(u_texture, tc);
+    }
+    vec2 ts = vec2(textureSize(u_texture, 0));
+    vec2 srcSize = abs(u_tex_rect.zw) * ts;
+    vec2 dstSize = max(abs(u_sprite_rect.zw), vec2(1.0));
+    // The floor rule is measured for an authored bitmap scaling DOWN
+    // (u_floor_rule). Text, field and shape textures keep the pixel-centre
+    // rule, and so does scaling up: unmeasured, and the floor rule there
+    // shifts a sprite by up to half a source pixel.
+    if (u_floor_rule < 0.5 || dstSize.x > srcSize.x || dstSize.y > srcSize.y) {
+        return texture(u_texture, tc);
+    }
+    // Position within the sprite, 0..1; a pixel centre sits at (d + 0.5) / dst,
+    // so floor has half a pixel of margin when recovering d.
+    vec2 rel = (tc - u_tex_rect.xy) / u_tex_rect.zw;
+    vec2 d = floor(rel * dstSize);
+    vec2 src = floor(d * srcSize / dstSize + 1e-3);
+    ivec2 texel = ivec2(floor(u_tex_rect.xy * ts + 1e-3)) + ivec2(src);
+    texel = clamp(texel, ivec2(0), ivec2(ts) - ivec2(1));
+    return texelFetch(u_texture, texel, 0);
+}
+
 void main() {
-    vec4 src = texture(u_texture, v_texcoord);
+    vec4 src = sampleSprite(v_texcoord);
 
     // Discard fully transparent pixels (from matte mask)
     if (src.a < 0.01) discard;
@@ -741,6 +1259,7 @@ void main() {
         let u_rotation = gl.get_uniform_location(&program, "u_rotation");
         let u_rotation_center = gl.get_uniform_location(&program, "u_rotation_center");
         let u_skew_flip = gl.get_uniform_location(&program, "u_skew_flip");
+        let u_floor_rule = gl.get_uniform_location(&program, "u_floor_rule");
         let u_skew = gl.get_uniform_location(&program, "u_skew");
 
         Ok(ShaderProgram {
@@ -759,6 +1278,7 @@ void main() {
             u_rotation,
             u_rotation_center,
             u_skew_flip,
+            u_floor_rule,
             u_skew,
         })
     }


### PR DESCRIPTION
Twenty fixes found by running a Director 8.5 title the engine had not seen before (Matematik i Måneby, a 2005 Danish school game). None of them is specific to that title; each is a piece of Director the player either lacked or got wrong, and each commit says what was measured.

- **net:** the three-second hold in `maybe_hold_dcr_for_preloader` applied to every `.dcr` in every game, not just the DGS preloader it was written for. Opening a scene took 3.4 to 4.7 s with the movie already in Cache Storage; now 1.4 s.
- **score:** `sprite.rect = rect(...)` with inverted corners gave a negative size instead of normalising like Director.
- **lingo:** `member(x).char[a..b] = v` compiles to `setProp(member, #char, a, b, v)`, which raised an error; it now writes just that chunk. Field and Text members, `#char/#word/#item/#line`.
- **cursor:** Director's numbered cursors (`cursor(280)` etc.) were ignored; mapped to CSS cursors.
- **gif:** the Animated GIF Asset Xtra's members (whole `.gif` in the XMED payload) fell through to the text parser and drew a white box. Decoded into per-frame bitmaps, animated from the frame loop, with `sprite.pause()/resume()/rewind()` and the GIF's own background colour for ink 36. The animation registry is cleared when the movie changes, so one movie's frames never land on another movie's members.
- **render:** bitmaps drawn smaller than they are sampled at the pixel centre; Director samples at `floor(d * src / dst)`. Verified pixel-for-pixel against the projector on a 239x46 bitmap drawn at 166x32. Only authored bitmaps, on both renderers: text, field and shape blits keep the centre rule, as does scaling up, which the existing snapshots match.
- **render:** one-pixel `#line` shapes were skipped by the degenerate-rect guard in all three render paths.
- **sound:** `fadeTo` read its arguments in the wrong order and all fades treated milliseconds as ticks.
- **bitmap:** `image.crop(rect)` on a 32-bit member went through ink Copy, which skips fully transparent pixels, so the cut-out drew inside a white box. Same-depth crops now copy the rows with their alpha, and a rect past the source is padded transparent.
- **score:** a sprite inside a film loop looked its behaviours up in the stage's sprite detail table instead of the film loop's own, so it ran whatever the main score kept at that index (here: another frame's frame script).
- **render:** the Lighten ink (40) ignored the sprite's foreColor, which Director adds to a true-colour image; a sprite highlighted with `color = rgb(50, 25, 0)` and ink 40 looked unchanged. 8-bit bitmaps keep their palette colours, as the Habbo snapshots show. The CPU path's Darken (41) TODO now does the same foreColor/bgColor remap as the shader.
- **events:** mouseEnter/mouseWithin/mouseLeave went to every overlapping sprite with a handler; Director sends them to the front-most sprite only (`the rollover`). A lower sprite's mouseEnter ran after the front-most one's and undid it.
- **keyboard:** `the key` and `the keyCode` read empty inside `on keyUp`, because the key had already left the down list; Director reports the key most recently pressed there.
- **sound:** `sound(n).queue(member)` was ignored unless given a property list; a bare member is now queued as `[#member: m]`.
- **render:** the stage was redrawn on any animation frame it was dirty, so a draw could land between a mouseUp handler and the exitFrame that follows it, showing the handler's half-finished state for one frame. Director draws once per frame after both have run; the redraw is now held from the start of a mouse or key handler and the frame is drawn right after its exitFrame.
- **sound:** when the browser refused to decode a compressed member, playback fell through to the PCM path with the MP3/Ogg frames as samples (seconds of noise), and a member with no sample size then divided by zero and took the player down. That path is only reached after the sniff found a chain of valid frames, so the fallback is gone: the channel goes idle, the console names the member, and a zero-byte frame size is an error.
- **sound:** `stop()` (and `puppetSound(n, 0)`) left the channel's queued entries behind, so the next `queue()` + `play()` played the old entries first.
- **sound:** `fadeOut()` faded to zero and left the channel playing there, still busy, and a running fade overwrote a `volume = x` the script set afterwards and carried into a sound started meanwhile. fadeOut now stops the channel at silence; an explicit volume or a new sound ends the fade.
- **events:** input that arrived while a frame script sat in `repeat while ... updateStage()` ran in the middle of that handler, because the command and event loops used the busy-wait's cooperative yield. Director delivers it after the handler returns. Mouse and key commands and queued sprite events now wait for the frame handler; nothing is dropped, and keyboard and mouse state still update at once for `keyPressed()` and `the mouseDown`.
- **cursor:** the `cursor(n)` setting survived a movie change, so a movie that hid the cursor with `cursor(200)` for a drag left the next movie without one. A new movie now starts with the arrow, as in Director (and in ScummVM's Director engine, where the setting lives on the movie's Score).
- **scripts:** `run-browser-tests.mjs` spawns through cmd.exe on Windows and passed paths unquoted, so a checkout under a directory with a space in its name stopped at wasm-bindgen.

Each commit builds and passes the test suite on its own. The score, lingo, sound, gif, bitmap, render, events, keyboard and cursor commits carry unit tests for the behaviour they fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
