### PR TITLE
Implement movieFileSize, member.size, and script.count

### DIFF
--- a/vm-rust/src/director/file.rs
+++ b/vm-rust/src/director/file.rs
@@ -41,6 +41,8 @@ use binary_reader::Endian;
 pub struct DirectorFile {
     pub base_path: Url,
     pub file_name: String,
+    /// Byte length of the source `.dcr`/`.dir` buffer (`the movieFileSize`).
+    pub file_size: u32,
     pub endian: Endian,
     pub after_burned: bool,
     pub version: u16,
@@ -158,6 +160,7 @@ impl DirectorFile {
         return Ok(DirectorFile {
             base_path,
             file_name,
+            file_size: 0,
             endian,
             after_burned,
             version: rifx.dir_version,
@@ -1138,11 +1141,13 @@ pub fn read_director_file_bytes(
 ) -> Result<DirectorFile, String> {
     let mut reader = binary_reader::BinaryReader::from_vec(bytes);
 
-    return DirectorFile::read(
+    let mut dir = DirectorFile::read(
         file_name.to_owned(),
         Url::from_str(base_path).unwrap(),
         &mut reader,
-    );
+    )?;
+    dir.file_size = bytes.len().min(u32::MAX as usize) as u32;
+    Ok(dir)
 }
 
 fn get_chunk_data(

--- a/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/cast_member_ref.rs
@@ -25,6 +25,51 @@ use crate::{
 
 pub struct CastMemberRefHandlers {}
 
+/// Director 11.5 `member.size`: "size in memory, in bytes, of a cast member"
+/// (read-only). A Flash preloader that has not loaded yet is distinguished
+/// with `member(x).size < 1000`. Never raise — return 0/1 if unknown.
+fn member_media_size_bytes(player: &DirPlayer, member_ref: &CastMemberRef) -> i32 {
+    let type_id = match player.movie.cast_manager.find_member_by_ref(member_ref) {
+        Some(m) => m.member_type.member_type_id(),
+        None => return 0,
+    };
+    if type_id == CastMemberTypeId::Script {
+        return player
+            .movie
+            .cast_manager
+            .get_script_by_ref(member_ref)
+            .map(|s| {
+                s.chunk
+                    .handlers
+                    .iter()
+                    .map(|h| h.bytecode_array.len())
+                    .sum::<usize>()
+                    .max(1) as i32
+            })
+            .unwrap_or(1);
+    }
+    let Some(member) = player.movie.cast_manager.find_member_by_ref(member_ref) else {
+        return 0;
+    };
+    match &member.member_type {
+        CastMemberType::Flash(f) => f.data.len() as i32,
+        CastMemberType::Text(t) => t
+            .text
+            .len()
+            .max(t.html_source.len())
+            .max(t.rtf_source.len())
+            .max(1) as i32,
+        CastMemberType::Field(f) => f.text.len().max(1) as i32,
+        CastMemberType::Bitmap(b) => player
+            .bitmap_manager
+            .get_bitmap(b.image_ref)
+            .map(|bm| bm.data.len().max(1) as i32)
+            .unwrap_or(1),
+        CastMemberType::Sound(s) => (s.sound.sample_count() as i32).max(1),
+        _ => 1,
+    }
+}
+
 fn is_3d_member(datum: &DatumRef) -> Result<bool, ScriptError> {
     reserve_player_mut(|player| {
         let r = match player.get_datum(datum) {
@@ -792,7 +837,7 @@ impl CastMemberRefHandlers {
             Some(BuiltInSymbol::MemberNum) => Ok(Datum::Int(-1)),
             Some(BuiltInSymbol::Text | BuiltInSymbol::Comments) => Ok(Datum::String("".to_string())),
             Some(BuiltInSymbol::Loaded | BuiltInSymbol::MediaReady) => Ok(Datum::Int(1)),
-            Some(BuiltInSymbol::Width | BuiltInSymbol::Height | BuiltInSymbol::Rect | BuiltInSymbol::Duration) => Ok(Datum::Void),
+            Some(BuiltInSymbol::Width | BuiltInSymbol::Height | BuiltInSymbol::Rect | BuiltInSymbol::Duration | BuiltInSymbol::Size) => Ok(Datum::Void),
             Some(BuiltInSymbol::Image) => Ok(Datum::Void),
             Some(BuiltInSymbol::RegPoint) => Ok(Datum::Point([0.0, 0.0], 0)),
             _ => Err(ScriptError::new(format!(
@@ -1118,11 +1163,10 @@ impl CastMemberRefHandlers {
                         )),
                         // `member.size` — "size in memory, in bytes, of a cast
                         // member. Read-only" (Director 11.5 Scripting Dictionary).
-                        // For a Flash member this is its SWF byte count. Neopets'
-                        // DGS `showPreLoader` gates on `member(x).size < 1000` to
-                        // detect a missing/empty preloader after linking it via
-                        // `x.fileName = <url>`, so this must reflect the bytes the
-                        // fileName setter loaded from the preload cache.
+                        // For a Flash member this is its SWF byte count, including
+                        // after `fileName` is set and the bytes are loaded from
+                        // the preload cache. An empty buffer is how
+                        // `member(x).size < 1000` detects an unlinked preloader.
                         Some(BuiltInSymbol::Size) => Ok(Datum::Int(flash.data.len() as i32)),
                         _ => Ok(Datum::Void),
                     }
@@ -1637,6 +1681,9 @@ impl CastMemberRefHandlers {
             Some(BuiltInSymbol::Comments) => Ok(Datum::String(comments)),
             Some(BuiltInSymbol::Ilk) => Ok(Datum::Symbol(Symbol::from_str("member"))),
             Some(BuiltInSymbol::Member) => Ok(Datum::CastMember(cast_member_ref.clone())),
+            Some(BuiltInSymbol::Size) => {
+                Ok(Datum::Int(member_media_size_bytes(player, cast_member_ref)))
+            }
             _ => Self::get_member_type_prop(player, cast_member_ref, &member_type, prop),
         }
     }
@@ -1751,5 +1798,193 @@ impl CastMemberRefHandlers {
             JsApi::dispatch_cast_member_changed(cast_member_ref.to_owned());
         }
         result
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod member_size_tests {
+    use super::*;
+    use crate::player::{
+        cast_lib::{cast_member_ref, CastLib, CastLibState},
+        cast_member::{FieldMember, FlashMember},
+        symbols::symbol_table::init_symbol_table,
+        testing::{run_test, TestPlayer},
+    };
+    use fxhash::FxHashMap;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    fn expect_int(d: &Datum, n: i32) {
+        match d {
+            Datum::Int(v) => assert_eq!(*v, n),
+            _ => panic!("expected Int({n}), got {}", d.type_str()),
+        }
+    }
+
+    fn empty_cast(number: u32) -> CastLib {
+        CastLib {
+            name: String::new(),
+            file_name: String::new(),
+            number,
+            is_external: false,
+            state: CastLibState::Loaded,
+            lctx: None,
+            members: FxHashMap::default(),
+            scripts: FxHashMap::default(),
+            name_symbols: Vec::new(),
+            preload_mode: 0,
+            capital_x: false,
+            dir_version: 0,
+            palette_id_offset: 0,
+            name_index: RefCell::new(None),
+            font_table: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn a_missing_member_reports_size_void_to_lingo() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let r = cast_member_ref(1, 1);
+                let size = CastMemberRefHandlers::get_prop(player, &r, Symbol::from_str("size"))
+                    .unwrap();
+                assert!(
+                    matches!(size, Datum::Void),
+                    "expected Void, got {}",
+                    size.type_str()
+                );
+                assert_eq!(member_media_size_bytes(player, &r), 0);
+            });
+        });
+    }
+
+    #[test]
+    fn a_flash_member_size_is_its_swf_byte_length() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let mut cast = empty_cast(1);
+                let data = vec![0u8; 2_500];
+                cast.members.insert(
+                    1,
+                    CastMember::new(
+                        1,
+                        CastMemberType::Flash(FlashMember {
+                            data: data.clone(),
+                            reg_point: (0, 0),
+                            flash_info: None,
+                        }),
+                    ),
+                );
+                player.movie.cast_manager.casts.push(cast);
+                let r = cast_member_ref(1, 1);
+                let size = CastMemberRefHandlers::get_prop(player, &r, Symbol::from_str("size"))
+                    .unwrap();
+                expect_int(&size, 2_500);
+            });
+        });
+    }
+
+    #[test]
+    fn an_empty_flash_member_size_is_zero() {
+        // `member(x).size < 1000` is how a preloader is recognised as unlinked.
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let mut cast = empty_cast(1);
+                cast.members.insert(
+                    1,
+                    CastMember::new(
+                        1,
+                        CastMemberType::Flash(FlashMember {
+                            data: vec![],
+                            reg_point: (0, 0),
+                            flash_info: None,
+                        }),
+                    ),
+                );
+                player.movie.cast_manager.casts.push(cast);
+                let r = cast_member_ref(1, 1);
+                let size = CastMemberRefHandlers::get_prop(player, &r, Symbol::from_str("size"))
+                    .unwrap();
+                expect_int(&size, 0);
+            });
+        });
+    }
+
+    #[test]
+    fn a_field_member_size_is_at_least_one() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let mut cast = empty_cast(1);
+                let mut empty = FieldMember::new();
+                empty.text = String::new();
+                cast.members.insert(
+                    1,
+                    CastMember::new(1, CastMemberType::Field(empty)),
+                );
+                let mut filled = FieldMember::new();
+                filled.text = "hello".to_string();
+                cast.members.insert(
+                    2,
+                    CastMember::new(2, CastMemberType::Field(filled)),
+                );
+                player.movie.cast_manager.casts.push(cast);
+                expect_int(
+                    &CastMemberRefHandlers::get_prop(
+                        player,
+                        &cast_member_ref(1, 1),
+                        Symbol::from_str("size")
+                    )
+                    .unwrap(),
+                    1
+                );
+                expect_int(
+                    &CastMemberRefHandlers::get_prop(
+                        player,
+                        &cast_member_ref(1, 2),
+                        Symbol::from_str("size")
+                    )
+                    .unwrap(),
+                    5
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn a_text_member_size_is_the_longest_source() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let mut cast = empty_cast(1);
+                let mut text = TextMember::new();
+                text.text = "ab".to_string();
+                text.html_source = "<p>abcd</p>".to_string();
+                text.rtf_source = String::new();
+                cast.members.insert(
+                    1,
+                    CastMember::new(1, CastMemberType::Text(text)),
+                );
+                player.movie.cast_manager.casts.push(cast);
+                expect_int(
+                    &CastMemberRefHandlers::get_prop(
+                        player,
+                        &cast_member_ref(1, 1),
+                        Symbol::from_str("size")
+                    )
+                    .unwrap(),
+                    "<p>abcd</p>".len() as i32
+                );
+            });
+        });
     }
 }

--- a/vm-rust/src/player/handlers/datum_handlers/script.rs
+++ b/vm-rust/src/player/handlers/datum_handlers/script.rs
@@ -16,6 +16,8 @@ impl ScriptDatumHandlers {
             "birth" => true,
             "rawnew" => false,
             "handler" => false,
+            "handlers" => false,
+            "count" => false,
             _ => {
                 reserve_player_ref(|player| {
                     if let Datum::ScriptRef(script_ref) = player.get_datum(obj_ref) {
@@ -104,9 +106,9 @@ impl ScriptDatumHandlers {
             "rawnew" => Self::raw_new(datum),
             "handler" => Self::handler(datum, args),
             "handlers" => Self::handlers(datum, args),
+            "count" => Self::count(datum, args),
             // A movie script's static properties are addressable through the
-            // script reference (Neopets DGS uses `script("globals")` as a global
-            // data store: `g.levellist = []`, `g.levellist.add(...)`, etc.).
+            // script reference (`g.levellist = []`, `g.levellist.add(...)`).
             // getPropRef returns the property's shared DatumRef so in-place list
             // mutation persists, mirroring the ScriptInstance handler.
             "getprop" | "getpropref" | "getaprop" => reserve_player_mut(|player| {
@@ -154,6 +156,45 @@ impl ScriptDatumHandlers {
                 "no handler {handler_name} for script datum"
             ))),
         }
+    }
+
+    /// `script.count(#prop)` — number of items in a static property that is a
+    /// list, matching `ScriptInstanceHandlers::count`.
+    /// No-arg `script.count()` is the number of static properties (Director
+    /// `count(object)` for a non-list object is 1 if there are none).
+    pub fn count(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
+        reserve_player_mut(|player| {
+            let script_ref = match player.get_datum(datum) {
+                Datum::ScriptRef(s) => s.clone(),
+                _ => return Err(ScriptError::new("Expected script reference".to_string())),
+            };
+            if args.is_empty() {
+                let n = player
+                    .movie
+                    .cast_manager
+                    .get_script_by_ref(&script_ref)
+                    .map(|s| s.properties.borrow().len() as i32)
+                    .unwrap_or(1)
+                    .max(1);
+                return Ok(player.alloc_datum(Datum::Int(n)));
+            }
+            let prop_name = Symbol::from_str(&player.get_datum(&args[0]).string_value()?);
+            let prop_value = crate::player::script::script_get_static_prop(player, &script_ref, prop_name)?;
+            let prop_value_datum = player.get_datum(&prop_value);
+            let count = match prop_value_datum {
+                Datum::List(_, list, _) => list.len(),
+                Datum::PropList(prop_list, ..) => prop_list.len(),
+                Datum::Void => 0,
+                other => {
+                    return Err(ScriptError::new(format!(
+                        "Cannot count non-list property {} (type {})",
+                        prop_name.as_str(),
+                        other.type_str()
+                    )))
+                }
+            };
+            Ok(player.alloc_datum(Datum::Int(count as i32)))
+        })
     }
 
     pub fn handlers(datum: &DatumRef, args: &Vec<DatumRef>) -> Result<DatumRef, ScriptError> {
@@ -343,5 +384,179 @@ impl ScriptDatumHandlers {
         } else {
             return Ok(datum_ref);
         }
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod script_count_tests {
+    use super::*;
+    use crate::{
+        director::{chunks::script::ScriptChunk, enums::ScriptType, lingo::datum::DatumType},
+        player::{
+            cast_lib::{cast_member_ref, CastLib, CastLibState},
+            script::Script,
+            symbols::symbol_table::init_symbol_table,
+            testing::{run_test, TestPlayer},
+        },
+    };
+    use fxhash::FxHashMap;
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use std::rc::Rc;
+
+    fn empty_cast(number: u32) -> CastLib {
+        CastLib {
+            name: String::new(),
+            file_name: String::new(),
+            number,
+            is_external: false,
+            state: CastLibState::Loaded,
+            lctx: None,
+            members: FxHashMap::default(),
+            scripts: FxHashMap::default(),
+            name_symbols: Vec::new(),
+            preload_mode: 0,
+            capital_x: false,
+            dir_version: 0,
+            palette_id_offset: 0,
+            name_index: RefCell::new(None),
+            font_table: HashMap::new(),
+        }
+    }
+
+    fn empty_script_chunk() -> ScriptChunk {
+        ScriptChunk {
+            script_number: 1,
+            literals: vec![],
+            handlers: vec![],
+            property_name_ids: vec![],
+            property_defaults: HashMap::new(),
+        }
+    }
+
+    fn install_script(player: &mut crate::player::DirPlayer, name: &str) -> (CastMemberRef, DatumRef) {
+        let member_ref = cast_member_ref(1, 1);
+        let script = Script {
+            member_ref: member_ref.clone(),
+            name: name.to_string(),
+            chunk: empty_script_chunk(),
+            script_type: ScriptType::Movie,
+            handlers: FxHashMap::default(),
+            handler_names_raw: vec![],
+            handler_names: vec![],
+            properties: RefCell::new(FxHashMap::default()),
+        };
+        let mut cast = empty_cast(1);
+        cast.scripts.insert(1, Rc::new(script));
+        player.movie.cast_manager.casts.push(cast);
+        let datum = player.alloc_datum(Datum::ScriptRef(member_ref.clone()));
+        (member_ref, datum)
+    }
+
+    #[test]
+    fn no_arg_count_is_at_least_one() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let (_r, datum) = install_script(player, "globals");
+                let n = ScriptDatumHandlers::count(&datum, &vec![]).unwrap();
+                match player.get_datum(&n) {
+                    Datum::Int(1) => {}
+                    other => panic!("expected Int(1), got {}", other.type_str()),
+                }
+            });
+        });
+    }
+
+    #[test]
+    fn no_arg_count_is_the_number_of_static_properties() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let (member_ref, datum) = install_script(player, "globals");
+                let a = player.alloc_datum(Datum::Int(1));
+                let b = player.alloc_datum(Datum::Int(2));
+                crate::player::script::script_set_static_prop(
+                    player,
+                    &member_ref,
+                    Symbol::from_str("one"),
+                    &a,
+                    false,
+                )
+                .unwrap();
+                crate::player::script::script_set_static_prop(
+                    player,
+                    &member_ref,
+                    Symbol::from_str("two"),
+                    &b,
+                    false,
+                )
+                .unwrap();
+                let n = ScriptDatumHandlers::count(&datum, &vec![]).unwrap();
+                match player.get_datum(&n) {
+                    Datum::Int(2) => {}
+                    other => panic!("expected Int(2), got {}", other.type_str()),
+                }
+            });
+        });
+    }
+
+    #[test]
+    fn count_of_a_list_property_is_the_list_length() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let (member_ref, datum) = install_script(player, "globals");
+                let items = VecDeque::from([
+                    player.alloc_datum(Datum::Int(1)),
+                    player.alloc_datum(Datum::Int(2)),
+                    player.alloc_datum(Datum::Int(3)),
+                ]);
+                let list = player.alloc_datum(Datum::List(DatumType::List, items, false));
+                crate::player::script::script_set_static_prop(
+                    player,
+                    &member_ref,
+                    Symbol::from_str("levellist"),
+                    &list,
+                    false,
+                )
+                .unwrap();
+                let prop = player.alloc_datum(Datum::Symbol(Symbol::from_str("levellist")));
+                let n = ScriptDatumHandlers::count(&datum, &vec![prop]).unwrap();
+                match player.get_datum(&n) {
+                    Datum::Int(3) => {}
+                    other => panic!("expected Int(3), got {}", other.type_str()),
+                }
+            });
+        });
+    }
+
+    #[test]
+    fn count_of_a_void_property_is_zero() {
+        init_symbol_table();
+        run_test(async {
+            let _p = TestPlayer::new();
+            reserve_player_mut(|player| {
+                let (member_ref, datum) = install_script(player, "globals");
+                crate::player::script::script_set_static_prop(
+                    player,
+                    &member_ref,
+                    Symbol::from_str("empty"),
+                    &DatumRef::Void,
+                    false,
+                )
+                .unwrap();
+                let prop = player.alloc_datum(Datum::Symbol(Symbol::from_str("empty")));
+                let n = ScriptDatumHandlers::count(&datum, &vec![prop]).unwrap();
+                match player.get_datum(&n) {
+                    Datum::Int(0) => {}
+                    other => panic!("expected Int(0), got {}", other.type_str()),
+                }
+            });
+        });
     }
 }

--- a/vm-rust/src/player/movie.rs
+++ b/vm-rust/src/player/movie.rs
@@ -27,6 +27,8 @@ pub struct Movie {
     pub alert_hook: Option<ScriptReceiver>,
     pub base_path: String,
     pub file_name: String,
+    /// `the movieFileSize` — length of the loaded movie file in bytes.
+    pub file_size: i32,
     pub stage_color: (u8, u8, u8),
     pub stage_color_ref: ColorRef,
     pub frame_rate: u16,
@@ -111,6 +113,7 @@ impl Movie {
             alert_hook: None,
             base_path: "".to_string(),
             file_name: "".to_string(),
+            file_size: 0,
             stage_color: (255, 255, 255),
             stage_color_ref: ColorRef::PaletteIndex(255),
             frame_rate: 30,
@@ -188,6 +191,7 @@ impl Movie {
             .await;
         self.score.load_from_dir(&file);
         self.file_name = file.file_name.to_string();
+        self.file_size = file.file_size.min(i32::MAX as u32) as i32;
         self.frame_rate = file.config.frame_rate;
         self.file = Some(file);
 
@@ -358,6 +362,13 @@ impl Movie {
             // checks pass instead of failing on a fabricated shortage.
             BuiltInSymbol::FreeBytes => Ok(Datum::Int(192 * 1024 * 1024)),
             BuiltInSymbol::FreeBlock => Ok(Datum::Int(128 * 1024 * 1024)),
+            // `the movieFileSize` — size of the current movie file in bytes
+            // (Director 11.5 Scripting Dictionary, memory properties).
+            // Afterburned Shockwave movies are already compact, so
+            // `the movieFileFreeSize` (slack that compacting would reclaim)
+            // is 0 — same as ScummVM's Director engine.
+            BuiltInSymbol::MovieFileSize => Ok(Datum::Int(self.file_size)),
+            BuiltInSymbol::MovieFileFreeSize => Ok(Datum::Int(0)),
             // `_system.colorDepth` — monitor color depth (Director 11.5
             // Scripting Dictionary, valid values 1/2/4/8/16/32). The web
             // canvas is true-color, so report 32. Setting it is a no-op
@@ -669,5 +680,36 @@ impl Movie {
         self.random_seed = Some(next_seed as i32);
         let value = (next_seed % (max as u32)) as i32 + 1;
         Some(value)
+    }
+}
+
+#[cfg(test)]
+mod movie_file_size_tests {
+    use super::*;
+    use crate::player::symbols::symbol_table::init_symbol_table;
+
+    #[test]
+    fn movie_file_size_is_the_loaded_byte_length() {
+        init_symbol_table();
+        let mut movie = Movie::empty();
+        movie.file_size = 48_291;
+        assert!(matches!(
+            movie.get_prop(Symbol::from_str("movieFileSize")).unwrap(),
+            Datum::Int(48_291)
+        ));
+    }
+
+    #[test]
+    fn movie_file_free_size_is_zero() {
+        // Afterburned Shockwave movies have no compactable slack; ScummVM's
+        // Director engine reports 0 as well.
+        init_symbol_table();
+        let movie = Movie::empty();
+        assert!(matches!(
+            movie
+                .get_prop(Symbol::from_str("movieFileFreeSize"))
+                .unwrap(),
+            Datum::Int(0)
+        ));
     }
 }

--- a/vm-rust/src/player/symbols/builtin.rs
+++ b/vm-rust/src/player/symbols/builtin.rs
@@ -95,6 +95,8 @@ define_builtin_symbols! {
     "windowList" => WindowList,
     "freeBytes" => FreeBytes,
     "freeBlock" => FreeBlock,
+    "movieFileSize" => MovieFileSize,
+    "movieFileFreeSize" => MovieFileFreeSize,
     "emulateMultibuttonMouse" => EmulateMultibuttonMouse,
     "enableFlashLingo" => EnableFlashLingo,
     "preLoadEventAbort" => PreLoadEventAbort,


### PR DESCRIPTION
[Hannah and the Ice Caves](https://www.neopets.com/games/game.phtml?game_id=473) (Neopets DGS) reads these. Related to #45, but this is the Lingo properties, not the nested `#movie` loader.

- Implement `the movieFileSize` as the loaded movie's byte length. Afterburned Shockwave movies have no compactable slack, so `the movieFileFreeSize` is 0 (same as ScummVM).
- Implement `member.size` as the member's media size in bytes (Director 11.5, read-only). Missing or unknown media returns 0/1 rather than raising; an empty Flash buffer is how `member(x).size < 1000` detects an unlinked preloader.
- Implement `script.count()` as the number of static properties (Director's `count(object)` is 1 when there are none) and `script.count(#prop)` as the length of a list/proplist on the script.

Unit tests cover all three. Happy to add e2e/snapshot coverage.

Hannah and the Ice Caves shows a location/leech warning after the movie starts. Hold **Shift+O+K** until it clears. That is the game's own check (same combo as real Shockwave on Neopets), not a DirPlayer error.